### PR TITLE
Add a Sponsor button on GitHub linking to the Patreon

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: tModLoader


### PR DESCRIPTION
<!-- 

PLEASE READ the following requirements:

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* If applicable, provide Example Mod usage (example code) in the 'Sample usage' section
* If a header/description isn't applicable to your PR, please add "N/A" or "Not Applicable" 

We are happy as long as you follow this template. Feel free to add any extra headings yourself if you deem them necessary or useful.
-->
### Description of the change

GitHub allows for the displaying of a Sponsor button on public repositories.

![The Sponsor button](https://user-images.githubusercontent.com/1540885/61982903-8508a100-affe-11e9-9081-7ab13d015c77.png)

The button, when clicked, opens a window containing one or more links to funding platforms, such as Patreon, Ko-fi, Open Collective or [even GitHub itself]!

![The proposed Sponsor links window](https://user-images.githubusercontent.com/1540885/61982935-a7022380-affe-11e9-8d2b-43046fede704.png)

Those links are specified in the [`FUNDING.yml` file](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository#about-funding-files) in the root of the repository.

After accepting this pull request, the Support button [should be enabled in the repository settings](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository#displaying-a-sponsor-button-in-your-repository).

![Enable it here](https://user-images.githubusercontent.com/1540885/61985659-77591880-b00a-11e9-8e3a-7278becefbea.png)

### Alternate designs

I couldn't find any other tModLoader funding pages other than [the official Patreon](https://www.patreon.com/tModLoader), so I added that to the file, but different ones [can be added](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository#about-funding-files).

### Why this should be merged into tModLoader
Because it is related to the tModLoader projects. Other projects can implement their own Sponsor button.

### Benefits
More people will be aware of the tModLoader Patreon page, especially those who visit the GitHub page.

### Possible drawbacks
Uh... None, I guess?