### PR TITLE
Fixed Some Typos in ExampleDashAccessory

### DIFF
--- a/ExampleMod/Items/ExampleDashAccessory.cs
+++ b/ExampleMod/Items/ExampleDashAccessory.cs
@@ -142,9 +142,9 @@ namespace ExampleMod.Items
 			else if(player.controlUp && player.releaseUp && player.doubleTapCardinalTimer[DashUp] < 15)
 				DashDir = DashUp;
 			else if(player.controlRight && player.releaseRight && player.doubleTapCardinalTimer[DashRight] < 15)
-				DashDir = DashUp;
+				DashDir = DashRight;
 			else if(player.controlLeft && player.releaseLeft && player.doubleTapCardinalTimer[DashLeft] < 15)
-				DashDir = DashUp;
+				DashDir = DashLeft;
 			else
 				return;	 //No dash was activated, return
 


### PR DESCRIPTION
### Description of the Change
Fixes a few typos regarding setting the `ExampleDashPlayer.DashDir` field due to copy/paste laziness.

### Alternate designs
n/a

### Why this should be merged into tModLoader
The example dash won't function properly without this change.

### Benefits
See previous section.

### Possible drawbacks
n/a

### Applicable Issues
n/a

### Sample Usage
n/a

