### PR TITLE
Add retry build button, fix tiny error in compile failed message

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Core/ModCompile.cs
@@ -591,7 +591,7 @@ namespace Terraria.ModLoader.Core
 
 			if (results.HasErrors) {
 				var firstError = results.Cast<CompilerError>().First(e => !e.IsWarning);
-				throw new BuildException(Language.GetTextValue("tModLoader.CompileError", Path.GetFileName(outputPath), numErrors, firstError));
+				throw new BuildException(Language.GetTextValue("tModLoader.CompileError", Path.GetFileName(outputPath), numErrors, numWarnings) + $"\nError: {firstError}");
 			}
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader.UI/UIBuildMod.cs
+++ b/patches/tModLoader/Terraria.ModLoader.UI/UIBuildMod.cs
@@ -76,13 +76,17 @@ namespace Terraria.ModLoader.UI
 
 				var mod = e.Data.Contains("mod") ? e.Data["mod"] : null;
 				var msg = Language.GetTextValue("tModLoader.BuildError", mod ?? "");
+				bool isBuildError = false;
 				if (e is BuildException)
+				{
 					msg += $"\n{e.Message}\n\n{e.InnerException?.ToString() ?? ""}";
-				else 
+					isBuildError = true;
+					Interface.errorMessage.modName = (string)mod;
+				}
+				else
 					msg += $"\n\n{e}";
 
-				Interface.errorMessage.modName = (string)mod;
-				Interface.errorMessage.Show(msg, Interface.modSourcesID, e.HelpLink);
+				Interface.errorMessage.Show(msg, Interface.modSourcesID, e.HelpLink, showRetry: isBuildError);
 				return Task.FromResult(false);
 			}
 			return Task.FromResult(true);

--- a/patches/tModLoader/Terraria.ModLoader.UI/UIBuildMod.cs
+++ b/patches/tModLoader/Terraria.ModLoader.UI/UIBuildMod.cs
@@ -33,7 +33,7 @@ namespace Terraria.ModLoader.UI
 		internal void BuildAll(bool reload)
 			=> Build(mc => mc.BuildAll(), reload);
 
-		private void Build(Action<ModCompile> buildAction, bool reload) {
+		internal void Build(Action<ModCompile> buildAction, bool reload) {
 			Main.menuMode = Interface.buildModID;
 			Task.Run(() => BuildMod(buildAction, reload));
 		}
@@ -76,17 +76,17 @@ namespace Terraria.ModLoader.UI
 
 				var mod = e.Data.Contains("mod") ? e.Data["mod"] : null;
 				var msg = Language.GetTextValue("tModLoader.BuildError", mod ?? "");
-				bool isBuildError = false;
+
+				Action retry = null;
 				if (e is BuildException)
 				{
 					msg += $"\n{e.Message}\n\n{e.InnerException?.ToString() ?? ""}";
-					isBuildError = true;
-					Interface.errorMessage.modName = (string)mod;
+					retry = () => Interface.buildMod.Build(buildAction, reload);
 				}
 				else
 					msg += $"\n\n{e}";
 
-				Interface.errorMessage.Show(msg, Interface.modSourcesID, e.HelpLink, showRetry: isBuildError);
+				Interface.errorMessage.Show(msg, Interface.modSourcesID, e.HelpLink, retryAction: retry);
 				return Task.FromResult(false);
 			}
 			return Task.FromResult(true);

--- a/patches/tModLoader/Terraria.ModLoader.UI/UIBuildMod.cs
+++ b/patches/tModLoader/Terraria.ModLoader.UI/UIBuildMod.cs
@@ -81,6 +81,7 @@ namespace Terraria.ModLoader.UI
 				else 
 					msg += $"\n\n{e}";
 
+				Interface.errorMessage.modName = (string)mod;
 				Interface.errorMessage.Show(msg, Interface.modSourcesID, e.HelpLink);
 				return Task.FromResult(false);
 			}

--- a/patches/tModLoader/Terraria.ModLoader.UI/UIErrorMessage.cs
+++ b/patches/tModLoader/Terraria.ModLoader.UI/UIErrorMessage.cs
@@ -23,8 +23,9 @@ namespace Terraria.ModLoader.UI
 		private string message;
 		private int gotoMenu;
 		private string webHelpURL;
-		private bool showRetry;
+		private bool continueIsRetry;
 		private bool showSkip;
