### PR TITLE
Change behavior of bool-returning PreX and OnX hooks.

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -576,14 +576,17 @@ namespace Terraria.ModLoader
 		/// <param name="knockBack">The projectile knock back.</param>
 		/// <returns></returns>
 		public static bool Shoot(Item item, Player player, ref Vector2 position, ref float speedX, ref float speedY, ref int type, ref int damage, ref float knockBack) {
-			foreach (var g in HookShoot.arr)
-				if (!g.Instance(item).Shoot(item, player, ref position, ref speedX, ref speedY, ref type, ref damage, ref knockBack))
-					return false;
+			bool result = false;
 
-			if (item.modItem != null && !item.modItem.Shoot(player, ref position, ref speedX, ref speedY, ref type, ref damage, ref knockBack))
-				return false;
+			foreach (var g in HookShoot.arr) {
+				result &= g.Instance(item).Shoot(item, player, ref position, ref speedX, ref speedY, ref type, ref damage, ref knockBack);
+			}
 
-			return true;
+			if (result && item.modItem != null) {
+				return item.modItem.Shoot(player, ref position, ref speedX, ref speedY, ref type, ref damage, ref knockBack);
+			}
+
+			return result;
 		}
 
 		private delegate void DelegateUseItemHitbox(Item item, Player player, ref Rectangle hitbox, ref bool noHitbox);
@@ -1069,11 +1072,14 @@ namespace Terraria.ModLoader
 		/// Calls each GlobalItem.PreOpenVanillaBag hook until one of them returns false. Returns true if all of them returned true.
 		/// </summary>
 		public static bool PreOpenVanillaBag(string context, Player player, int arg) {
+			bool result = true;
 			foreach (var g in HookPreOpenVanillaBag.arr)
-				if (!g.PreOpenVanillaBag(context, player, arg)) {
-					NPCLoader.blockLoot.Clear(); // clear blockloot
-					return false;
-				}
+				result &= g.PreOpenVanillaBag(context, player, arg);
+
+			if (!result) {
+				NPCLoader.blockLoot.Clear(); // clear blockloot
+				return false;
+			}
 
 			return true;
 		}

