### PR TITLE
Fix enable/disable mods lag/freeze with many mods

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader.UI/UIModItem.cs
@@ -247,18 +247,20 @@ namespace Terraria.ModLoader.UI
 		}
 
 		private void ToggleEnabled(UIMouseEvent evt, UIElement listeningElement) {
-			Main.PlaySound(12);
+			Main.PlaySound(SoundID.MenuTick);
 			_mod.Enabled = !_mod.Enabled;
 		}
 
 		internal void Enable() {
-			Main.PlaySound(12);
+			if(_mod.Enabled){return;}
+			Main.PlaySound(SoundID.MenuTick);
 			_mod.Enabled = true;
 			_uiModStateText.SetEnabled();
 		}
 
 		internal void Disable() {
-			Main.PlaySound(12);
+			if(!_mod.Enabled){return;}
+			Main.PlaySound(SoundID.MenuTick);
 			_mod.Enabled = false;
 			_uiModStateText.SetDisabled();
 		}

--- a/patches/tModLoader/Terraria.ModLoader.UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader.UI/UIModItem.cs
@@ -277,6 +277,7 @@ namespace Terraria.ModLoader.UI
 		}
 
 		private void EnableDepsRecursive(LocalMod[] modList, string[] modRefs, List<string> missingRefs) {
+			ModLoader.PauseSavingEnabledMods = true;
 			foreach (var modRef in modRefs) {
 				// To enable the ref, its own refs must also be enabled
 				var refLocalMod = modList.FirstOrDefault(m => m.Name == modRef);
@@ -292,6 +293,7 @@ namespace Terraria.ModLoader.UI
 				ModLoader.EnableMod(modRef);
 				Interface.modsMenu.FindUIModItem(modRef)?.Enable();
 			}
+			ModLoader.PauseSavingEnabledMods = false;
 		}
 
 		internal void ShowMoreInfo(UIMouseEvent evt, UIElement listeningElement) {

--- a/patches/tModLoader/Terraria.ModLoader.UI/UIMods.cs
+++ b/patches/tModLoader/Terraria.ModLoader.UI/UIMods.cs
@@ -260,16 +260,20 @@ namespace Terraria.ModLoader.UI
 
 		private void EnableAll(UIMouseEvent evt, UIElement listeningElement) {
 			Main.PlaySound(12, -1, -1, 1);
+			ModLoader.PauseSavingEnabledMods = true;
 			foreach (UIModItem modItem in items) {
 				modItem.Enable();
 			}
+			ModLoader.PauseSavingEnabledMods = false;
 		}
 
 		private void DisableAll(UIMouseEvent evt, UIElement listeningElement) {
 			Main.PlaySound(12, -1, -1, 1);
+			ModLoader.PauseSavingEnabledMods = true;
 			foreach (UIModItem modItem in items) {
 				modItem.Disable();
 			}
+			ModLoader.PauseSavingEnabledMods = false;
 		}
 
 		public UIModItem FindUIModItem(string modName) {

--- a/patches/tModLoader/Terraria.ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModLoader.cs
@@ -292,6 +292,19 @@ namespace Terraria.ModLoader
 			return f.VerifySignature(mod.hash, mod.signature);
 		}
 
+		private static bool _pauseSavingEnabledMods;
+		private static bool _needsSavingEnabledMods;
+		internal static bool PauseSavingEnabledMods {
+			get=>_pauseSavingEnabledMods;
+			set {
+				if(_pauseSavingEnabledMods == value) {return;}
+				if(!value && _needsSavingEnabledMods) {
+					ModOrganizer.SaveEnabledMods();
+					_needsSavingEnabledMods = false;
+				}
+				_pauseSavingEnabledMods = value;
+			}
+		}
 		/// <summary>A cached list of enabled mods (not necessarily currently loaded or even installed), mirroring the enabled.json file.</summary>
 		private static HashSet<string> _enabledMods;
 		internal static HashSet<string> EnabledMods => _enabledMods ?? (_enabledMods = ModOrganizer.LoadEnabledMods());
@@ -308,8 +321,12 @@ namespace Terraria.ModLoader
 				EnabledMods.Remove(modName);
 				Logging.tML.InfoFormat("Disabling Mod: {0}", modName);
 			}
-
-			ModOrganizer.SaveEnabledMods();
+			if(PauseSavingEnabledMods) {
+				_needsSavingEnabledMods = true;
+			}
+			else {
+				ModOrganizer.SaveEnabledMods();
+			}
 		}
 
 		internal static void SaveConfiguration() {


### PR DESCRIPTION
### What is the bug?
From #815 .
When there are a large number of mods installed, using Enable All or Disable All will always cause a lag spike, even if only a few mods would change. This is because it allows it to Enable/Disable a mod which has already been Enabled/Disabled respectively. When it is enabled, it tells it to save the set of enabled mods which it has to do for every mod.

### How did you fix the bug?
Added a quick check to return when told to enable/disable while already in that state.
Also added a property to pause saving EnabledMods list. Once it is unpaused, if any changes were made, it will automatically save the new list. With this, I implemented it around all cases where multiple mods would be enabled/disabled in a loop (like for mod dependencies and for the enable/disable all buttons).

### Are there alternatives to your fix?
Not likely without some significant reworking of how the enabled mods list is handled.