### PR TITLE
Team enum

### DIFF
--- a/patches/tModLoader/Terraria.Enums/Team.cs
+++ b/patches/tModLoader/Terraria.Enums/Team.cs
@@ -1,0 +1,12 @@
+﻿namespace Terraria.Enums
+{
+	public enum Team : byte
+	{
+		None,
+		Red,
+		Green,
+		Blue,
+		Yellow,
+		Pink
+	}
+}


### PR DESCRIPTION
### What is the new feature?
This new feature is an enum placed in Terraria.Enums for team ids.

### Why should this be part of tModLoader?
This new "feature" should be a part of tModLoader purely for convenience for modders so if they need team ids for whatever reason, they don't have to look through the source code to find the values.

### Are there alternative designs?
An alternate design would be having a class with `const`s or `static readonly`s.

### Sample usage for the new feature
Saving the current team and doing stuff with it.