--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -576,7 +576,7 @@ namespace Terraria.ModLoader
 		/// <param name="knockBack">The projectile knock back.</param>
 		/// <returns></returns>
 		public static bool Shoot(Item item, Player player, ref Vector2 position, ref float speedX, ref float speedY, ref int type, ref int damage, ref float knockBack) {
-			bool result = false;
+			bool result = true;
 
 			foreach (var g in HookShoot.arr) {
 				result &= g.Instance(item).Shoot(item, player, ref position, ref speedX, ref speedY, ref type, ref damage, ref knockBack);

--- a/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
@@ -255,15 +255,14 @@ namespace Terraria.ModLoader
 		private static HookList HookPreAI = AddHook<Func<NPC, bool>>(g => g.PreAI);
 
 		public static bool PreAI(NPC npc) {
+			bool result = true;
 			foreach (GlobalNPC g in HookPreAI.arr) {
-				if (!g.Instance(npc).PreAI(npc)) {
-					return false;
-				}
+				result &= g.Instance(npc).PreAI(npc);
 			}
 			if (npc.modNPC != null) {
-				return npc.modNPC.PreAI();
+				result &= npc.modNPC.PreAI();
 			}
-			return true;
+			return result;
 		}
 
 		private static HookList HookAI = AddHook<Action<NPC>>(g => g.AI);
@@ -371,15 +370,14 @@ namespace Terraria.ModLoader
 		private static HookList HookCheckDead = AddHook<Func<NPC, bool>>(g => g.CheckDead);
 
 		public static bool CheckDead(NPC npc) {
-			if (npc.modNPC != null && !npc.modNPC.CheckDead()) {
-				return false;
+			bool result = true;
+			if (npc.modNPC != null) {
+				result &= npc.modNPC.CheckDead();
 			}
 			foreach (GlobalNPC g in HookCheckDead.arr) {
-				if (!g.Instance(npc).CheckDead(npc)) {
-					return false;
-				}
+				result &= g.Instance(npc).CheckDead(npc);
 			}
-			return true;
+			return result;
 		}
 
 		private static HookList HookSpecialNPCLoot = AddHook<Func<NPC, bool>>(g => g.SpecialNPCLoot);
@@ -399,16 +397,19 @@ namespace Terraria.ModLoader
 		private static HookList HookPreNPCLoot = AddHook<Func<NPC, bool>>(g => g.PreNPCLoot);
 
 		public static bool PreNPCLoot(NPC npc) {
+			bool result = true;
 			foreach (GlobalNPC g in HookPreNPCLoot.arr) {
-				if (!g.Instance(npc).PreNPCLoot(npc)) {
-					blockLoot.Clear();
-					return false;
-				}
+				result &= g.Instance(npc).PreNPCLoot(npc);
 			}
-			if (npc.modNPC != null && !npc.modNPC.PreNPCLoot()) {
+			if (npc.modNPC != null) {
+				result &= npc.modNPC.PreNPCLoot();
+			}
+
+			if (!result) {
 				blockLoot.Clear();
 				return false;
 			}
+
 			return true;
 		}
 
@@ -681,15 +682,14 @@ namespace Terraria.ModLoader
 		private static HookList HookPreDraw = AddHook<Func<NPC, SpriteBatch, Color, bool>>(g => g.PreDraw);
 
 		public static bool PreDraw(NPC npc, SpriteBatch spriteBatch, Color drawColor) {
+			bool result = true;
 			foreach (GlobalNPC g in HookPreDraw.arr) {
-				if (!g.Instance(npc).PreDraw(npc, spriteBatch, drawColor)) {
-					return false;
-				}
+				result &= g.Instance(npc).PreDraw(npc, spriteBatch, drawColor);
 			}
 			if (npc.modNPC != null) {
-				return npc.modNPC.PreDraw(spriteBatch, drawColor);
+				result &= npc.modNPC.PreDraw(spriteBatch, drawColor);
 			}
-			return true;
+			return result;
 		}
 
 		private static HookList HookPostDraw = AddHook<Action<NPC, SpriteBatch, Color>>(g => g.PostDraw);
@@ -876,12 +876,16 @@ namespace Terraria.ModLoader
 		public static bool PreChatButtonClicked(bool firstButton) {
 			NPC npc = Main.npc[Main.LocalPlayer.talkNPC];
 
+			bool result = true;
 			foreach (GlobalNPC g in HookPreChatButtonClicked.arr) {
-				if (!g.Instance(npc).PreChatButtonClicked(npc, firstButton)) {
-					Main.PlaySound(SoundID.MenuTick);
-					return false;
-				}
+				result &= g.Instance(npc).PreChatButtonClicked(npc, firstButton);
 			}
+
+			if (!result) {
+				Main.PlaySound(SoundID.MenuTick);
+				return false;
+			}
+
 			return true;
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
@@ -259,8 +259,8 @@ namespace Terraria.ModLoader
 			foreach (GlobalNPC g in HookPreAI.arr) {
 				result &= g.Instance(npc).PreAI(npc);
 			}
-			if (npc.modNPC != null) {
-				result &= npc.modNPC.PreAI();
+			if (result && npc.modNPC != null) {
+				return npc.modNPC.PreAI();
 			}
 			return result;
 		}
@@ -371,12 +371,15 @@ namespace Terraria.ModLoader
 
 		public static bool CheckDead(NPC npc) {
 			bool result = true;
+
 			if (npc.modNPC != null) {
-				result &= npc.modNPC.CheckDead();
+				result = npc.modNPC.CheckDead();
 			}
+
 			foreach (GlobalNPC g in HookCheckDead.arr) {
 				result &= g.Instance(npc).CheckDead(npc);
 			}
+
 			return result;
 		}
 
@@ -401,8 +404,9 @@ namespace Terraria.ModLoader
 			foreach (GlobalNPC g in HookPreNPCLoot.arr) {
 				result &= g.Instance(npc).PreNPCLoot(npc);
 			}
-			if (npc.modNPC != null) {
-				result &= npc.modNPC.PreNPCLoot();
+
+			if (result && npc.modNPC != null) {
+				result = npc.modNPC.PreNPCLoot();
 			}
 
 			if (!result) {
@@ -686,8 +690,8 @@ namespace Terraria.ModLoader
 			foreach (GlobalNPC g in HookPreDraw.arr) {
 				result &= g.Instance(npc).PreDraw(npc, spriteBatch, drawColor);
 			}
-			if (npc.modNPC != null) {
-				result &= npc.modNPC.PreDraw(spriteBatch, drawColor);
+			if (result && npc.modNPC != null) {
+				return npc.modNPC.PreDraw(spriteBatch, drawColor);
 			}
 			return result;
 		}

--- a/patches/tModLoader/Terraria.ModLoader/PlayerHooks.cs
+++ b/patches/tModLoader/Terraria.ModLoader/PlayerHooks.cs
@@ -514,12 +514,11 @@ namespace Terraria.ModLoader
 		private static HookList HookPreItemCheck = AddHook<Func<bool>>(p => p.PreItemCheck);
 
 		public static bool PreItemCheck(Player player) {
+			bool result = true;
 			foreach (int index in HookPreItemCheck.arr) {
-				if (!player.modPlayers[index].PreItemCheck()) {
-					return false;
-				}
+				result &= player.modPlayers[index].PreItemCheck();
 			}
-			return true;
+			return result;
 		}
 
 		private static HookList HookPostItemCheck = AddHook<Action>(p => p.PostItemCheck);

--- a/patches/tModLoader/Terraria.ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ProjectileLoader.cs
@@ -167,15 +167,14 @@ namespace Terraria.ModLoader
 		private static HookList HookPreAI = AddHook<Func<Projectile, bool>>(g => g.PreAI);
 
 		public static bool PreAI(Projectile projectile) {
+			bool result = true;
 			foreach (GlobalProjectile g in HookPreAI.arr) {
-				if (!g.Instance(projectile).PreAI(projectile)) {
-					return false;
-				}
+				result &= g.Instance(projectile).PreAI(projectile));
 			}
 			if (projectile.modProjectile != null) {
-				return projectile.modProjectile.PreAI();
+				result &= projectile.modProjectile.PreAI();
 			}
-			return true;
+			return result;
 		}
 
 		private static HookList HookAI = AddHook<Action<Projectile>>(g => g.AI);
@@ -269,15 +268,14 @@ namespace Terraria.ModLoader
 		private static HookList HookOnTileCollide = AddHook<Func<Projectile, Vector2, bool>>(g => g.OnTileCollide);
 
 		public static bool OnTileCollide(Projectile projectile, Vector2 oldVelocity) {
+			bool result = true;
 			foreach (GlobalProjectile g in HookOnTileCollide.arr) {
-				if (!g.Instance(projectile).OnTileCollide(projectile, oldVelocity)) {
-					return false;
-				}
+				result &= g.Instance(projectile).OnTileCollide(projectile, oldVelocity);
 			}
 			if (projectile.modProjectile != null) {
-				return projectile.modProjectile.OnTileCollide(oldVelocity);
+				result &= projectile.modProjectile.OnTileCollide(oldVelocity);
 			}
-			return true;
+			return result;
 		}
 
 		private static HookList HookCanCutTiles = AddHook<Func<Projectile, bool?>>(g => g.CanCutTiles);
@@ -304,15 +302,14 @@ namespace Terraria.ModLoader
 		private static HookList HookPreKill = AddHook<Func<Projectile, int, bool>>(g => g.PreKill);
 
 		public static bool PreKill(Projectile projectile, int timeLeft) {
+			bool result = true;
 			foreach (GlobalProjectile g in HookPreKill.arr) {
-				if (!g.Instance(projectile).PreKill(projectile, timeLeft)) {
-					return false;
-				}
+				result &= g.Instance(projectile).PreKill(projectile, timeLeft);
 			}
 			if (projectile.modProjectile != null) {
-				return projectile.modProjectile.PreKill(timeLeft);
+				result &= projectile.modProjectile.PreKill(timeLeft);
 			}
-			return true;
+			return result;
 		}
 
 		private static HookList HookKill = AddHook<Action<Projectile, int>>(g => g.Kill);
@@ -520,29 +517,27 @@ namespace Terraria.ModLoader
 		private static HookList HookPreDrawExtras = AddHook<Func<Projectile, SpriteBatch, bool>>(g => g.PreDrawExtras);
 
 		public static bool PreDrawExtras(Projectile projectile, SpriteBatch spriteBatch) {
+			bool result = true;
 			foreach (GlobalProjectile g in HookPreDrawExtras.arr) {
-				if (!g.Instance(projectile).PreDrawExtras(projectile, spriteBatch)) {
-					return false;
-				}
+				result &= g.Instance(projectile).PreDrawExtras(projectile, spriteBatch);
 			}
 			if (projectile.modProjectile != null) {
-				return projectile.modProjectile.PreDrawExtras(spriteBatch);
+				result &= projectile.modProjectile.PreDrawExtras(spriteBatch);
 			}
-			return true;
+			return result;
 		}
 
 		private static HookList HookPreDraw = AddHook<Func<Projectile, SpriteBatch, Color, bool>>(g => g.PreDraw);
 
 		public static bool PreDraw(Projectile projectile, SpriteBatch spriteBatch, Color lightColor) {
+			bool result = true;
 			foreach (GlobalProjectile g in HookPreDraw.arr) {
-				if (!g.Instance(projectile).PreDraw(projectile, spriteBatch, lightColor)) {
-					return false;
-				}
+				result &= g.Instance(projectile).PreDraw(projectile, spriteBatch, lightColor);
 			}
 			if (projectile.modProjectile != null) {
-				return projectile.modProjectile.PreDraw(spriteBatch, lightColor);
+				result &= projectile.modProjectile.PreDraw(spriteBatch, lightColor);
 			}
-			return true;
+			return result;
 		}
 
 		private static HookList HookPostDraw = AddHook<Action<Projectile, SpriteBatch, Color>>(g => g.PostDraw);

--- a/patches/tModLoader/Terraria.ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ProjectileLoader.cs
@@ -169,7 +169,7 @@ namespace Terraria.ModLoader
 		public static bool PreAI(Projectile projectile) {
 			bool result = true;
 			foreach (GlobalProjectile g in HookPreAI.arr) {
-				result &= g.Instance(projectile).PreAI(projectile));
+				result &= g.Instance(projectile).PreAI(projectile);
 			}
 			if (projectile.modProjectile != null) {
 				result &= projectile.modProjectile.PreAI();

--- a/patches/tModLoader/Terraria.ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ProjectileLoader.cs
@@ -171,8 +171,8 @@ namespace Terraria.ModLoader
 			foreach (GlobalProjectile g in HookPreAI.arr) {
 				result &= g.Instance(projectile).PreAI(projectile);
 			}
-			if (projectile.modProjectile != null) {
-				result &= projectile.modProjectile.PreAI();
+			if (result && projectile.modProjectile != null) {
+				return projectile.modProjectile.PreAI();
 			}
 			return result;
 		}
@@ -272,8 +272,8 @@ namespace Terraria.ModLoader
 			foreach (GlobalProjectile g in HookOnTileCollide.arr) {
 				result &= g.Instance(projectile).OnTileCollide(projectile, oldVelocity);
 			}
-			if (projectile.modProjectile != null) {
-				result &= projectile.modProjectile.OnTileCollide(oldVelocity);
+			if (result && projectile.modProjectile != null) {
+				return projectile.modProjectile.OnTileCollide(oldVelocity);
 			}
 			return result;
 		}
@@ -306,8 +306,8 @@ namespace Terraria.ModLoader
 			foreach (GlobalProjectile g in HookPreKill.arr) {
 				result &= g.Instance(projectile).PreKill(projectile, timeLeft);
 			}
-			if (projectile.modProjectile != null) {
-				result &= projectile.modProjectile.PreKill(timeLeft);
+			if (result && projectile.modProjectile != null) {
+				return projectile.modProjectile.PreKill(timeLeft);
 			}
 			return result;
 		}
@@ -521,8 +521,8 @@ namespace Terraria.ModLoader
 			foreach (GlobalProjectile g in HookPreDrawExtras.arr) {
 				result &= g.Instance(projectile).PreDrawExtras(projectile, spriteBatch);
 			}
-			if (projectile.modProjectile != null) {
-				result &= projectile.modProjectile.PreDrawExtras(spriteBatch);
+			if (result && projectile.modProjectile != null) {
+				return projectile.modProjectile.PreDrawExtras(spriteBatch);
 			}
 			return result;
 		}
@@ -534,8 +534,8 @@ namespace Terraria.ModLoader
 			foreach (GlobalProjectile g in HookPreDraw.arr) {
 				result &= g.Instance(projectile).PreDraw(projectile, spriteBatch, lightColor);
 			}
-			if (projectile.modProjectile != null) {
-				result &= projectile.modProjectile.PreDraw(spriteBatch, lightColor);
+			if (result && projectile.modProjectile != null) {
+				return projectile.modProjectile.PreDraw(spriteBatch, lightColor);
 			}
 			return result;
 		}


### PR DESCRIPTION
### Description of the Change
This PR stops many bool-returning 'Pre' and 'On' Player, NPC and Projectile hooks from being able to cancel each other out (with their random order), where it makes no sense, to improve mod cross-compatibility. There's zero sense to why a call of a hook like PreAI should get cancelled just because some other call (sorted pretty much randomly) wants to prevent AI from running. PreAI is not AI, and it's not specialized-sounding ShouldCallAI.

### Alternate designs
Sounds too simple for there to be any.

### Why this should be merged into tModLoader & Benefits
With how things currently are, mod devs are screwing up each other without knowing, by just using the hooks they're supposed to use.

### Possible drawbacks & Applicable Issues
None? If someone's vile enough to want to stop others' hooks from being called, they can use MonoMod.

### Sample Usage
Hooks are used the same.
But I can show you what I and others will **no longer** have to do, which is [using a big dumb reflection-filled method](https://paste.mod.gg/ihatekapeq.cs) to ensure priority of their hooks to solve issues caused by mods like Calamity returning false in PreAI for their boss changes, causing bugs of size up to that of making all bosses immortal. All, by the way, just because C is the 3rd letter of English alphabet. I can't even blame them at all here.


