### PR TITLE
Changed GetManaCost to ModifyManaCost

### DIFF
--- a/ExampleMod/Items/Weapons/ExampleMagicMissile.cs
+++ b/ExampleMod/Items/Weapons/ExampleMagicMissile.cs
@@ -1,3 +1,4 @@
+using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -33,13 +34,27 @@ namespace ExampleMod.Items.Weapons
 		// This item's mana usage changes through the day, peaking at 1.5x mana usage at noon, and 0.5x mana usage at midnight.
 		public override void ModifyManaCost(Player player, ref float reduce, ref float mult) {
 			float currentTime = (float)Main.time;
+			// The time at which it changes from day to night and vice versa.
 			int maxTime = Main.dayTime ? 54000 : 32400;
+			// The time at which it is 12pm or 12am, which isn't exactly half the values above.
 			int time12 = Main.dayTime ? 28800 : 18000;
+			// If the time it after 12, recalculate the current time to account for the length of the second half of the day instead of the first.
 			if (currentTime > time12) {
+				currentTime -= time12;
 				time12 = maxTime - time12;
-				currentTime = maxTime - currentTime;
+				currentTime += time12;
 			}
-			float timeMult = 1 + currentTime / time12 * 0.5f * (Main.dayTime ? 1 : -1);
+			// If it is night time, add twice the duration of the current half of the night.
+			if (!Main.dayTime) {
+				currentTime += time12 * 2;
+			}
+			// We divide the current time by the current half of the day or night's time, then by 2.
+			// The result would gradually go from 0 at 4:30am, 0.5 at 12pm, 1 at 7:30pm and 1.5f at 12 am.
+			float timeMult = currentTime / time12 / 2;
+			// Then we multiply the result above by PI, and calculate the sine of that, then multiply it by 0.5f and add 1.
+			// The result would go from 1 at 4:30am, 1.5 at 12pm, 1 at 7:30pm and 0.5f at 12 am, in a sine wave pattern.
+			timeMult = 1 + (float)Math.Sin(timeMult * Math.PI) * 0.5f;
+			// Last, we multiply the current mana cost multiplier of the item by our multiplier.
 			mult *= timeMult;
 		}
 

--- a/ExampleMod/Items/Weapons/ExampleMagicMissile.cs
+++ b/ExampleMod/Items/Weapons/ExampleMagicMissile.cs
@@ -32,28 +32,17 @@ namespace ExampleMod.Items.Weapons
 		}
 
 		// This item's mana usage changes through the day, peaking at 1.5x mana usage at noon, and 0.5x mana usage at midnight.
+		// Thanks to chikenbones for the help in the calculations
 		public override void ModifyManaCost(Player player, ref float reduce, ref float mult) {
-			float currentTime = (float)Main.time;
+			double currentTime = Main.time;
 			// The time at which it changes from day to night and vice versa.
-			int maxTime = Main.dayTime ? 54000 : 32400;
-			// The time at which it is 12pm or 12am, which isn't exactly half the values above.
-			int time12 = Main.dayTime ? 28800 : 18000;
-			// If the time it after 12, recalculate the current time to account for the length of the second half of the day instead of the first.
-			if (currentTime > time12) {
-				currentTime -= time12;
-				time12 = maxTime - time12;
-				currentTime += time12;
-			}
-			// If it is night time, add twice the duration of the current half of the night.
-			if (!Main.dayTime) {
-				currentTime += time12 * 2;
-			}
-			// We divide the current time by the current half of the day or night's time, then by 2.
-			// The result would gradually go from 0 at 4:30am, 0.5 at 12pm, 1 at 7:30pm and 1.5f at 12 am.
-			float timeMult = currentTime / time12 / 2;
-			// Then we multiply the result above by PI, and calculate the sine of that, then multiply it by 0.5f and add 1.
-			// The result would go from 1 at 4:30am, 1.5 at 12pm, 1 at 7:30pm and 0.5f at 12 am, in a sine wave pattern.
-			timeMult = 1 + (float)Math.Sin(timeMult * Math.PI) * 0.5f;
+			double maxTime = Main.dayTime ? Main.dayLength : Main.nightLength;
+			// More mana during day, less at night
+			int direction = Main.dayTime ? 1 : -1;
+			// Sine goes from 0 to 1 to 0 over a period of pi, so we match that to the length of the day/night.
+			float timeMult = (float)Math.Sin(currentTime / maxTime * Math.PI);
+			// Then we multiply by direction so it goes between 1 and -1 through the entire day, then multiply by 0.5 and add 1 to make it go between 1.5 and 0.5.
+			timeMult = 1 + timeMult * direction * 0.5f;
 			// Last, we multiply the current mana cost multiplier of the item by our multiplier.
 			mult *= timeMult;
 		}

