### PR TITLE
Volcano Tremor Fix

### DIFF
--- a/ExampleMod/ExampleMod.cs
+++ b/ExampleMod/ExampleMod.cs
@@ -231,9 +231,8 @@ namespace ExampleMod
 		float targetOffsetX = 0;
 		float targetOffsetY = 0;
 
-		// Volcano Tremor
-		/* To be fixed later.
-		public override Matrix ModifyTransformMatrix(Matrix Transform)
+		// Volcano Tremor (Fixed!)
+		public override void ModifyTransformMatrix(ref SpriteViewMatrix Transform)
 		{
 			if (!Main.gameMenu)
 			{
@@ -266,20 +265,31 @@ namespace ExampleMod
 
 					world.VolcanoTremorTime--;
 					ShakeCount++;
-
-
-					return Transform
-						* Matrix.CreateTranslation(-transX, -transY, 0f)
+					
+					Matrix shakeMatrix = new Matrix(
+						Matrix.CreateTranslation(-transX, -transY, 0f)
 						* Matrix.CreateRotationZ(rotation)
 						* Matrix.CreateTranslation(transX, transY, 0f)
-						* Matrix.CreateTranslation(offsetX, offsetY, 0f);
-					//Matrix.CreateFromAxisAngle(new Vector3(Main.screenWidth / 2, Main.screenHeight / 2, 0f), .2f);
-					//Matrix.CreateRotationZ(MathHelper.ToRadians(30));
+						* Matrix.CreateTranslation(offsetX, offsetY, 0f)
+						//Matrix.CreateFromAxisAngle(new Vector3(Main.screenWidth / 2, Main.screenHeight / 2, 0f), .2f);
+						//Matrix.CreateRotationZ(MathHelper.ToRadians(30));
+					);
+					
+					Transform.TransformationMatrix = shakeMatrix;
+					
+		/*
+			A few of the other things you can do with ModifyTransformMatrix include:
+			-Zooming/Stretching the screen.
+			Example: Transform.Zoom = new Vector2(1.7777f, 1f);
+			Result: Scales pixels by a factor of 1.7777 on the X axis, making the screen appear stretched.
+			
+			-Flipping the screen.
+			Example: Effects = SpriteEffects.FlipVertically;
+			Result: Screen is flipped upside-down.
+		*/
 				}
 			}
-			return Transform;
 		}
-		*/
 
 		public override void UpdateUI(GameTime gameTime)
 		{


### PR DESCRIPTION
### Description of the Change

Volcano Tremor code updated to work with the new version of ModifyTransformMatrix. I also added a comment with some code showing how to do things with ModifyTransformMatrix that the Volcano Tremor doesn't implement. (Namely, zooming the screen and flipping it)

### Benefits

Modders can use the Example Mod to help them learn how to use the new version of ModifyTransformMatrix.

### Applicable Issues

Comment could appear off to some, due to most additional comments like that being one-line comments, not comment blocks.

### Comments

I'm honestly wondering why this hasn't been updated. It was very easy to do, as I just had to look at SpriteViewMatrix.cs in the source code and just make minor tweaks.
