### PR TITLE
Check for Grass instead of Dirt tiles in MakeWells

### DIFF
--- a/ExampleMod/ExampleWorld.cs
+++ b/ExampleMod/ExampleWorld.cs
@@ -215,7 +215,7 @@ namespace ExampleMod
 						while (!Main.tile[i, j].active() && (double)j < Main.worldSurface) {
 							j++;
 						}
-						if (Main.tile[i, j].type == TileID.Dirt) {
+						if (Main.tile[i, j].type == TileID.Grass) {
 							j--;
 							if (j > 150) {
 								bool placementOK = true;


### PR DESCRIPTION
Right now MakeWells checks for dirt tiles, but worlds hardly ever generate with dirt on the surface touching air. Checking for grass should be more effective.