--- a/ExampleMod/Items/Weapons/ExampleMagicMissile.cs
+++ b/ExampleMod/Items/Weapons/ExampleMagicMissile.cs
@@ -31,7 +31,7 @@ namespace ExampleMod.Items.Weapons
 		}
 
 		// This item's mana usage changes through the day, peaking at 1.5x mana usage at noon, and 0.5x mana usage at midnight.
-		public override void GetManaCost(Player player, ref int mana) {
+		public override void ModifyManaCost(Player player, ref float reduce, ref float mult) {
 			float currentTime = (float)Main.time;
 			int maxTime = Main.dayTime ? 54000 : 32400;
 			int time12 = Main.dayTime ? 28800 : 18000;
@@ -39,8 +39,8 @@ namespace ExampleMod.Items.Weapons
 				time12 = maxTime - time12;
 				currentTime = maxTime - currentTime;
 			}
-			float multi = 1 + currentTime / time12 * 0.5f * Main.dayTime.ToDirectionInt();
-			mana = (int)(mana * multi);
+			float timeMult = 1 + currentTime / time12 * 0.5f * (Main.dayTime ? 1 : -1);
+			mult *= timeMult;
 		}
 
 		public override void AddRecipes() {

--- a/patches/tModLoader/Terraria.ModLoader/CombinedHooks.cs
+++ b/patches/tModLoader/Terraria.ModLoader/CombinedHooks.cs
@@ -15,9 +15,9 @@ namespace Terraria.ModLoader
 			PlayerHooks.GetWeaponDamage(player, item, ref damage);
 		}
 