+		private bool showRetry;
 		internal string modName;
 
 		public override void OnInitialize() {
@@ -90,7 +91,6 @@ namespace Terraria.ModLoader.UI
 		private void RetryBuild(UIMouseEvent evt, UIElement listeningElement)
 		{
 			Interface.buildMod.Build(Path.Combine(ModCompile.ModSourcePath, modName), true);
-			modName = null;
 		}
 
 		public override void OnActivate() {
@@ -98,22 +98,23 @@ namespace Terraria.ModLoader.UI
 
 			messageBox.SetText(message);
 
-			var continueKey = gotoMenu < 0 ? "Exit" : showRetry ? "Retry" : "Continue";
+			var continueKey = gotoMenu < 0 ? "Exit" : continueIsRetry ? "Retry" : "Continue";
 			continueButton.SetText(Language.GetTextValue("tModLoader." + continueKey));
 			continueButton.TextColor = gotoMenu >= 0 ? Color.White : Color.Red;
 			
 			area.AddOrRemoveChild(webHelpButton, !string.IsNullOrEmpty(webHelpURL));
 			area.AddOrRemoveChild(skipLoadButton, showSkip);
 			area.AddOrRemoveChild(exitAndDisableAllButton, gotoMenu < 0);
-			area.AddOrRemoveChild(retryButton, modName != null);
+			area.AddOrRemoveChild(retryButton, showRetry);
 		}
 
-		internal void Show(string message, int gotoMenu, string webHelpURL = "", bool showRetry = false, bool showSkip = false) {
+		internal void Show(string message, int gotoMenu, string webHelpURL = "", bool continueIsRetry = false, bool showSkip = false, bool showRetry = false) {
 			this.message = message;
 			this.gotoMenu = gotoMenu;
 			this.webHelpURL = webHelpURL;
-			this.showRetry = showRetry;
+			this.continueIsRetry = continueIsRetry;
 			this.showSkip = showSkip;
+			this.showRetry = showRetry;
 			Main.gameMenu = true;
 			Main.menuMode = Interface.errorMessageID;
 		}

--- a/patches/tModLoader/Terraria.ModLoader.UI/UIErrorMessage.cs
+++ b/patches/tModLoader/Terraria.ModLoader.UI/UIErrorMessage.cs
@@ -25,8 +25,7 @@ namespace Terraria.ModLoader.UI
 		private string webHelpURL;
 		private bool continueIsRetry;
 		private bool showSkip;
-		private bool showRetry;
-		internal string modName;
+		private Action retryAction;
 
 		public override void OnInitialize() {
 			area = new UIElement {
@@ -83,14 +82,9 @@ namespace Terraria.ModLoader.UI
 			retryButton.CopyStyle(continueButton);
 			retryButton.Top.Set(-50f, 1f);
 			retryButton.WithFadedMouseOver();
-			retryButton.OnClick += RetryBuild;
+			retryButton.OnClick += (evt, elem) => retryAction();
 
 			Append(area);
-		}
-
-		private void RetryBuild(UIMouseEvent evt, UIElement listeningElement)
-		{
-			Interface.buildMod.Build(Path.Combine(ModCompile.ModSourcePath, modName), true);
 		}
 
 		public override void OnActivate() {
@@ -105,16 +99,20 @@ namespace Terraria.ModLoader.UI
 			area.AddOrRemoveChild(webHelpButton, !string.IsNullOrEmpty(webHelpURL));
 			area.AddOrRemoveChild(skipLoadButton, showSkip);
 			area.AddOrRemoveChild(exitAndDisableAllButton, gotoMenu < 0);
-			area.AddOrRemoveChild(retryButton, showRetry);
+			area.AddOrRemoveChild(retryButton, retryAction != null);
 		}
 
-		internal void Show(string message, int gotoMenu, string webHelpURL = "", bool continueIsRetry = false, bool showSkip = false, bool showRetry = false) {
+		public override void OnDeactivate() {
+			retryAction = null; //release references for the GC
+		}
+
+		internal void Show(string message, int gotoMenu, string webHelpURL = "", bool continueIsRetry = false, bool showSkip = false, Action retryAction = null) {
 			this.message = message;
 			this.gotoMenu = gotoMenu;
 			this.webHelpURL = webHelpURL;
 			this.continueIsRetry = continueIsRetry;
 			this.showSkip = showSkip;
-			this.showRetry = showRetry;
+			this.retryAction = retryAction;
 			Main.gameMenu = true;
 			Main.menuMode = Interface.errorMessageID;
 		}

--- a/patches/tModLoader/Terraria.ModLoader.UI/UIErrorMessage.cs
+++ b/patches/tModLoader/Terraria.ModLoader.UI/UIErrorMessage.cs
@@ -1,9 +1,11 @@
 using Microsoft.Xna.Framework;
 using System;
 using System.Diagnostics;
+using System.IO;
 using Terraria.GameContent.UI.Elements;
 using Terraria.ID;
 using Terraria.Localization;
+using Terraria.ModLoader.Core;
 using Terraria.UI;
 
 namespace Terraria.ModLoader.UI
@@ -16,12 +18,14 @@ namespace Terraria.ModLoader.UI
 		private UITextPanel<string> exitAndDisableAllButton;
 		private UITextPanel<string> webHelpButton;
 		private UITextPanel<string> skipLoadButton;
+		private UITextPanel<string> retryButton;
 		
 		private string message;
 		private int gotoMenu;
 		private string webHelpURL;
 		private bool showRetry;
 		private bool showSkip;
+		internal string modName;
 
 		public override void OnInitialize() {
 			area = new UIElement {
@@ -74,7 +78,19 @@ namespace Terraria.ModLoader.UI
 			exitAndDisableAllButton.WithFadedMouseOver();
 			exitAndDisableAllButton.OnClick += ExitAndDisableAll;
 
+			retryButton = new UITextPanel<string>("Retry", 0.7f, true);
+			retryButton.CopyStyle(continueButton);
+			retryButton.Top.Set(-50f, 1f);
+			retryButton.WithFadedMouseOver();
+			retryButton.OnClick += RetryBuild;
+
 			Append(area);
+		}
+
+		private void RetryBuild(UIMouseEvent evt, UIElement listeningElement)
+		{
+			Interface.buildMod.Build(Path.Combine(ModCompile.ModSourcePath, modName), true);
+			modName = null;
 		}
 
 		public override void OnActivate() {
@@ -89,6 +105,7 @@ namespace Terraria.ModLoader.UI
 			area.AddOrRemoveChild(webHelpButton, !string.IsNullOrEmpty(webHelpURL));
 			area.AddOrRemoveChild(skipLoadButton, showSkip);
 			area.AddOrRemoveChild(exitAndDisableAllButton, gotoMenu < 0);
+			area.AddOrRemoveChild(retryButton, modName != null);
 		}
 
 		internal void Show(string message, int gotoMenu, string webHelpURL = "", bool showRetry = false, bool showSkip = false) {

--- a/patches/tModLoader/Terraria.ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModLoader.cs
@@ -277,7 +277,7 @@ namespace Terraria.ModLoader
 				Interface.errorMessage.Show(msg,
 					gotoMenu: fatal ? -1 : Interface.reloadModsID,
 					webHelpURL: e.HelpLink,
-					showRetry: continueIsRetry,
+					continueIsRetry: continueIsRetry,
 					showSkip: !fatal);
 			}
 		}


### PR DESCRIPTION
### What is the new feature?
This PR adds a new button that allows the modder to retry building and loading their mod. It only appears if the error is that of a build failure, and it doesn't appear otherwise (e.g due to mod load failure). Useful for saving 1-2 clicks and implements the suggestion in #804 
(This PR also fixes a very small issue with the CompileError message. The bug was that the string was formatted with the error message in place of the number of warnings. I feel like the fix was too small to warrant a separate PR 😛 )

### Why should this be part of tModLoader?
A small quality-of-life addition to make mod dev lives a little easier. It's also helpful in the _extreme_ case a modder's mod sources list takes a long time to repopulate (for whatever odd reason).

### Are there alternative designs?
Perhaps separate the button into two, where one retries the build and the other retries the build and reloads as well, or it can stay as one button that builds and infers whether to reload or not based on what the modder clicked (`Build` or `Build + Reload` in the mod sources UI).
Optionally the retry button can be extended to retry mod loading alone, but often this yields the same result and it's better if the root issue that causes mod loading failure gets fixed by the mod dev.
The only other point is to probably add localization for `Retry`.

### Sample usage for the new feature
https://streamable.com/ude1mn

### ExampleMod updates
No changes to ExampleMod.

