### PR TITLE
WIP feat: Make max (de)buff limit modifiable

### DIFF
--- a/patches/tModLoader/Terraria.ID/BuffID.cs.patch
+++ b/patches/tModLoader/Terraria.ID/BuffID.cs.patch
@@ -7,10 +7,12 @@
  
  namespace Terraria.ID
  {
-@@ -210,5 +_,29 @@
+@@ -209,6 +_,30 @@
+ 		public const int BetsysCurse = 203;
  		public const int Oiled = 204;
  		public const int BallistaPanic = 205;
- 		public const int Count = 206;
+-		public const int Count = 206;
++		public static int Count = Player.maxBuffs + 206;
 +
 +		public static readonly IdDictionary Search = IdDictionary.Create<BuffID, int>();
 +

--- a/patches/tModLoader/Terraria.ID/BuffID.cs.patch
+++ b/patches/tModLoader/Terraria.ID/BuffID.cs.patch
@@ -7,12 +7,10 @@
  
  namespace Terraria.ID
  {
-@@ -209,6 +_,30 @@
- 		public const int BetsysCurse = 203;
+@@ -210,5 +_,29 @@
  		public const int Oiled = 204;
  		public const int BallistaPanic = 205;
--		public const int Count = 206;
-+		public static int Count = Player.maxBuffs + 206;
+ 		public const int Count = 206;
 +
 +		public static readonly IdDictionary Search = IdDictionary.Create<BuffID, int>();
 +

--- a/patches/tModLoader/Terraria.ModLoader.IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria.ModLoader.IO/PlayerIO.cs
@@ -149,7 +149,6 @@ namespace Terraria.ModLoader.IO
 
 		internal static List<TagCompound> SaveModBuffs(Player player) {
 			var list = new List<TagCompound>();
-			byte vanillaIndex = 0;
 			for (int k = 0; k < Player.maxBuffs; k++) {
 				int buff = player.buffType[k];
 				if (buff == 0 || Main.buffNoSave[buff])
@@ -158,7 +157,6 @@ namespace Terraria.ModLoader.IO
 				if (BuffLoader.IsModBuff(buff)) {
 					var modBuff = BuffLoader.GetBuff(buff);
 					list.Add(new TagCompound {
-						["index"] = vanillaIndex, //position of the loaded buff if there were no modBuffs before it
 						["mod"] = modBuff.mod.Name,
 						["name"] = modBuff.Name,
 						["time"] = player.buffTime[k]
@@ -166,12 +164,10 @@ namespace Terraria.ModLoader.IO
 				}
 				else {
 					list.Add(new TagCompound {
-						["index"] = vanillaIndex,
-						["mod"] = "Vanilla",
-						["name"] = buff,
+						["mod"] = "Terraria",
+						["id"] = buff,
 						["time"] = player.buffTime[k]
 					});
-					vanillaIndex++;
 				}
 			}
 			return list;
@@ -183,23 +179,28 @@ namespace Terraria.ModLoader.IO
 			while (buffCount > 0 && player.buffType[buffCount - 1] == 0)
 				buffCount--;
 
+			if (buffCount == 0) {
+				//always the case since vanilla buff saving was disabled, when extra buff slots were added
+				foreach (var tag in list) {
+					if (buffCount == Player.maxBuffs)
+						return;
+
+					var modName = tag.GetString("mod");
+					int type = modName == "Terraria" ? tag.GetInt("id") : ModLoader.GetMod(modName)?.BuffType(tag.GetString("name")) ?? 0;
+					if (type > 0) {
+						player.buffType[buffCount] = type;
+						player.buffTime[buffCount] = tag.GetInt("time");
+						buffCount++;
+					}
+				}
+				return;
+			}
+
+			//legacy code path
 			//iterate the list in reverse, insert each buff at its index and push the buffs after it up a slot
 			foreach (var tag in list.Reverse()) {
-				Mod mod;
-				int type;
-
-				// get the name beforehand so we know if it's vanilla
-				string modName = tag.GetString("mod");
-
-				if (modName != "Vanilla") {
-					mod = ModLoader.GetMod(modName);
-					type = mod?.BuffType(tag.GetString("name")) ?? 0;
-				}
-				else 
-				{
-					type = tag.GetInt("name");
-				}
-
+				var mod = ModLoader.GetMod(tag.GetString("mod"));
+				int type = mod?.BuffType(tag.GetString("name")) ?? 0;
 				if (type == 0)
 					continue;
 

--- a/patches/tModLoader/Terraria.ModLoader.IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria.ModLoader.IO/PlayerIO.cs
@@ -165,6 +165,12 @@ namespace Terraria.ModLoader.IO
 					});
 				}
 				else {
+					list.Add(new TagCompound {
+						["index"] = vanillaIndex,
+						["mod"] = "Vanilla",
+						["name"] = buff,
+						["time"] = player.buffTime[k]
+					});
 					vanillaIndex++;
 				}
 			}
@@ -179,8 +185,21 @@ namespace Terraria.ModLoader.IO
 
 			//iterate the list in reverse, insert each buff at its index and push the buffs after it up a slot
 			foreach (var tag in list.Reverse()) {
-				var mod = ModLoader.GetMod(tag.GetString("mod"));
-				int type = mod?.BuffType(tag.GetString("name")) ?? 0;
+				Mod mod;
+				int type;
+
+				// get the name beforehand so we know if it's vanilla
+				string modName = tag.GetString("mod");
+
+				if (modName != "Vanilla") {
+					mod = ModLoader.GetMod(modName);
+					type = mod?.BuffType(tag.GetString("name")) ?? 0;
+				}
+				else 
+				{
+					type = tag.GetInt("name");
+				}
+
 				if (type == 0)
 					continue;
 

--- a/patches/tModLoader/Terraria.ModLoader/BuffLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/BuffLoader.cs
@@ -1,6 +1,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using Terraria.ID;
 using Terraria.Localization;
@@ -28,6 +29,14 @@ namespace Terraria.ModLoader
 		private static DelegateModifyBuffTip[] HookModifyBuffTip;
 		private static Action<string, List<Vector2>>[] HookCustomBuffTipSize;
 		private static Action<string, SpriteBatch, int, int>[] HookDrawCustomBuffTip;
+
+		private static int _ExtraBuffCount;
+		internal static int ExtraBuffCount {
+			get {
+				if(Main.playerLoaded) return _ExtraBuffCount;
+				return _ExtraBuffCount = ModLoader.Mods.Sum(m => (int)m.ExtraBuffSlots);
+			}
+		}
 
 		static BuffLoader() {
 			for (int k = 0; k < BuffID.Count; k++) {

--- a/patches/tModLoader/Terraria.ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria.ModLoader/Mod.cs
@@ -83,6 +83,11 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// The amount of extra buff slots this mod defines.
+		/// </summary>
+		public virtual uint ExtraBuffSlots { get; }
+
+		/// <summary>
 		/// Override this method to add recipe groups to this mod. You must add recipe groups by calling the RecipeGroup.RegisterGroup method here. A recipe group is a set of items that can be used interchangeably in the same recipe.
 		/// </summary>
 		public virtual void AddRecipeGroups() {

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -47,6 +47,14 @@
  		public static FileMetadata WorldFileMetadata;
  		public static FileMetadata MapFileMetadata;
  		private AchievementManager _achievements;
+@@ -184,6 +_,7 @@
+ 		public static ulong LobbyId = 0uL;
+ 		private static object _audioLock = new object();
+ 		private static Microsoft.Xna.Framework.Color[] _mapColorCacheArray = new Microsoft.Xna.Framework.Color[30000];
++		public static bool playerLoaded { get { return Main.ActivePlayersCount > 0; } }
+ 		public static float expertLife = 2f;
+ 		public static float expertDamage = 2f;
+ 		public static float expertDebuffTime = 2f;
 @@ -211,11 +_,13 @@
  		public static bool UseHeatDistortion = true;
  		public static int npcStreamSpeed = 60;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -129,6 +129,15 @@
  		public static int renderCount = 99;
  		public static GraphicsDeviceManager graphics;
  		public static SpriteBatch spriteBatch;
+@@ -578,7 +_,7 @@
+ 		public static bool armorHide = false;
+ 		public static float craftingAlpha = 1f;
+ 		public static float armorAlpha = 1f;
+-		public static float[] buffAlpha = new float[206];
++		public static float[] buffAlpha = new float[Player.maxBuffs + 206];
+ 		public static bool hardMode = false;
+ 		public float chestLootScale = 1f;
+ 		public bool chestLootHover;
 @@ -598,6 +_,7 @@
  		public static bool maxQ = true;
  		public static float gfxQuality = 1f;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -4002,12 +4002,14 @@
  			{
  				if (Main.player[Main.myPlayer].buffType[i] > 0)
  				{
-@@ -38013,7 +_,7 @@
+@@ -38012,8 +_,8 @@
+ 					int num3 = 76;
  					if (i >= num2)
  					{
- 						x = 32 + (i - num2) * 38;
+-						x = 32 + (i - num2) * 38;
 -						num3 += 50;
-+						num3 += 50; // could change Y to adapt to increased buff limit
++						x = 32 + Math.Abs(i % 11) * 38;
++						num3 += 50 * (i / 11);
  					}
  					num = Main.DrawBuffIcon(num, i, b, x, num3);
  				}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1088,6 +1088,15 @@
  				if (flag)
  				{
  					NetMessage.SendData(36, -1, -1, null, Main.myPlayer, 0f, 0f, 0f, 0, 0, 0);
+@@ -12468,7 +_,7 @@
+ 					NetMessage.SendData(42, -1, -1, null, Main.myPlayer, 0f, 0f, 0f, 0, 0, 0);
+ 				}
+ 				bool flag2 = false;
+-				for (int num4 = 0; num4 < 22; num4++)
++				for (int num4 = 0; num4 < Player.maxBuffs; num4++)
+ 				{
+ 					if (Main.player[Main.myPlayer].buffType[num4] != Main.clientPlayer.buffType[num4])
+ 					{
 @@ -12498,6 +_,7 @@
  				{
  					NetMessage.SendData(115, -1, -1, null, Main.myPlayer, 0f, 0f, 0f, 0, 0, 0);
@@ -3736,8 +3745,12 @@
  				}
  			}
  			Microsoft.Xna.Framework.Rectangle rectangle = new Microsoft.Xna.Framework.Rectangle(Main.screenWidth / 2 - Main.chatBackTexture.Width / 2, 100, Main.chatBackTexture.Width, (num2 + 2) * 30);
-@@ -34287,11 +_,15 @@
- 			for (int j = 0; j < 22; j++)
+@@ -34284,14 +_,18 @@
+ 			string focusText = "";
+ 			string focusText2 = "";
+ 			int num5 = Main.player[Main.myPlayer].statLifeMax2 - Main.player[Main.myPlayer].statLife;
+-			for (int j = 0; j < 22; j++)
++			for (int j = 0; j < Player.maxBuffs; j++)
  			{
  				int num6 = Main.player[Main.myPlayer].buffType[j];
 -				if (Main.debuff[num6] && Main.player[Main.myPlayer].buffTime[j] > 5 && num6 != 28 && num6 != 34 && num6 != 87 && num6 != 89 && num6 != 21 && num6 != 86 && num6 != 199)
@@ -3805,9 +3818,10 @@
  											Main.npcChatText = Lang.dialog(230, false);
  										}
 -										Main.player[Main.myPlayer].statLife = Main.player[Main.myPlayer].statLifeMax2;
+-										for (int l = 0; l < 22; l++)
 +										Main.player[Main.myPlayer].statLife += health;
 +										if (removeDebuffs) { // no indent for better patching
- 										for (int l = 0; l < 22; l++)
++										for (int l = 0; l < Player.maxBuffs; l++)
  										{
  											int num24 = Main.player[Main.myPlayer].buffType[l];
 -											if (Main.debuff[num24] && Main.player[Main.myPlayer].buffTime[l] > 0 && num24 != 28 && num24 != 34 && num24 != 87 && num24 != 89 && num24 != 21 && num24 != 86 && num24 != 199)
@@ -3845,6 +3859,15 @@
  			new Microsoft.Xna.Framework.Color(150, 150, 150, 150);
  			if (Main.mouseX >= num && (float)Main.mouseX <= (float)num + (float)Main.inventoryBackTexture.Width * Main.inventoryScale && Main.mouseY >= num2 && (float)Main.mouseY <= (float)num2 + (float)Main.inventoryBackTexture.Height * Main.inventoryScale && !PlayerInput.IgnoreMouseInterface)
  			{
+@@ -36095,7 +_,7 @@
+ 					num24++;
+ 				}
+ 				int num26 = 46;
+-				for (int n = 0; n < 22; n++)
++				for (int n = 0; n < Player.maxBuffs; n++)
+ 				{
+ 					int num27 = Main.player[Main.myPlayer].buffType[n];
+ 					if (num27 != 0)
 @@ -36133,14 +_,13 @@
  							int num31 = (int)(Main.player[Main.myPlayer].manaSickReduction * 100f) + 1;
  							Main.buffString = Main.buffString + num31 + "%";
@@ -3970,6 +3993,24 @@
  							{
  								Microsoft.Xna.Framework.Rectangle rectangle2 = new Microsoft.Xna.Framework.Rectangle((int)(Main.player[Main.myPlayer].position.X + (float)(Main.player[Main.myPlayer].width / 2) - (float)(Player.tileRangeX * 16)), (int)(Main.player[Main.myPlayer].position.Y + (float)(Main.player[Main.myPlayer].height / 2) - (float)(Player.tileRangeY * 16)), Player.tileRangeX * 16 * 2, Player.tileRangeY * 16 * 2);
  								Microsoft.Xna.Framework.Rectangle value4 = new Microsoft.Xna.Framework.Rectangle((int)Main.npc[k].position.X, (int)Main.npc[k].position.Y, Main.npc[k].width, Main.npc[k].height);
+@@ -38003,7 +_,7 @@
+ 			Main.recBigList = false;
+ 			int num = -1;
+ 			int num2 = 11;
+-			for (int i = 0; i < 22; i++)
++			for (int i = 0; i <	Player.maxBuffs; i++)
+ 			{
+ 				if (Main.player[Main.myPlayer].buffType[i] > 0)
+ 				{
+@@ -38013,7 +_,7 @@
+ 					if (i >= num2)
+ 					{
+ 						x = 32 + (i - num2) * 38;
+-						num3 += 50;
++						num3 += 50; // could change Y to adapt to increased buff limit
+ 					}
+ 					num = Main.DrawBuffIcon(num, i, b, x, num3);
+ 				}
 @@ -38028,6 +_,7 @@
  				if (num4 > 0)
  				{

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -373,11 +373,15 @@
  							NetMessage.SendData(3, this.whoAmI, -1, null, 0, 0f, 0f, 0f, 0, 0, 0);
  							return;
  						}
-@@ -2132,7 +_,7 @@
+@@ -2130,9 +_,9 @@
+ 							return;
+ 						}
  						Player player12 = Main.player[num132];
- 						for (int num133 = 0; num133 < 22; num133++)
- 						{
+-						for (int num133 = 0; num133 < 22; num133++)
+-						{
 -							player12.buffType[num133] = (int)this.reader.ReadByte();
++						for (int num133 = 0; num133 < Player.maxBuffs; num133++)
++						{
 +							player12.buffType[num133] = (int)(ModNet.AllowVanillaClients ? reader.ReadByte() : reader.ReadUInt16());
  							if (player12.buffType[num133] > 0)
  							{

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -495,4 +495,3 @@
  			int num218 = (int)this.reader.ReadInt16();
  			float num219 = this.reader.ReadSingle();
  			float num220 = this.reader.ReadSingle();
-

--- a/patches/tModLoader/Terraria/Mount.cs.patch
+++ b/patches/tModLoader/Terraria/Mount.cs.patch
@@ -143,6 +143,15 @@
  					}
  					if (mountedPlayer.statLife <= mountedPlayer.statLifeMax2 / 2)
  					{
+@@ -2523,7 +_,7 @@
+ 			{
+ 				return;
+ 			}
+-			for (int i = 0; i < 22; i++)
++			for (int i = 0; i < Player.maxBuffs; i++)
+ 			{
+ 				if (mountedPlayer.buffType[i] == this._data.buff)
+ 				{
 @@ -2585,6 +_,7 @@
  		public bool AimAbility(Player mountedPlayer, Vector2 mousePosition)
  		{

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -170,11 +170,15 @@
  							break;
  						}
  					case 38:
-@@ -747,7 +_,10 @@
+@@ -745,9 +_,12 @@
+ 						}
+ 					case 50:
  						writer.Write((byte)number);
- 						for (int num16 = 0; num16 < 22; num16++)
- 						{
+-						for (int num16 = 0; num16 < 22; num16++)
+-						{
 -							writer.Write((byte)Main.player[number].buffType[num16]);
++						for (int num16 = 0; num16 < Player.maxBuffs; num16++)
++						{
 +							if (ModNet.AllowVanillaClients)
 +								writer.Write((byte)Main.player[number].buffType[num16]);
 +							else

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -39,7 +39,7 @@
  			}
  		}
  
-+		public static int maxBuffs = 22;
++		internal static int maxBuffs { get { return 22 + BuffLoader.ExtraBuffCount; } }
 +
  		public const int maxSolarShields = 3;
  		public const int nebulaMaxLevel = 3;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -35,7 +35,23 @@
  			}
  		}
  
-@@ -304,7 +_,7 @@
+@@ -286,6 +_,8 @@
+ 			}
+ 		}
+ 
++		public static int maxBuffs = 22;
++
+ 		public const int maxSolarShields = 3;
+ 		public const int nebulaMaxLevel = 3;
+ 		public const int SupportedSlotsArmor = 3;
+@@ -297,14 +_,13 @@
+ 		public const int miscSlotCart = 2;
+ 		public const int miscSlotMount = 3;
+ 		public const int miscSlotHook = 4;
+-		public const int maxBuffs = 22;
+ 		public const int defaultWidth = 20;
+ 		public const int defaultHeight = 42;
+ 		public const int shadowMax = 3;
  		public const int SHIELD_PARRY_DURATION = 20;
  		public const int SHIELD_PARRY_DURATION_DRAWING_TWEAKER = 20;
  		public const int SHIELD_PARRY_DAMAGE_BUFF_MULTIPLIER = 5;
@@ -133,19 +149,27 @@
  					this.inventory[this.selectedItem].stack--;
  				}
  				else
-@@ -1796,6 +_,11 @@
- 					NetMessage.SendData(21, -1, -1, null, num, 0f, 0f, 0f, 0, 0, 0);
- 				}
+@@ -1798,13 +_,18 @@
  			}
-+		}
-+
+ 		}
+ 
 +		public bool HasBuff(int type)
 +		{
 +			return FindBuffIndex(type) != -1;
- 		}
- 
++		}
++
  		public int FindBuffIndex(int type)
-@@ -1821,7 +_,7 @@
+ 		{
+ 			if (this.buffImmune[type])
+ 			{
+ 				return -1;
+ 			}
+-			for (int i = 0; i < 22; i++)
++			for (int i = 0; i < Player.maxBuffs; i++)
+ 			{
+ 				if (this.buffTime[i] >= 1 && this.buffType[i] == type)
+ 				{
+@@ -1821,14 +_,14 @@
  				return;
  			}
  			int num = time1;
@@ -154,7 +178,20 @@
  			{
  				num = (int)(Main.expertDebuffTime * (float)num);
  			}
-@@ -1846,7 +_,10 @@
+ 			if (!quiet && Main.netMode == 1)
+ 			{
+ 				bool flag = true;
+-				for (int i = 0; i < 22; i++)
++				for (int i = 0; i < Player.maxBuffs; i++)
+ 				{
+ 					if (this.buffType[i] == type)
+ 					{
+@@ -1842,11 +_,14 @@
+ 				}
+ 			}
+ 			int num2 = -1;
+-			for (int j = 0; j < 22; j++)
++			for (int j = 0; j < Player.maxBuffs; j++)
  			{
  				if (this.buffType[j] == type)
  				{
@@ -166,10 +203,80 @@
  					{
  						this.buffTime[j] += num;
  						if (this.buffTime[j] > Player.manaSickTimeMax)
-@@ -1961,6 +_,22 @@
- 			return num;
- 		}
+@@ -1864,7 +_,7 @@
+ 			}
+ 			if (Main.vanityPet[type] || Main.lightPet[type])
+ 			{
+-				for (int k = 0; k < 22; k++)
++				for (int k = 0; k < Player.maxBuffs; k++)
+ 				{
+ 					if (Main.vanityPet[type] && Main.vanityPet[this.buffType[k]])
+ 					{
+@@ -1879,7 +_,7 @@
+ 			while (num2 == -1)
+ 			{
+ 				int num3 = -1;
+-				for (int l = 0; l < 22; l++)
++				for (int l = 0; l < Player.maxBuffs; l++)
+ 				{
+ 					if (!Main.debuff[this.buffType[l]])
+ 					{
+@@ -1891,7 +_,7 @@
+ 				{
+ 					return;
+ 				}
+-				for (int m = num3; m < 22; m++)
++				for (int m = num3; m < Player.maxBuffs; m++)
+ 				{
+ 					if (this.buffType[m] == 0)
+ 					{
+@@ -1908,7 +_,7 @@
+ 			this.buffTime[num2] = num;
+ 			if (Main.meleeBuff[type])
+ 			{
+-				for (int n = 0; n < 22; n++)
++				for (int n = 0; n < Player.maxBuffs; n++)
+ 				{
+ 					if (n != num2 && Main.meleeBuff[this.buffType[n]])
+ 					{
+@@ -1922,11 +_,11 @@
+ 		{
+ 			this.buffTime[b] = 0;
+ 			this.buffType[b] = 0;
+-			for (int i = 0; i < 21; i++)
++			for (int i = 0; i < Player.maxBuffs - 1; i++)
+ 			{
+ 				if (this.buffTime[i] == 0 || this.buffType[i] == 0)
+ 				{
+-					for (int j = i + 1; j < 22; j++)
++					for (int j = i + 1; j < Player.maxBuffs; j++)
+ 					{
+ 						this.buffTime[j - 1] = this.buffTime[j];
+ 						this.buffType[j - 1] = this.buffType[j];
+@@ -1939,7 +_,7 @@
  
+ 		public void ClearBuff(int type)
+ 		{
+-			for (int i = 0; i < 22; i++)
++			for (int i = 0; i < Player.maxBuffs; i++)
+ 			{
+ 				if (this.buffType[i] == type)
+ 				{
+@@ -1951,7 +_,7 @@
+ 		public int CountBuffs()
+ 		{
+ 			int num = 0;
+-			for (int i = 0; i < 22; i++)
++			for (int i = 0; i < Player.maxBuffs; i++)
+ 			{
+ 				if (this.buffType[num] > 0)
+ 				{
+@@ -1959,6 +_,22 @@
+ 				}
+ 			}
+ 			return num;
++		}
++
 +		public int GetHealLife(Item item, bool quickHeal = false)
 +		{
 +			int healValue = item.healLife;
@@ -184,11 +291,9 @@
 +			ItemLoader.GetHealMana(item, this, quickHeal, ref healValue);
 +			PlayerHooks.GetHealMana(this, item, quickHeal, ref healValue);
 +			return healValue > 0 ? healValue : 0;
-+		}
-+
+ 		}
+ 
  		public void QuickHeal()
- 		{
- 			if (this.noItems)
 @@ -1990,8 +_,11 @@
  					this.AddBuff(21, this.potionDelay, true);
  				}
@@ -312,15 +417,34 @@
  				{
  					return this.inventory[i];
  				}
-@@ -2138,7 +_,7 @@
+@@ -2131,15 +_,15 @@
+ 			LegacySoundStyle legacySoundStyle = null;
+ 			for (int i = 0; i < 58; i++)
+ 			{
+-				if (this.CountBuffs() == 22)
++				if (this.CountBuffs() == Player.maxBuffs)
+ 				{
+ 					return;
+ 				}
  				if (this.inventory[i].stack > 0 && this.inventory[i].type > 0 && this.inventory[i].buffType > 0 && !this.inventory[i].summon && this.inventory[i].buffType != 90)
  				{
  					int num = this.inventory[i].buffType;
 -					bool flag = true;
+-					for (int j = 0; j < 22; j++)
 +					bool flag = ItemLoader.CanUseItem(this.inventory[i], this);
- 					for (int j = 0; j < 22; j++)
++					for (int j = 0; j < Player.maxBuffs; j++)
  					{
  						if (num == 27 && (this.buffType[j] == num || this.buffType[j] == 101 || this.buffType[j] == 102))
+ 						{
+@@ -2159,7 +_,7 @@
+ 					}
+ 					if (Main.lightPet[this.inventory[i].buffType] || Main.vanityPet[this.inventory[i].buffType])
+ 					{
+-						for (int k = 0; k < 22; k++)
++						for (int k = 0; k < Player.maxBuffs; k++)
+ 						{
+ 							if (Main.lightPet[this.buffType[k]] && Main.lightPet[this.inventory[i].buffType])
+ 							{
 @@ -2173,6 +_,10 @@
  					}
  					if (this.inventory[i].mana > 0 && flag)
@@ -677,6 +801,15 @@
  					{
  						this.cWings = (int)this.dye[num].dye;
  					}
+@@ -5802,7 +_,7 @@
+ 					this.ownedProjectileCounts[Main.projectile[j].type]++;
+ 				}
+ 			}
+-			for (int k = 0; k < 22; k++)
++			for (int k = 0; k < Player.maxBuffs; k++)
+ 			{
+ 				if (this.buffType[k] > 0 && this.buffTime[k] > 0)
+ 				{
 @@ -5810,6 +_,7 @@
  					{
  						this.buffTime[k]--;
@@ -700,6 +833,60 @@
  					}
  					else if (this.buffType[k] == 119)
  					{
+@@ -6134,7 +_,7 @@
+ 							}
+ 							else
+ 							{
+-								for (int n = 0; n < 22; n++)
++								for (int n = 0; n < Player.maxBuffs; n++)
+ 								{
+ 									if (this.buffType[n] >= 95 && this.buffType[n] <= 95 + num3 - 1)
+ 									{
+@@ -6169,7 +_,7 @@
+ 							}
+ 							else
+ 							{
+-								for (int num5 = 0; num5 < 22; num5++)
++								for (int num5 = 0; num5 < Player.maxBuffs; num5++)
+ 								{
+ 									if (this.buffType[num5] >= 170 && this.buffType[num5] <= 170 + num4 - 1)
+ 									{
+@@ -6199,7 +_,7 @@
+ 							}
+ 							else
+ 							{
+-								for (int num7 = 0; num7 < 22; num7++)
++								for (int num7 = 0; num7 < Player.maxBuffs; num7++)
+ 								{
+ 									if (this.buffType[num7] >= 98 && this.buffType[num7] <= 98 + num6 - 1)
+ 									{
+@@ -6236,7 +_,7 @@
+ 							}
+ 							else
+ 							{
+-								for (int num10 = 0; num10 < 22; num10++)
++								for (int num10 = 0; num10 < Player.maxBuffs; num10++)
+ 								{
+ 									if (this.buffType[num10] >= 176 && this.buffType[num10] <= 178 + num9 - 1)
+ 									{
+@@ -6267,7 +_,7 @@
+ 							}
+ 							else
+ 							{
+-								for (int num13 = 0; num13 < 22; num13++)
++								for (int num13 = 0; num13 < Player.maxBuffs; num13++)
+ 								{
+ 									if (this.buffType[num13] >= 173 && this.buffType[num13] <= 175 + num12 - 1)
+ 									{
+@@ -6299,7 +_,7 @@
+ 							}
+ 							else
+ 							{
+-								for (int num16 = 0; num16 < 22; num16++)
++								for (int num16 = 0; num16 < Player.maxBuffs; num16++)
+ 								{
+ 									if (this.buffType[num16] >= 179 && this.buffType[num16] <= 181 + num15 - 1)
+ 									{
 @@ -6317,11 +_,14 @@
  							this.buffTime[k] = 480;
  						}
@@ -3177,6 +3364,42 @@
  			}
  			if (this.head == 22 && this.body == 14 && this.legs == 14)
  			{
+@@ -10030,7 +_,7 @@
+ 				}
+ 				if (num != this.beetleOrbs && this.beetleOrbs > 0)
+ 				{
+-					for (int j = 0; j < 22; j++)
++					for (int j = 0; j < Player.maxBuffs; j++)
+ 					{
+ 						if (this.buffType[j] >= 98 && this.buffType[j] <= 100 && this.buffType[j] != 97 + num)
+ 						{
+@@ -10049,7 +_,7 @@
+ 				{
+ 					if (this.beetleOrbs > 0 && this.beetleOrbs < 3)
+ 					{
+-						for (int k = 0; k < 22; k++)
++						for (int k = 0; k < Player.maxBuffs; k++)
+ 						{
+ 							if (this.buffType[k] >= 95 && this.buffType[k] <= 96)
+ 							{
+@@ -10198,7 +_,7 @@
+ 			}
+ 			else if (this.crystalLeaf)
+ 			{
+-				for (int n = 0; n < 22; n++)
++				for (int n = 0; n < Player.maxBuffs; n++)
+ 				{
+ 					if (this.buffType[n] == 60)
+ 					{
+@@ -10335,7 +_,7 @@
+ 				{
+ 					if (this.solarShields > 0 && this.solarShields < 3)
+ 					{
+-						for (int num12 = 0; num12 < 22; num12++)
++						for (int num12 = 0; num12 < Player.maxBuffs; num12++)
+ 						{
+ 							if (this.buffType[num12] >= 170 && this.buffType[num12] <= 171)
+ 							{
 @@ -10485,6 +_,7 @@
  				this.setMonkT2 = true;
  				this.maxTurrets++;
@@ -3202,14 +3425,17 @@
  			if (!this.dead)
  			{
  				Point point2 = base.Center.ToTileCoordinates();
-@@ -10924,6 +_,7 @@
+@@ -10924,8 +_,9 @@
  			this.yoraiz0rEye = 0;
  			this.yoraiz0rDarkness = false;
  			this.leinforsHair = false;
 +			PlayerHooks.UpdateDead(this);
  			this.gravDir = 1f;
- 			for (int i = 0; i < 22; i++)
+-			for (int i = 0; i < 22; i++)
++			for (int i = 0; i < Player.maxBuffs; i++)
  			{
+ 				if (this.buffType[i] <= 0 || !Main.persistentBuff[this.buffType[i]])
+ 				{
 @@ -11321,6 +_,7 @@
  				flag = true;
  			}
@@ -3532,6 +3758,15 @@
  			if (this.whoAmI == Main.myPlayer)
  			{
  				if (!this.onFire && !this.poisoned)
+@@ -19725,7 +_,7 @@
+ 			this.forceWerewolf = false;
+ 			if (this.whoAmI == Main.myPlayer)
+ 			{
+-				for (int num26 = 0; num26 < 22; num26++)
++				for (int num26 = 0; num26 < Player.maxBuffs; num26++)
+ 				{
+ 					if (this.buffType[num26] > 0 && this.buffTime[num26] <= 0)
+ 					{
 @@ -19797,6 +_,7 @@
  			}
  			this.UpdateArmorLights();
@@ -3557,6 +3792,15 @@
  			this.UpdateLifeRegen();
  			this.soulDrain = 0;
  			this.UpdateManaRegen();
+@@ -20078,7 +_,7 @@
+ 			this.runAcceleration *= this.moveSpeed;
+ 			this.maxRunSpeed *= this.moveSpeed;
+ 			this.UpdateJumpHeight();
+-			for (int num31 = 0; num31 < 22; num31++)
++			for (int num31 = 0; num31 < Player.maxBuffs; num31++)
+ 			{
+ 				if (this.buffType[num31] > 0 && this.buffTime[num31] > 0 && this.buffImmune[this.buffType[num31]])
+ 				{
 @@ -20095,11 +_,14 @@
  			}
  			if (this.witheredWeapon)
@@ -3623,6 +3867,24 @@
  								{
  									if (this.wings == 30)
  									{
+@@ -22383,7 +_,7 @@
+ 				}
+ 				if (flag23 && Main.myPlayer == this.whoAmI)
+ 				{
+-					for (int num137 = 0; num137 < 22; num137++)
++					for (int num137 = 0; num137 < Player.maxBuffs; num137++)
+ 					{
+ 						if (this.buffType[num137] == 38)
+ 						{
+@@ -22665,7 +_,7 @@
+ 			{
+ 				if (this.onFire && !this.lavaWet)
+ 				{
+-					for (int num142 = 0; num142 < 22; num142++)
++					for (int num142 = 0; num142 < Player.maxBuffs; num142++)
+ 					{
+ 						if (this.buffType[num142] == 24)
+ 						{
 @@ -22983,6 +_,7 @@
  			{
  				this.velocity.Y = this.velocity.Y * 0.8f + (float)Math.Cos((double)(base.Center.X % 120f / 120f * 6.28318548f)) * 5f * 0.2f;
@@ -4040,6 +4302,15 @@
  			this.dead = false;
  			this.immuneTime = 0;
  			this.active = true;
+@@ -28378,7 +_,7 @@
+ 			}
+ 			if (this.whoAmI == Main.myPlayer)
+ 			{
+-				for (int j = 0; j < 22; j++)
++				for (int j = 0; j < Player.maxBuffs; j++)
+ 				{
+ 					if (this.buffTime[j] > 0 && this.buffType[j] == 59)
+ 					{
 @@ -28485,6 +_,14 @@
  				this.ShadowDodge();
  				return 0.0;
@@ -4064,6 +4335,24 @@
  			if (Crit)
  			{
  				num *= 2;
+@@ -28508,7 +_,7 @@
+ 			{
+ 				if (this.invis)
+ 				{
+-					for (int i = 0; i < 22; i++)
++					for (int i = 0; i < Player.maxBuffs; i++)
+ 					{
+ 						if (this.buffType[i] == 10)
+ 						{
+@@ -28540,7 +_,7 @@
+ 					float num5 = 0.15f * (float)this.beetleOrbs;
+ 					num2 = (double)((int)((double)(1f - num5) * num2));
+ 					this.beetleOrbs--;
+-					for (int j = 0; j < 22; j++)
++					for (int j = 0; j < Player.maxBuffs; j++)
+ 					{
+ 						if (this.buffType[j] >= 95 && this.buffType[j] <= 97)
+ 						{
 @@ -28653,6 +_,7 @@
  					}
  					Projectile.NewProjectile(base.Center.X + (float)Main.rand.Next(-40, 40), base.Center.Y - (float)Main.rand.Next(20, 60), this.velocity.X * 0.3f, this.velocity.Y * 0.3f, 565, 0, 0f, this.whoAmI, 0f, 0f);
@@ -5510,6 +5799,15 @@
  		}
  
  		public static bool WouldSpotOverlapWithSentry(int worldX, int worldY)
+@@ -37186,7 +_,7 @@
+ 				{
+ 					num = 102;
+ 				}
+-				for (int i = 0; i < 22; i++)
++				for (int i = 0; i < Player.maxBuffs; i++)
+ 				{
+ 					if (this.buffType[i] == 27 || this.buffType[i] == 101 || this.buffType[i] == 102)
+ 					{
 @@ -37374,73 +_,82 @@
  			{
  				KnockBack *= 1f + (1f - this.stealth) * 0.5f;
@@ -5857,7 +6155,15 @@
  			player.extraAccessory = this.extraAccessory;
  			player.MinionRestTargetPoint = this.MinionRestTargetPoint;
  			player.MinionAttackTargetNPC = this.MinionAttackTargetNPC;
-@@ -38375,6 +_,7 @@
+@@ -38368,13 +_,14 @@
+ 				}
+ 			}
+ 			player.trashItem = this.trashItem.Clone();
+-			for (int j = 0; j < 22; j++)
++			for (int j = 0; j < Player.maxBuffs; j++)
+ 			{
+ 				player.buffType[j] = this.buffType[j];
+ 				player.buffTime[j] = this.buffTime[j];
  			}
  			this.DpadRadial.CopyTo(player.DpadRadial);
  			this.CircularRadial.CopyTo(player.CircularRadial);
@@ -5906,7 +6212,7 @@
  						BitsByte bb = 0;
  						for (int i = 0; i < 8; i++)
  						{
-@@ -38594,49 +_,49 @@
+@@ -38594,49 +_,52 @@
  						binaryWriter.Write(player.shoeColor.B);
  						for (int k = 0; k < player.armor.Length; k++)
  						{
@@ -5958,9 +6264,14 @@
  							binaryWriter.Write(player.bank3.item[num3].stack);
  							binaryWriter.Write(player.bank3.item[num3].prefix);
  						}
- 						for (int num4 = 0; num4 < 22; num4++)
- 						{
+-						for (int num4 = 0; num4 < 22; num4++)
+-						{
 -							if (Main.buffNoSave[player.buffType[num4]])
++						// Could potentially have unintended side effects by editing player data structure
++						// e.i.: create player with 22 maxBuffs, try to read it with 23 maxBuffs
++						// possible solution: set maxBuffs within Player#LoadPlayer based on player data
++						for (int num4 = 0; num4 < Player.maxBuffs; num4++) 
++						{
 +							if (Main.buffNoSave[player.buffType[num4]] || BuffLoader.IsModBuff(player.buffType[num4]))
  							{
  								binaryWriter.Write(0);
@@ -5999,6 +6310,19 @@
  							{
  								player.loadStatus = 1;
  								player.name = binaryReader.ReadString();
+@@ -39111,10 +_,10 @@
+ 							}
+ 							if (num >= 11)
+ 							{
+-								int num27 = 22;
++								int num27 = Player.maxBuffs;
+ 								if (num < 74)
+ 								{
+-									num27 = 10;
++									num27 = num27 - 12;
+ 								}
+ 								for (int num28 = 0; num28 < num27; num28++)
+ 								{
 @@ -39179,6 +_,7 @@
  								player.bartenderQuestLog = binaryReader.ReadInt32();
  							}
@@ -6079,11 +6403,15 @@
  			this.extraAccessorySlots = 2;
  			this.tankPet = -1;
  			this.solarShieldPos = new Vector2[3];
-@@ -39349,7 +_,7 @@
+@@ -39347,9 +_,9 @@
+ 			this.miscDyes = new Item[5];
+ 			this.trashItem = new Item();
  			this.ghostDir = 1f;
- 			this.buffType = new int[22];
- 			this.buffTime = new int[22];
+-			this.buffType = new int[22];
+-			this.buffTime = new int[22];
 -			this.buffImmune = new bool[206];
++			this.buffType = new int[Player.maxBuffs];
++			this.buffTime = new int[Player.maxBuffs];
 +			this.buffImmune = new bool[BuffLoader.BuffCount];
  			this.heldProj = -1;
  			this.breathMax = 200;
@@ -6294,12 +6622,10 @@
  			int type = list[Main.rand.Next(list.Count)];
  			Item item = new Item();
  			item.SetDefaults(type, false);
-@@ -40007,6 +_,45 @@
- 					NetMessage.SendData(21, -1, -1, null, number, 1f, 0f, 0f, 0, 0, 0);
- 				}
+@@ -40009,6 +_,45 @@
  			}
-+		}
-+
+ 		}
+ 
 +		public int GetManaCost(Item item) {
 +			float reduce = manaCost;
 +			float mult = 1;
@@ -6337,7 +6663,27 @@
 +				return true;
 +			}
 +			return false;
- 		}
- 
++		}
++
  		public bool CheckMana(int amount, bool pay = false, bool blockQuickMana = false)
+ 		{
+ 			int num = (int)((float)amount * this.manaCost);
+@@ -40056,7 +_,7 @@
+ 				return true;
+ 			}
+ 			this.solarShields--;
+-			for (int i = 0; i < 22; i++)
++			for (int i = 0; i < Player.maxBuffs; i++)
+ 			{
+ 				if (this.buffType[i] >= 170 && this.buffType[i] <= 172)
+ 				{
+@@ -40371,7 +_,7 @@
+ 			if (this.whoAmI == Main.myPlayer)
+ 			{
+ 				int time = 480;
+-				for (int i = 0; i < 22; i++)
++				for (int i = 0; i < Player.maxBuffs; i++)
+ 				{
+ 					if (this.buffType[i] >= type && this.buffType[i] < type + 3)
+ 					{
 

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -6212,7 +6212,7 @@
  						BitsByte bb = 0;
  						for (int i = 0; i < 8; i++)
  						{
-@@ -38594,49 +_,52 @@
+@@ -38594,58 +_,50 @@
  						binaryWriter.Write(player.shoeColor.B);
  						for (int k = 0; k < player.armor.Length; k++)
  						{
@@ -6267,15 +6267,22 @@
 -						for (int num4 = 0; num4 < 22; num4++)
 -						{
 -							if (Main.buffNoSave[player.buffType[num4]])
-+						// Could potentially have unintended side effects by editing player data structure
-+						// e.i.: create player with 22 maxBuffs, try to read it with 23 maxBuffs
-+						// possible solution: set maxBuffs within Player#LoadPlayer based on player data
-+						for (int num4 = 0; num4 < Player.maxBuffs; num4++) 
+-							{
+-								binaryWriter.Write(0);
+-								binaryWriter.Write(0);
+-							}
+-							else
+-							{
+-								binaryWriter.Write(player.buffType[num4]);
+-								binaryWriter.Write(player.buffTime[num4]);
+-							}
++						for (int num4 = 0; num4 < 22; num4++) 
 +						{
-+							if (Main.buffNoSave[player.buffType[num4]] || BuffLoader.IsModBuff(player.buffType[num4]))
- 							{
- 								binaryWriter.Write(0);
- 								binaryWriter.Write(0);
++							binaryWriter.Write(0);
++							binaryWriter.Write(0);
+ 						}
+ 						for (int num5 = 0; num5 < 200; num5++)
+ 						{
 @@ -38681,9 +_,11 @@
  						{
  							SocialAPI.Cloud.Write(playerFile.Path, ((MemoryStream)stream).ToArray());
@@ -6310,12 +6317,8 @@
  							{
  								player.loadStatus = 1;
  								player.name = binaryReader.ReadString();
-@@ -39111,10 +_,10 @@
- 							}
- 							if (num >= 11)
- 							{
--								int num27 = 22;
-+								int num27 = Player.maxBuffs;
+@@ -39114,7 +_,7 @@
+ 								int num27 = 22;
  								if (num < 74)
  								{
 -									num27 = 10;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -39,7 +39,7 @@
  			}
  		}
  
-+		internal static int maxBuffs { get { return 22 + BuffLoader.ExtraBuffCount; } }
++		public static int maxBuffs { get { return 22 + BuffLoader.ExtraBuffCount; } }
 +
  		public const int maxSolarShields = 3;
  		public const int nebulaMaxLevel = 3;


### PR DESCRIPTION
# Description of the Change
`Player.maxBuffs` is a property defining the (de)buff limit within Terraria, it is a constant property, meaning that it is unchangeable and set at compile time.

This PR aims to make the buff limit changeable from a single property rather than hooking **28** (see below) different methods that affect the buff limit.
The way this is accomplished is by
- Changing `Player.maxBuffs` from `const` to `static`
- Modifying all points where `22` (vanilla buff limit) became hard-coded to reference `Player.maxBuffs`
### Alternate designs
- There could be an optional `maxBuffs` parameter within the Player constructor which defines the limit, defaulting to 22
- Another option could be adding a `maxBuffs` property to `ModLoader.ModPlayer` enabling the same functionality while leaving `Player.maxBuffs` completely vanilla
### Why this should be merged into tModLoader
This PR brings more mod functionality to tModLoader, as of the time of this PR, in order to modify the buff limit, you'd have to modify multiple methods throughout multiple classes, both public and non public.
### Benefits
Merging these patches would enable the average mod creator to implement more content such as buffs, debuffs, potions, and summons, without the need to hook into multiple methods.
### Possible drawbacks
As these changes currently stand,
~~- There is an issue within the `Player.SavePlayer` method when the buff limit is changed. The way player files are created and read from, if a character is created with a buff limit set to 22, afterwards reloading with a new buff limit of any other number, the file will appear corrupted in-game because of the way `BinaryReader` functions.~~

~~This could be remedied by including a marker of some kind that states the buff limit within the file, then reading that marker in order to on-the-fly switch the buff limit to load that player file.~~ Fixed in https://github.com/tModLoader/tModLoader/pull/662/commits/1a74ba76483e9ea242dea01400c1d3dd46d06458
~~- I have not implemented any form of auto modification of the Y value when [drawing buff icons](https://github.com/AnimeCatgirl/tModLoader/blob/StaticBuffLimit/patches/tModLoader/Terraria/Main.cs.patch#L4010)~~

~~This is a simple fix only requiring some basic logic and math adding onto the Y value when it hits 22 or more.~~ Fixed in https://github.com/tModLoader/tModLoader/pull/662/commits/4bb5281aaaf4826ae3c758bd8c7859b5623c883d
~~- What happens when two mods change the buff limit?~~

~~We could implement some type of mod selector for choosing what mod change tModLoader should follow, similar to what @Agrair suggested in #362.~~ Fixed in https://github.com/tModLoader/tModLoader/pull/662/commits/3fc4a687e4f744f9770236dd3bdd74caf8966c39
### Sample Usage
<!-- Please provide a code sample that demonstrates how your changes are applicable in the real world, or how your changes reflect on mods' code, preferably code that we can use in Example Mod -->
Originally in order to change the buff limit, you would need to modify [these methods](https://paste.mod.gg/rolifoqura.cs).
With this PR a mod creator can simply add a new override for `ExtraBuffSlots` in their main mod file.
```c#
public override uint ExtraBuffSlots => 100;
```