### PR TITLE
When compiling and loading mods, check for {Dep}.XNA.dll and {Dep}.FNA.dll

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Core/AssemblyManager.cs
@@ -112,8 +112,13 @@ namespace Terraria.ModLoader.Core
 
 				try {
 					using (modFile.Open()) {
-						foreach (var dll in properties.dllReferences)
-							LoadAssembly(EncapsulateReferences(modFile.GetBytes("lib/" + dll + ".dll")));
+						const string suffixPlat = PlatformUtilities.IsXNA ? ".XNA.dll" : ".FNA.dll";
+						foreach (var dll in properties.dllReferences) {
+							byte[] dllBytes = modFile.GetBytes("lib/" + dll + suffixPlat) ??
+							                  modFile.GetBytes("lib/" + dll + ".dll");
+
+							LoadAssembly(EncapsulateReferences(dllBytes));
+						}
 
 						if (eacEnabled && HasEaC) //load the unmodified dll and EaC pdb
 							assembly = LoadAssembly(modFile.GetModAssembly(), File.ReadAllBytes(properties.eacPath));

--- a/patches/tModLoader/Terraria.ModLoader.Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Core/ModCompile.cs
@@ -376,7 +376,7 @@ namespace Terraria.ModLoader.Core
 
 			// add dll references from the bin folder
 			var libFolder = Path.Combine(mod.path, "lib");
-			foreach (var dllPath in mod.properties.dllReferences.Select(dllName => DllRefPath(mod, dllName)))
+			foreach (var dllPath in mod.properties.dllReferences.SelectMany(dllName => DllRefPathsForPackaging(mod, dllName)))
 				if (!dllPath.StartsWith(libFolder))
 					mod.modFile.AddFile("lib/"+Path.GetFileName(dllPath), File.ReadAllBytes(dllPath));
 		}
@@ -554,7 +554,7 @@ namespace Terraria.ModLoader.Core
 				.Where(path => !path.EndsWith("Thunk.dll") && !path.EndsWith("Wrapper.dll")));
 
 			//libs added by the mod
-			refs.AddRange(mod.properties.dllReferences.Select(dllName => DllRefPath(mod, dllName)));
+			refs.AddRange(mod.properties.dllReferences.Select(dllName => DllRefPathForCompilation(mod, dllName, xna)));
 
 			//all dlls included in all referenced mods
 			foreach (var refMod in refMods) {
@@ -595,8 +595,42 @@ namespace Terraria.ModLoader.Core
 			}
 		}
 
-		private string DllRefPath(BuildingMod mod, string dllName) {
-			var path = Path.Combine(mod.path, "lib", dllName + ".dll");
+		private string DllRefPathForCompilation(BuildingMod mod, string dllName, bool xna)
+		{
+			string path = Path.Combine(mod.path, $"lib/{dllName}");
+			string refPath = DllRefPath(path, dllName, xna);
+			if (refPath != null)
+				return refPath;
+
+			throw new BuildException("Missing dll reference: " + path);
+		}
+
+		private IEnumerable<string> DllRefPathsForPackaging(BuildingMod mod, string dllName)
+		{
+			string path = Path.Combine(mod.path, $"lib/{dllName}");
+			string xnaRefPath = DllRefPath(path, dllName, true);
+			string fnaRefPath = DllRefPath(path, dllName, false);
+
+			string[] refPaths = new[] {xnaRefPath, fnaRefPath}.Where(p => p != null)
+				.Distinct().ToArray();
+
+			if (!refPaths.Any())
+				throw new BuildException("Missing dll reference: " + path);
+
+			return refPaths;
+		}
+
+		private string DllRefPath(string path, string dllName, bool xna)
+		{
+			//check if .XNA.dll /.FNA.dll exists when compiling for that platform
+			string suffixPlat = xna ? ".XNA.dll" : ".FNA.dll";
+			string pathPlat = path + suffixPlat;
+			if (File.Exists(pathPlat))
+				return pathPlat;
+
+			//fallback to main .dll
+			path += ".dll";
+
 			if (File.Exists(path))
 				return path;
 
@@ -606,7 +640,7 @@ namespace Terraria.ModLoader.Core
 					return outputCopiedPath;
 			}
 
-			throw new BuildException("Missing dll reference: "+path);
+			return null;
 		}
 
 		private static IEnumerable<string> GetTerrariaReferences(string tempDir, bool xna) {


### PR DESCRIPTION
This change adapts #417 to work with XNA/FNA instead of Mono/Windows. A bit of extra code is required to support noCompile mods because tML needs to include both dlls if they exist, rather than just picking one as is done during compilation.

Updated sample usage:

* In build.txt, dllReferences = CoolLibrary
* In lib folder,
  * CoolLibrary.dll (XNA)
  * CoolLibrary.FNA.dll
* Compiled {modName}.XNA.dll uses CoolLibrary.dll
* Compiled {modName}.FNA.dll uses CoolLibrary.FNA.dll

Since the purpose of this request is the same as that of #417, please refer to the request description there.