-		public static void GetManaCost(Player player, Item item, ref int mana) {
-			ItemLoader.GetManaCost(item, player, ref mana);
-			PlayerHooks.GetManaCost(player, item, ref mana);
+		public static void ModifyManaCost(Player player, Item item, ref float reduce, ref float mult) {
+			ItemLoader.ModifyManaCost(item, player, ref reduce, ref mult);
+			PlayerHooks.ModifyManaCost(player, item, ref reduce, ref mult);
 		}
 
 		public static void OnConsumeMana(Player player, Item item, int manaConsumed) {

--- a/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
@@ -168,8 +168,9 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="item">The item being used.</param>
 		/// <param name="player">The player using the item.</param>
-		/// <param name="mana">The amount of mana the item will use, after being affected by mana cost reduction.</param>
-		public virtual void GetManaCost(Item item, Player player, ref int mana) {
+		/// <param name="reduce">Used for decreasingly stacking buffs (most common). Only ever use -= on this field.</param>
+		/// <param name="mult">Use to directly multiply the item's effective mana cost. Good for debuffs, or things which should stack separately (eg meteor armor set bonus).</param>
+		public virtual void ModifyManaCost(Item item, Player player, ref float reduce, ref float mult) {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -381,19 +381,19 @@ namespace Terraria.ModLoader
 				g.Instance(item).GetHealMana(item, player, quickHeal, ref healValue);
 		}
 
-		private delegate void DelegateGetManaCost(Item item, Player player, ref int mana);
-		private static HookList HookGetManaCost = AddHook<DelegateGetManaCost>(g => g.GetManaCost);
+		private delegate void DelegateModifyManaCost(Item item, Player player, ref float reduce, ref float mult);
+		private static HookList HookModifyManaCost = AddHook<DelegateModifyManaCost>(g => g.ModifyManaCost);
 		/// <summary>
-		/// Calls ModItem.GetManaCost, then all GlobalItem.GetManaCost hooks.
+		/// Calls ModItem.ModifyManaCost, then all GlobalItem.ModifyManaCost hooks.
 		/// </summary>
-		public static void GetManaCost(Item item, Player player, ref int mana) {
+		public static void ModifyManaCost(Item item, Player player, ref float reduce, ref float mult) {
 			if (item.IsAir)
 				return;
 			
-			item.modItem?.GetManaCost(player, ref mana);
+			item.modItem?.ModifyManaCost(player, ref reduce, ref mult);
 
-			foreach (var g in HookGetManaCost.arr) {
-				g.Instance(item).GetManaCost(item, player, ref mana);
+			foreach (var g in HookModifyManaCost.arr) {
+				g.Instance(item).ModifyManaCost(item, player, ref reduce, ref mult);
 			}
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModItem.cs
@@ -262,8 +262,9 @@ namespace Terraria.ModLoader
 		/// Allows you to temporarily modify the amount of mana this item will consume on use, based on player buffs, accessories, etc. This is only called for items with a mana value.
 		/// </summary>
 		/// <param name="player">The player using the item.</param>
-		/// <param name="mana">The amount of mana the item will use, after being affected by mana cost reduction.</param>
-		public virtual void GetManaCost(Player player, ref int mana) {
+		/// <param name="reduce">Used for decreasingly stacking buffs (most common). Only ever use -= on this field.</param>
+		/// <param name="mult">Use to directly multiply the item's effective mana cost. Good for debuffs, or things which should stack separately (eg meteor armor set bonus).</param>
+		public virtual void ModifyManaCost(Player player, ref float reduce, ref float mult) {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria.ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModPlayer.cs
@@ -439,8 +439,9 @@ namespace Terraria.ModLoader
 		/// Allows you to temporarily modify the amount of mana an item will consume on use, based on player buffs, accessories, etc. This is only called for items with a mana value.
 		/// </summary>
 		/// <param name="item">The item being used.</param>
-		/// <param name="mana">The amount of mana the item will use, after being affected by mana cost reduction.</param>
-		public virtual void GetManaCost(Item item, ref int mana) {
+		/// <param name="reduce">Used for decreasingly stacking buffs (most common). Only ever use -= on this field.</param>
+		/// <param name="mult">Use to directly multiply the item's effective mana cost. Good for debuffs, or things which should stack separately (eg meteor armor set bonus).</param>
+		public virtual void ModifyManaCost(Item item, ref float reduce, ref float mult) {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria.ModLoader/PlayerHooks.cs
+++ b/patches/tModLoader/Terraria.ModLoader/PlayerHooks.cs
@@ -585,15 +585,15 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		private delegate void DelegateGetManaCost(Item item, ref int mana);
-		private static HookList HookGetManaCost = AddHook<DelegateGetManaCost>(p => p.GetManaCost);
+		private delegate void DelegateModifyManaCost(Item item, ref float reduce, ref float mult);
+		private static HookList HookModifyManaCost = AddHook<DelegateModifyManaCost>(p => p.ModifyManaCost);
 
-		public static void GetManaCost(Player player, Item item, ref int mana) {
+		public static void ModifyManaCost(Player player, Item item, ref float reduce, ref float mult) {
 			if (item.IsAir)
 				return;
 			
-			foreach (int index in HookGetManaCost.arr) {
-				player.modPlayers[index].GetManaCost(item, ref mana);
+			foreach (int index in HookModifyManaCost.arr) {
+				player.modPlayers[index].ModifyManaCost(item, ref reduce, ref mult);
 			}
 		}
 

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -6288,7 +6288,7 @@
  			int type = list[Main.rand.Next(list.Count)];
  			Item item = new Item();
  			item.SetDefaults(type, false);
-@@ -40007,6 +_,42 @@
+@@ -40007,6 +_,45 @@
  					NetMessage.SendData(21, -1, -1, null, number, 1f, 0f, 0f, 0, 0, 0);
  				}
  			}
@@ -6296,7 +6296,10 @@
 +
 +		public int GetManaCost(Item item) {
 +			float reduce = manaCost;
-+			float mult = item.type != 127 || !spaceGun ? 1 : 0;
++			float mult = 1;
++			if (item.type == ItemID.SpaceGun && spaceGun) {
++				mult = 0;
++			}
 +			CombinedHooks.ModifyManaCost(this, item, ref reduce, ref mult);
 +			int mana = (int)(item.mana * reduce * mult);
 +			return mana >= 0 ? mana : 0;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -6288,15 +6288,17 @@
  			int type = list[Main.rand.Next(list.Count)];
  			Item item = new Item();
  			item.SetDefaults(type, false);
-@@ -40007,6 +_,40 @@
+@@ -40007,6 +_,42 @@
  					NetMessage.SendData(21, -1, -1, null, number, 1f, 0f, 0f, 0, 0, 0);
  				}
  			}
 +		}
 +
 +		public int GetManaCost(Item item) {
-+			int mana = (item.type != 127 || !this.spaceGun) ? (int)(item.mana * this.manaCost) : 0;
-+			CombinedHooks.GetManaCost(this, item, ref mana);
++			float reduce = manaCost;
++			float mult = item.type != 127 || !spaceGun ? 1 : 0;
++			CombinedHooks.ModifyManaCost(this, item, ref reduce, ref mult);
++			int mana = (int)(item.mana * reduce * mult);
 +			return mana >= 0 ? mana : 0;
 +		}
 +


### PR DESCRIPTION
### Description of the Change
Changed `ModItem`, `GlobalItem` and `ModPlayer` `GetManaCost` hooks to `ModifyManaCost`. The new hooks closely resemble the new `ModifyWeaponDamage` hooks, which allow modifying the multipliers that affect the value in the end, rather than the value itself.
The change was done after realizing that the previous hook not only didn't took the mana cost multiplier into account correctly, but also didn't allow to temporarily modify it.

### Sample Usage
See the modified version of the ExampleMagicMissile item.


