### PR TITLE
Bugfix of permission on linux in installer

### DIFF
--- a/installer2/Installer.java
+++ b/installer2/Installer.java
@@ -76,12 +76,7 @@ public class Installer
                 }
                 copy(source, destination);
                 if(file == "tModLoaderServer" || file == "Terraria"){
-                    // Alt: file.setExecutable(true, false);
-                    Set<PosixFilePermission> permissions = new HashSet<>();
-                    permissions.add(PosixFilePermission.OWNER_READ);
-                    permissions.add(PosixFilePermission.OWNER_WRITE);
-                    permissions.add(PosixFilePermission.OWNER_EXECUTE);
-                    Files.setPosixFilePermissions(destination.toPath(), permissions);
+                    file.setExecutable(true, false); // Result should be rw-r--r-- becoming rwxr-xr-x
                 }
             }
             else

--- a/installer2/Installer.java
+++ b/installer2/Installer.java
@@ -78,6 +78,8 @@ public class Installer
                 if(file == "tModLoaderServer" || file == "Terraria"){
                     // Alt: file.setExecutable(true, false);
                     Set<PosixFilePermission> permissions = new HashSet<>();
+                    permissions.add(PosixFilePermission.OWNER_READ);
+                    permissions.add(PosixFilePermission.OWNER_WRITE);
                     permissions.add(PosixFilePermission.OWNER_EXECUTE);
                     Files.setPosixFilePermissions(destination.toPath(), permissions);
                 }


### PR DESCRIPTION
As discussed on discord:

`tModLoaderInstaller.jar` provides wrong permission for `Terraria` and `tModLoaderServer` as follows:
```
---x------  1 kreyren kreyren      133 Jun 14 23:45 Terraria
---x------  1 kreyren kreyren     1151 Jul  1 20:52 tModLoaderServer
```

Which won't open Terraria on Linux due permission issue.

Expecting Read+Write+Executable as:

```
-rwxrwxrwx  1 kreyren kreyren      133 Jun 14 23:45 Terraria
-rwxrwxrwx  1 kreyren kreyren     1151 Jul  1 20:52 tModLoaderServer
```

Reference: https://discordapp.com/channels/103110554649894912/436261997416546305/596861420944097304

---

Requires sanity check since i'm not the best in java..