### PR TITLE
Stabilize ExampleSign anchors, add search terms

### DIFF
--- a/ExampleMod/Tiles/ExampleCommandSign.cs
+++ b/ExampleMod/Tiles/ExampleCommandSign.cs
@@ -9,6 +9,7 @@ using Terraria.ObjectData;
 
 namespace ExampleMod.Tiles
 {
+	// This is an example mod for ExampleSign and ExampleCommandCaller combined into one
 	public class ExampleCommandSign : ModTile
 	{
 		public override void SetDefaults()
@@ -24,39 +25,55 @@ namespace ExampleMod.Tiles
 			Main.tileFrameImportant[Type] = true;
 			Main.tileLavaDeath[Type] = true;
 
-			// Allow hanging from ceilings
+			// Use a 2x2 style as our foundation
 			TileObjectData.newTile.CopyFrom(TileObjectData.Style2x2);
+
+			// Allow hanging from ceilings
 			TileObjectData.newAlternate.CopyFrom(TileObjectData.newTile);
 			TileObjectData.newAlternate.StyleHorizontal = true;
+			TileObjectData.newAlternate.AnchorAlternateTiles = new int[] { 124 };
 			TileObjectData.newAlternate.Origin = new Point16(0, 0);
-			TileObjectData.newAlternate.AnchorTop = new AnchorData(AnchorType.SolidTile | AnchorType.SolidSide, 2, 0);
+			TileObjectData.newAlternate.AnchorLeft = AnchorData.Empty;
+			TileObjectData.newAlternate.AnchorRight = AnchorData.Empty;
+			TileObjectData.newAlternate.AnchorTop = new AnchorData(AnchorType.SolidTile | AnchorType.SolidBottom, TileObjectData.newTile.Width, 0);
 			TileObjectData.newAlternate.AnchorBottom = AnchorData.Empty;
 			TileObjectData.addAlternate(1);
 
 			// Allow attaching to a solid object that is to the left of the sign
 			TileObjectData.newAlternate.CopyFrom(TileObjectData.newTile);
 			TileObjectData.newAlternate.StyleHorizontal = true;
+			TileObjectData.newAlternate.AnchorAlternateTiles = new int[] { 124 };
 			TileObjectData.newAlternate.Origin = new Point16(0, 0);
-			TileObjectData.newAlternate.AnchorLeft = new AnchorData(AnchorType.SolidTile | AnchorType.SolidSide, 2, 0);
+			TileObjectData.newAlternate.AnchorLeft = new AnchorData(AnchorType.SolidTile | AnchorType.SolidSide | AnchorType.Tree, TileObjectData.newTile.Width, 0);
 			TileObjectData.newAlternate.AnchorBottom = AnchorData.Empty;
 			TileObjectData.addAlternate(2);
 
 			// Allow attaching to a solid object that is to the right of the sign
 			TileObjectData.newAlternate.CopyFrom(TileObjectData.newTile);
 			TileObjectData.newAlternate.StyleHorizontal = true;
+			TileObjectData.newAlternate.AnchorAlternateTiles = new int[] { 124 };
 			TileObjectData.newAlternate.Origin = new Point16(0, 0);
-			TileObjectData.newAlternate.AnchorRight = new AnchorData(AnchorType.SolidTile | AnchorType.SolidSide, 2, 0);
+			TileObjectData.newAlternate.AnchorRight = new AnchorData(AnchorType.SolidTile | AnchorType.SolidSide | AnchorType.Tree, TileObjectData.newTile.Width, 0);
 			TileObjectData.newAlternate.AnchorBottom = AnchorData.Empty;
 			TileObjectData.addAlternate(3);
 
 			// Allow attaching to a wall behind the sign
 			TileObjectData.newAlternate.CopyFrom(TileObjectData.newTile);
 			TileObjectData.newAlternate.StyleHorizontal = true;
+			TileObjectData.newAlternate.AnchorAlternateTiles = new int[] { 124 };
 			TileObjectData.newAlternate.Origin = new Point16(0, 0);
 			TileObjectData.newAlternate.AnchorWall = true;
 			TileObjectData.newAlternate.AnchorBottom = AnchorData.Empty;
 			TileObjectData.addAlternate(4);
+
+			// Allow attaching sign to the ground
+			TileObjectData.newAlternate.CopyFrom(TileObjectData.newTile);
+			TileObjectData.newAlternate.StyleHorizontal = true;
+			TileObjectData.newAlternate.AnchorAlternateTiles = new int[] { 124 };
+			TileObjectData.newAlternate.Origin = new Point16(0, 0);
+			TileObjectData.addAlternate(5);
 			TileObjectData.addTile(Type);
+
 			ModTranslation name = CreateMapEntryName();
 			name.SetDefault("Example Command Sign");
 			AddMapEntry(new Color(200, 200, 200), name);


### PR DESCRIPTION
# tl;dr

- Add a comment containing "ExampleSign" and "ExampleCommandCaller" so it can be searched by either term
- Adjust sign anchors so they're more stable

### Description of the Change
This PR are subtle changes to the ExampleCommandSign aimed to improve placement stability and make it easier to search for in the GitHub search engine. 

A comment containing "ExampleSign" and "ExampleCommandCaller" has been added so that the ExampleMod can be searched by either term. ExampleCommandSign does not encompass either term and can not be easily searched for without knowing of its existence.

The anchors have been adjusted to be able to place the ExampleSign on trees, make the sign less jumpy to place, and to ensure all tiles are anchored throughout the tiles. 

### Alternate designs
N/A

### Why this should be merged into tModLoader
With these changes, the ExampleCommandSign example will be a much stronger example of how to work with signs in tModLoader. It will also help increase education with the ability to search multiple terms for it. 

### Benefits
A more performant example
Increased searchability in the GitHub search engine

### Possible drawbacks
No drawbacks can be determined from this PR

### Applicable Issues
N/A

### Sample Usage
See [https://github.com/tModLoader/tModLoader/commit/c31e56db7042b68c7efd0182bd60bccdacaef4ac](https://github.com/tModLoader/tModLoader/commit/c31e56db7042b68c7efd0182bd60bccdacaef4ac)

