### PR TITLE
Added new DrawMenu hooks

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/ModHooks.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModHooks.cs
@@ -78,6 +78,42 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to modify what a menu text button does when pressed. See <see cref="Main.menuMode"/> for the current menu mode ID.
+		/// </summary>
+		/// <param name="selectedMenu">The currently selected (clicked) menu text button.</param>
+		public virtual void PreMenuPress(int selectedMenu)
+		{
+		}
+
+		/// <summary>
+		/// Allows you to modify the text, scale, and position for menu text buttons, as well as add new ones. See <see cref="Main.menuMode"/> for the current menu mode ID. <para/>
+		/// This cannot be used to modify what a pre-existing menu text button does when pressed. To do this, override <see cref="PreMenuPress(int)"/>.
+		/// </summary>
+		/// <param name="focusMenu">The currently focused (hovered) menu text button.</param>
+		/// <param name="selectedMenu">The currently selected (clicked) menu text button.</param>
+		/// <param name="buttonNames">An array of the button names for the current menuMode ID.</param>
+		/// <param name="buttonScales">An array of the button scales for the current menuMode ID.</param>
+		/// <param name="buttonVerticalSpacing">An array of the spacings for the current menuMode ID.</param>
+		/// <param name="offY"></param>
+		/// <param name="spacing"></param>
+		/// <param name="numButtons">The total number of buttons. Be sure to increase this number if new text buttons were added.</param>
+		/// <param name="backButtonDown"></param>
+		public virtual void ModifyMenus(int focusMenu, int selectedMenu, string[] buttonNames, float[] buttonScales, int[] buttonVerticalSpacing, ref int offY, ref int spacing, ref int numButtons, ref bool backButtonDown)
+		{
+		}
+
+		/// <summary>
+		/// Allows you to modify the colors of a menu text button. See <see cref="Main.menuMode"/> for the current menu mode ID. <para/>
+		/// This is called in a for loop 5 times for each existing menu text button; the first 4 being the outline draw pass, and the last being the inner draw pass.
+		/// </summary>
+		/// <param name="currentTextIndex">The current index of the menu text button.</param>
+		/// <param name="isOutlineColor">Whether or not this is running in an outline color draw pass.</param>
+		/// <param name="oldColor">The current color before modification.</param>
+		public virtual void ModifyMenuTextsColors(int currentTextIndex, bool isOutlineColor, ref Color oldColor)
+		{
+		}
+
+		/// <summary>
 		/// Ran every update and suitable for calling Update for UserInterface classes
 		/// </summary>
 		public virtual void UpdateUI(GameTime gameTime)
@@ -224,6 +260,33 @@ namespace Terraria.ModLoader
 			foreach (Mod mod in ModLoader.mods.Values)
 			{
 				mod.UpdateUI(gameTime);
+			}
+		}
+
+		internal static void PreMenuPress(int selectedMenu)
+		{
+			if (!Main.gameMenu || selectedMenu == -1) return;
+			foreach (Mod mod in ModLoader.mods.Values)
+			{
+				mod.PreMenuPress(selectedMenu);
+			}
+		}
+
+		internal static void ModifyMenus(int focusMenu, int selectedMenu, string[] buttonNames, float[] buttonScales, int[] buttonVerticalSpacing, ref int offY, ref int spacing, ref int numButtons, ref bool backButtonDown)
+		{
+			if (!Main.gameMenu) return;
+			foreach (Mod mod in ModLoader.mods.Values)
+			{
+				mod.ModifyMenus(focusMenu, selectedMenu, buttonNames, buttonScales, buttonVerticalSpacing, ref offY, ref spacing, ref numButtons, ref backButtonDown);
+			}
+		}
+
+		internal static void ModifyMenuTextsColors(int currentTextIndex, bool isOutlineColor, ref Color oldColor)
+		{
+			if (!Main.gameMenu) return;
+			foreach (Mod mod in ModLoader.mods.Values)
+			{
+				mod.ModifyMenuTextsColors(currentTextIndex, isOutlineColor, ref oldColor);
 			}
 		}
 

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3623,12 +3623,20 @@
  						}
  						flag10 = true;
  					}
+@@ -43049,6 +_,7 @@
+ 			if (loadedEverything)
+ 			{
+ 				GamepadMainMenuHandler.CanRun = true;
++				ModHooks.PreMenuPress(selectedMenu);
+ 			}
+ 			if (!loadedEverything)
+ 			{
 @@ -43092,7 +_,7 @@
  				if (this.selectedMenu >= 1)
  				{
  					LanguageManager.Instance.SetLanguage(this.selectedMenu);
 -					Main.menuMode = 0;
-+					Main.menuMode = ModLoader.Interface.loadModsID;;
++					Main.menuMode = ModLoader.Interface.loadModsID; ;
  					Main.PlaySound(10, -1, -1, 1, 1f, 0f);
  					Main.SaveSettings();
  				}
@@ -3770,17 +3778,23 @@
  						}
  						num21++;
  						array9[num21] = Lang.menu[5].Value;
-@@ -45616,6 +_,10 @@
+@@ -45616,8 +_,14 @@
  							WorldGen.setWorldSize();
  						}
  					}
+-				}
+-			}
 +					else
 +					{
 +						Interface.ModLoaderMenus(this, this.selectedMenu, array9, array7, array4, ref num2, ref num4, ref num5, ref flag5);
 +					}
