### PR TITLE
Fix Smart Select bypassing ModNPC and GlobalNPC CanChat

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
@@ -831,25 +831,10 @@ namespace Terraria.ModLoader
 			return npc.modNPC?.UsesPartyHat() ?? true;
 		}
 
-		public static bool VanillaCanChat(NPC npc) {
-			switch (npc.type) {
-				case NPCID.BoundGoblin:
-				case NPCID.BoundWizard:
-				case NPCID.BoundMechanic:
-				case NPCID.WebbedStylist:
-				case NPCID.SleepingAngler:
-				case NPCID.BartenderUnconscious:
-				case NPCID.SkeletonMerchant:
-					return true;
-				default:
-					return npc.townNPC;
-			}
-		}
-
 		private static HookList HookCanChat = AddHook<Func<NPC, bool?>>(g => g.CanChat);
 
-		public static bool CanChat(NPC npc) {
-			bool defaultCanChat = npc.modNPC?.CanChat() ?? VanillaCanChat(npc);
+		public static bool CanChat(NPC npc, bool vanillaCanChat) {
+			bool defaultCanChat = npc.modNPC?.CanChat() ?? vanillaCanChat;
 
 			foreach (GlobalNPC g in HookCanChat.arr) {
 				bool? canChat = g.Instance(npc).CanChat(npc);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -4006,7 +4006,7 @@
  						{
  							bool flag3 = Main.SmartInteractShowingGenuine && Main.SmartInteractNPC == k;
 -							if (Main.npc[k].townNPC || Main.npc[k].type == 105 || Main.npc[k].type == 106 || Main.npc[k].type == 123 || Main.npc[k].type == 354 || Main.npc[k].type == 376 || Main.npc[k].type == 579 || Main.npc[k].type == 453)
-+							if (NPCLoader.CanChat(Main.npc[k]))
++							if (NPCLoader.CanChat(Main.npc[k], Main.npc[k].townNPC || Main.npc[k].type == 105 || Main.npc[k].type == 106 || Main.npc[k].type == 123 || Main.npc[k].type == 354 || Main.npc[k].type == 376 || Main.npc[k].type == 579 || Main.npc[k].type == 453))
  							{
  								Microsoft.Xna.Framework.Rectangle rectangle2 = new Microsoft.Xna.Framework.Rectangle((int)(Main.player[Main.myPlayer].position.X + (float)(Main.player[Main.myPlayer].width / 2) - (float)(Player.tileRangeX * 16)), (int)(Main.player[Main.myPlayer].position.Y + (float)(Main.player[Main.myPlayer].height / 2) - (float)(Player.tileRangeY * 16)), Player.tileRangeX * 16 * 2, Player.tileRangeY * 16 * 2);
  								Microsoft.Xna.Framework.Rectangle value4 = new Microsoft.Xna.Framework.Rectangle((int)Main.npc[k].position.X, (int)Main.npc[k].position.Y, Main.npc[k].width, Main.npc[k].height);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -6273,8 +6273,8 @@
  							binaryWriter.Write(player.bank3.item[num3].stack);
  							binaryWriter.Write(player.bank3.item[num3].prefix);
  						}
- 						for (int num4 = 0; num4 < 22; num4++)
- 						{
+-						for (int num4 = 0; num4 < 22; num4++)
+-						{
 -							if (Main.buffNoSave[player.buffType[num4]])
 -							{
 -								binaryWriter.Write(0);
@@ -6285,6 +6285,8 @@
 -								binaryWriter.Write(player.buffType[num4]);
 -								binaryWriter.Write(player.buffTime[num4]);
 -							}
++						for (int num4 = 0; num4 < 22; num4++) 
++						{
 +							binaryWriter.Write(0);
 +							binaryWriter.Write(0);
  						}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3480,6 +3480,15 @@
  					if (num13 != 0 && num14 != 0)
  					{
  						int num19 = item3 - (int)tile2.frameX % (num15 * num13 + num17) / num15;
+@@ -13830,7 +_,7 @@
+ 				for (int num22 = 0; num22 < 200; num22++)
+ 				{
+ 					NPC nPC = Main.npc[num22];
+-					if (nPC.active && nPC.townNPC && nPC.Hitbox.Intersects(value2))
++					if (nPC.active && nPC.townNPC && NPCLoader.CanChat(nPC, nPC.townNPC) && nPC.Hitbox.Intersects(value2))
+ 					{
+ 						Main.SmartInteractNPCsNearby.Add(num22);
+ 						if (!flag4)
 @@ -14168,6 +_,7 @@
  			if (this.controlTorch && this.itemAnimation == 0)
  			{
@@ -6264,8 +6273,8 @@
  							binaryWriter.Write(player.bank3.item[num3].stack);
  							binaryWriter.Write(player.bank3.item[num3].prefix);
  						}
--						for (int num4 = 0; num4 < 22; num4++)
--						{
+ 						for (int num4 = 0; num4 < 22; num4++)
+ 						{
 -							if (Main.buffNoSave[player.buffType[num4]])
 -							{
 -								binaryWriter.Write(0);
@@ -6276,8 +6285,6 @@
 -								binaryWriter.Write(player.buffType[num4]);
 -								binaryWriter.Write(player.buffTime[num4]);
 -							}
-+						for (int num4 = 0; num4 < 22; num4++) 
-+						{
 +							binaryWriter.Write(0);
 +							binaryWriter.Write(0);
  						}


### PR DESCRIPTION
### Description of the Change

* Changed `NPCLoader.CanChat` so it receives the default CanChat behavior as a parameter.
* Added `NPCLoader.CanChat` call to the NPC smart select code that only gets called if the NPC is a town NPC, to mimic vanilla behavior.

### Applicable Issues
#665 


