### PR TITLE
Fixes #751 (fix for very high speed yoyos)

### DIFF
--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -627,6 +627,14 @@
  					bool flag12 = player.channel && flag11 && !player.noItems && !player.CCed;
  					if (flag12)
  					{
+@@ -37928,6 +_,7 @@
+ 			num7 /= (1f + Main.player[this.owner].meleeSpeed * 3f) / 4f;
+ 			num8 /= (1f + Main.player[this.owner].meleeSpeed * 3f) / 4f;
+ 			float num11 = 14f - num8 / 2f;
++			if (num11 < 1.01f) num11 = 1.01f;
+ 			float num12 = 5f + num8 / 2f;
+ 			if (flag)
+ 			{
 @@ -38602,7 +_,7 @@
  								Tile tileSafely2 = Framing.GetTileSafely(i, j - 1);
  								if (!tileSafely2.active() || !Main.tileSolid[(int)tileSafely2.type] || Main.tileSolidTop[(int)tileSafely2.type])

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -627,10 +627,14 @@
  					bool flag12 = player.channel && flag11 && !player.noItems && !player.CCed;
  					if (flag12)
  					{
-@@ -37928,6 +_,7 @@
+@@ -37928,6 +_,11 @@
  			num7 /= (1f + Main.player[this.owner].meleeSpeed * 3f) / 4f;
  			num8 /= (1f + Main.player[this.owner].meleeSpeed * 3f) / 4f;
  			float num11 = 14f - num8 / 2f;
++			// Yoyos with effective top speed (boosted by melee speed) num8 > 26 will set num11 to be less than 1.
++			// This breaks the AI's acceleration vector math and stops the velocity from being correctly capped every frame.
++			// Providing a minimum value of 1.01 to num11 fixes this, allowing for very fast modded yoyos.
++			// See issue #751 for more details.
 +			if (num11 < 1.01f) num11 = 1.01f;
  			float num12 = 5f + num8 / 2f;
  			if (flag)


### PR DESCRIPTION
### Description of the Change
See issue #751 for a detailed breakdown of the vanilla code that these commits edit. A brief description is also included as a comment on the changed code.

The change enforces a minimum value on the "responsiveness" of any yoyo: `1.01`. This prevents the velocity recombination math which governs the yoyo's movement from breaking when the responsiveness value is less than 1. In the vanilla game, the responsiveness value can become less than 1 when a yoyo's effective top speed (boosted by melee speed) is greater than 26. This is possible by using the Terrarian and stacking a ton of melee speed, or by using even faster modded yoyos.

### Alternate designs
It would also be possible to enforce a minimum value of exactly `1.0`. I decided against this because a yoyo with responsiveness `1.0` snaps instantly to move towards the cursor every frame, which seemed antithetical to the design of yoyos in general.

### Why this should be merged into tModLoader
This change fixes a vanilla bug which can negatively impact all mods simultaneously and the player experience. It is not any one mod's job to fix the problem, and making players install a mod specifically to fix a vanilla bug seems unreasonable.

### Benefits
Mods can make yoyos with top speeds as high as they want. Players will no longer have to worry about using too much melee speed stat and breaking yoyos, especially modded ones.

### Possible drawbacks
This is another change to the `Projectile.cs` patch, which is quite large already.

### Applicable Issues
#751 _(as mentioned earlier)_

### Sample Usage
`ItemID.Sets.YoyosTopSpeed[item.type] = 27f;` in the yoyo of your choice.
ExampleMod could add an "ultra high speed yoyo" to demonstrate this feature if desired.