- 				}
- 			}
++				}
++
++			}
++			ModHooks.ModifyMenus(this.focusMenu, this.selectedMenu, array9, array7, array4, ref num2, ref num4, ref num5, ref flag5);
  			IL_5597:
+ 			if (Main.menuMode == 888)
+ 			{
 @@ -46217,6 +_,7 @@
  			bool flag11 = false;
  			for (int num94 = 0; num94 < num5; num94++)
@@ -3789,8 +3803,11 @@
  				if (array9[num94] != null)
  				{
  					Vector2 origin = Main.fontDeathText.MeasureString(array9[num94]);
-@@ -46326,6 +_,7 @@
+@@ -46324,8 +_,10 @@
+ 							num103 *= 0.5f;
+ 						}
  						num103 *= array7[num94];
++						ModHooks.ModifyMenuTextsColors(num94, num95 != 4, ref color10);
  						if (!array8[num94])
  						{
 +							//patch file: array9, array7, array4, num2, num4


### PR DESCRIPTION
Added 3 new hooks: PreMenuPress, ModifyMenus, ModifyMenuTextsColors.

<!-- Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Where applicable, provide Example Mod usage (example code), see the 'Sample usage' section
* If a header/description isn't applicable to your PR, leave it empty or remove it -->

### Description of the Change
I have added 3 new hooks with the intention of adding functionality to be able to change the Main Menu's text buttons and their functionality.
These hooks are: 

PreMenuPress(int selectedMenu)
A hook created to detect what menu text button has been pressed before the button does anything.

selectedMenu parameter: The menu that has been clicked. 

This hook is not called if no button has been clicked (Main.selectedMenu == -1)

ModifyMenus(int focusMenu, int selectedMenu, string[] buttonNames, float[] buttonScales, ref int offY, ref int spacing, ref int numButtons, ref bool backButtonDown)
This is the main hook that allows changing/adding Main Menu text buttons.

focusMenu parameter: The currently focused (hovered) menu.
selectedMenu parameter: The menu that has been clicked. 
buttonNames parameter: An array of the button names for the current menuMode ID.
buttonScales parameter: An array of the button scales for the current menuMode ID.
buttonVerticalSpacing parameter: An array of the spacings for the current menuMode ID.
numButtons parameter: The total number of buttons on the screen.

ModifyMenuTextsColors (int currentTextIndex, bool isOutlineColor, ref Color oldColor)
Allows you to modify the colors of a menu text button. 
This is called in a for loop 5 times for each existing menu text button; the first 4 being the outline draw pass (isOutlineColor is true,) and the last being the inner draw pass.

currentTextIndex: The current index of the menu text button.
isOutlineColor: Whether or not this is running in an outline color draw pass.
oldColor: The current color before modification.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate designs
N/A
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why this should be merged into tModLoader
Modifying the the main menu is (afaik) impossible in current versions in mods. If this change were added it would allow much greater freedom to modders, as the main menu is no longer off-limits.
<!-- Explain why this functionality should be in our API as opposed to something standalone (like a mod/framework etc.) -->

### Benefits
The ability to change the main menu to the modder's discretion, something that is not currently possible (afaik) without modifying vanilla in some way.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
None that I can think of.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable issues here -->

### Sample Usage
Code added to a mod's main Mod class:
`public override void PreMenuPress(int selectedMenu)
{
    if (Main.menuMode == -7)
    {
		Main.expertMode = false;    //may not be necessary; I think vanilla resets this automatically. But better safe than sorry.
    }
}

public override void ModifyMenus(int focusMenu, int selectedMenu, string[] buttonNames, float[] buttonScales, int[] buttonVerticalSpacing, ref int offY, ref int spacing, ref int numButtons, ref bool backButtonDown)
{
    if (Main.menuMode == -7)
    {
        buttonVerticalSpacing[4] = 100;
        int index = numButtons;
        buttonNames[index] = "Hell";
        buttonVerticalSpacing[index] = -30;
        buttonScales[index] = 1;
        numButtons++;

        if (focusMenu == index)
        {
            buttonNames[0] = "Do you enjoy pain?";
            buttonNames[1] = "(Even greater difficulty)";
        }

        if (selectedMenu == index)
        {
            Main.expertMode = true;

            Main.PlaySound(10, -1, -1, 1, 1f, 0f);
            Main.menuMode = 7;
            if (Main.SettingsUnlock_WorldEvil)
            {
                Main.menuMode = -71;
            }
        }
    }
}

public override void ModifyMenuTextsColors(int currentTextIndex, bool isOutlineColor, ref Color oldColor)
{
    if (Main.menuMode == -7)
    {
        if (currentTextIndex == 5 && !isOutlineColor)
        {
            oldColor = new Color(Color.DarkRed.R, Color.DarkRed.G, Color.DarkRed.B, 145);
        }
    }
}`
https://hastebin.com/abatapuzuk.cs for a more formatted version.
Adds a new option in the world creation menu, so that in addition to 'Normal' and 'Expert' modes, there is now a 'Hell' mode option. (Note that selecting this option does nothing more than enable expert mode, exactly the same as the expert mode button works.)
<!-- Please provide a sample of code that demonstrates how your changes should be handled, or how your changes reflect on mods' code, preferably code that can be used in Example Mod -->


