### PR TITLE
When compiling mods, check for {Dep}.Windows.dll and {Dep}.Mono.dll

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria.ModLoader/AssemblyManager.cs
@@ -118,8 +118,14 @@ namespace Terraria.ModLoader
 				{
 					modFile.Read(TmodFile.LoadedState.Code);
 
+					string suffixPlat = ModLoader.windows ? ".Windows.dll" : ".Mono.dll";
 					foreach (var dll in properties.dllReferences)
-						LoadAssembly(EncapsulateReferences(modFile.GetFile("lib/" + dll + ".dll")));
+					{
+						LoadAssembly(EncapsulateReferences(
+							modFile.GetFile("lib/" + dll + suffixPlat) ??
+							modFile.GetFile("lib/" + dll + ".dll")
+						));
+					}
 
 					assembly = LoadAssembly(EncapsulateReferences(modFile.GetMainAssembly()), modFile.GetMainPDB());
 					NeedsReload = false;

--- a/patches/tModLoader/Terraria.ModLoader/ModCompile.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModCompile.cs
@@ -427,7 +427,22 @@ namespace Terraria.ModLoader
 			refs.AddRange(GetTerrariaReferences(tempDir, forWindows));
 
 			//libs added by the mod
-			refs.AddRange(mod.properties.dllReferences.Select(refDll => Path.Combine(mod.path, "lib/" + refDll + ".dll")));
+			string suffixPlat = forWindows ? ".Windows.dll" : ".Mono.dll";
+			refs.AddRange(mod.properties.dllReferences.Select(refDll =>
+			{
+				refDll = Path.Combine(mod.path, "lib/" + refDll);
+				//check if .Windows.dll /.Mono.dll exists when compiling for that platform
+				if (File.Exists(refDll + suffixPlat))
+				{
+					refDll += suffixPlat;
+				}
+				else
+				{
+					//fallback to main .dll
+					refDll += ".dll";
+				}
+				return refDll;
+			}));
 
 			//all dlls included in all referenced mods
 			foreach (var refMod in refMods)


### PR DESCRIPTION
### Description of the Change

Allow compiling any given mod's `Windows.dll` and `Mono.dll` against the appropriate version of a given `dllReferences` by checking for `.Windows.dll` and `.Mono.dll` versions of the library.

### Alternate designs

I've initially thought about allowing modders to supply `dllWindowsReferences` and `dllMonoReferences`, but dropped the idea due to the additional work that needs to be done by the modder and the higher possibility for errors.

### Why this should be merged into tModLoader

This is required to compile mods which use libraries using XNA / FNA. Otherwise, both `Windows.dll` and `Mono.dll` would use the XNA version of the library.

### Benefits

Mods will be able to use libraries which in themselves depend on XNA / FNA, as long as both versions are provided.

### Possible drawbacks

There could be conflicts if a library `CoolLibrary.dll` ships with `CoolLibrary.Windows.dll` and / or `CoolLibrary.Mono.dll`, which serve some internal purpose. Renaming the files should resolve the issue though, as the file name doesn't affect assembly resolution.

~~From what I can tell, tModLoader loads all libraries when the mod loads. This causes both versions to be loaded, but it shouldn't cause issues: only the version needed for the platform is actually used at runtime.~~  
Resolved: https://github.com/blushiemagic/tModLoader/pull/417/commits/74da2ff5bb932ffc489eee42b4cbc46c4c31f1ae

### Sample Usage

- In `build.txt`, `dllReferences = CoolLibrary`
- In `lib` folder,
    - `CoolLibrary.dll` (XNA)
    - `CoolLibrary.Mono.dll` (FNA)
- Compiled `Windows.dll` uses `CoolLibrary.dll`
- Compiled `Mono.dll` uses `CoolLibrary.Mono.dll`