### PR TITLE
Added hover text to MysteryTile

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.Default/MysteryTile.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Default/MysteryTile.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-
 namespace Terraria.ModLoader.Default
 {
 	public class MysteryTile : ModTile
@@ -9,19 +7,19 @@ namespace Terraria.ModLoader.Default
 			Main.tileFrameImportant[Type] = true;
 		}
 
-		//public override void MouseOver(int i, int j) {
-		//	var tile = Main.tile[i, j];
-		//	if (tile != null && tile.type == Type) {
-		//		var frame = new MysteryTileFrame(tile.frameX, tile.frameY);
-		//		var info = ModLoaderMod.Instance.GetModWorld<MysteryTilesWorld>().infos
-		//			.FirstOrDefault(x => {
-		//				return frame.FrameID == new MysteryTileFrame(x.frameX, x.frameY).FrameID;
-		//			});
+		public override void MouseOver(int i, int j)
+		{
+			var tile = Main.tile[i, j];
+			if(tile != null && tile.type == Type) {
+				var frame = new MysteryTileFrame(tile.frameX, tile.frameY);
+				var info = ModContent.GetInstance<MysteryTilesWorld>().infos[frame.FrameID];
 
-		//		if (info != null) {
-		//			Main.hoverItemName = $"{info.modName}: {info.name}";
-		//		}
-		//	}
-		//}
+				if(info != null) {
+					Main.LocalPlayer.showItemIcon = true;
+					Main.LocalPlayer.showItemIcon2 = -1;
+					Main.LocalPlayer.showItemIconText = $"{info.modName}: {info.name}";
+				}
+			}
+		}
 	}
 }

--- a/patches/tModLoader/Terraria.ModLoader.Default/MysteryTilesWorld.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Default/MysteryTilesWorld.cs
@@ -7,7 +7,7 @@ namespace Terraria.ModLoader.Default
 {
 	class MysteryTilesWorld : ModWorld
 	{
-		private List<MysteryTileInfo> infos = new List<MysteryTileInfo>();
+		internal List<MysteryTileInfo> infos = new List<MysteryTileInfo>();
 		internal List<MysteryTileInfo> pendingInfos = new List<MysteryTileInfo>();
 
 		public override void Initialize() {


### PR DESCRIPTION
### What is the new feature?
Mousing over a mystery tile will now show the mod and tile name of the unloaded tile.
From #613 

### Why should this be part of tModLoader?
Helpful for knowing what specific mod an unloaded tile was from.

### Are there alternative designs?
No. It is intended to be a rather simple, basic, and functional. As it stands, it requires no changes to the base game.

### Sample usage for the new feature
Somewhat niche but still, having a way to discern between multiple unloaded tiles that otherwise look completely identical could be useful at times.

### ExampleMod updates
None
