### PR TITLE
FrostArmor type hurt sound replacements.

### DIFF
--- a/ExampleMod/ExamplePlayer.cs
+++ b/ExampleMod/ExamplePlayer.cs
@@ -114,7 +114,6 @@ namespace ExampleMod
 			packet.Write((byte)ExampleModMessageType.ExamplePlayerSyncPlayer);
 			packet.Write((byte)player.whoAmI);
 			packet.Write(exampleLifeFruits);
-			packet.Write(blockyAccessory);
 			packet.Write(nonStopParty); // While we sync nonStopParty in SendClientChanges, we still need to send it here as well so newly joining players will receive the correct value.
 			packet.Send(toWho, fromWho);
 		}
@@ -127,7 +126,6 @@ namespace ExampleMod
 				var packet = mod.GetPacket();
 				packet.Write((byte)ExampleModMessageType.NonStopPartyChanged);
 				packet.Write((byte)player.whoAmI);
-				packet.Write(blockyAccessory);
 				packet.Write(nonStopParty);
 				packet.Send();
 			}
@@ -451,7 +449,7 @@ namespace ExampleMod
 				}
 				customDamage = true;
 			}
-            if (blockyAccessory) playSound = false;
+			if (blockyAccessory) playSound = false;
 			constantDamage = 0;
 			percentDamage = 0f;
 			defenseEffect = -1f;
@@ -459,8 +457,8 @@ namespace ExampleMod
 		}
 
 		public override void Hurt(bool pvp, bool quiet, double damage, int hitDirection, bool crit) {
-            if (blockyAccessory) Main.PlaySound(SoundID.Frog, player.position);
-            if (elementShield && damage > 1.0) {
+			if (blockyAccessory) Main.PlaySound(SoundID.Zombie, player.position, 13);
+			if (elementShield && damage > 1.0) {
 				if (elementShields < 6) {
 					int k;
 					bool flag = false;

--- a/ExampleMod/ExamplePlayer.cs
+++ b/ExampleMod/ExamplePlayer.cs
@@ -449,6 +449,7 @@ namespace ExampleMod
 				}
 				customDamage = true;
 			}
+            if (blockyAccessory) playSound = false;
 			constantDamage = 0;
 			percentDamage = 0f;
 			defenseEffect = -1f;
@@ -456,7 +457,8 @@ namespace ExampleMod
 		}
 
 		public override void Hurt(bool pvp, bool quiet, double damage, int hitDirection, bool crit) {
-			if (elementShield && damage > 1.0) {
+            if (blockyAccessory) Main.PlaySound(SoundID.Frog, player.position);
+            if (elementShield && damage > 1.0) {
 				if (elementShields < 6) {
 					int k;
 					bool flag = false;

--- a/ExampleMod/ExamplePlayer.cs
+++ b/ExampleMod/ExamplePlayer.cs
@@ -114,6 +114,7 @@ namespace ExampleMod
 			packet.Write((byte)ExampleModMessageType.ExamplePlayerSyncPlayer);
 			packet.Write((byte)player.whoAmI);
 			packet.Write(exampleLifeFruits);
+			packet.Write(blockyAccessory);
 			packet.Write(nonStopParty); // While we sync nonStopParty in SendClientChanges, we still need to send it here as well so newly joining players will receive the correct value.
 			packet.Send(toWho, fromWho);
 		}
@@ -126,6 +127,7 @@ namespace ExampleMod
 				var packet = mod.GetPacket();
 				packet.Write((byte)ExampleModMessageType.NonStopPartyChanged);
 				packet.Write((byte)player.whoAmI);
+				packet.Write(blockyAccessory);
 				packet.Write(nonStopParty);
 				packet.Send();
 			}


### PR DESCRIPTION
### Description of the Change
When the player has a `Charm of Example` or`ExampleCostume` worn, this will make the `blockyAccessory` field in ExamplePlayer true, I have added 2 lines of code that check if this field is true, one disables the default sound([Line 452](https://github.com/KryptonIon/tModLoader/blob/5e0b7d544f145dd20f8c55bb2fe943239e5272ef/ExampleMod/ExamplePlayer.cs#L452)) and the other plays a the frog sound([Line 460](https://github.com/KryptonIon/tModLoader/blob/5e0b7d544f145dd20f8c55bb2fe943239e5272ef/ExampleMod/ExamplePlayer.cs#L460))

### Alternate designs
N/A

### Why this should be merged into tModLoader
Quoted from the issue this is trying to fix,
> This will show off how to accomplish FrostArmor type hurt sound replacements.

### Benefits
Modders can simply look at ExampleMod instead of asking on Discord.

### Possible drawbacks
N/A

### Applicable Issues
#522

### Sample Usage
`if (blockyAccessory) playSound = false;` In PreHurt
`if (blockyAccessory) Main.PlaySound(SoundID.Frog, player.position);` In Hurt


