### PR TITLE
Added example fishing rod

### DIFF
--- a/ExampleMod/Items/ExampleFishingRod.cs
+++ b/ExampleMod/Items/ExampleFishingRod.cs
@@ -52,6 +52,7 @@ namespace ExampleMod.Items
 		}
 
 		//Overrides the default shooting method to fire multiple bobbers
+		//NOTE: This will allow the fishing rod to summon multiple Duke Fishrons with multiple Truffle Worms in the inventory
 		public override bool Shoot(Player player, ref Vector2 position, ref float speedX, ref float speedY, ref int type, ref int damage, ref float knockBack) {
 			int bobberAmount = Main.rand.Next(3,6); //3 to 5 bobbers
 			float spreadAmount = 75f;

--- a/ExampleMod/Items/ExampleFishingRod.cs
+++ b/ExampleMod/Items/ExampleFishingRod.cs
@@ -1,0 +1,80 @@
+using ExampleMod.Projectiles;
+using ExampleMod.Tiles;
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+using static Terraria.ModLoader.ModContent;
+
+namespace ExampleMod.Items
+{
+	public class ExampleFishingRod : ModItem
+	{
+		// You can use vanilla textures by using the format: Terraria/Item_<ID>
+		public override string Texture => "Terraria/Item_" + ItemID.WoodFishingPole;
+		public static Color OverrideColor = Color.Coral;
+
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Example Fishing Rod");
+            Tooltip.SetDefault("Fires multiple lines at once. Can fish in lava.\n" +
+				"The fishing line never snaps.");
+			//Allows the pole to fish in lava
+			ItemID.Sets.CanFishInLava[item.type] = true;
+        }
+
+        public override void SetDefaults()
+        {
+			//These are copied through the CloneDefaults method
+			//item.useStyle = 1;
+			//item.useAnimation = 8;
+			//item.useTime = 8;
+			//item.width = 24;
+			//item.height = 28;
+			//item.UseSound = SoundID.Item1;
+			item.CloneDefaults(ItemID.WoodFishingPole);
+
+			//Sets the poles fishing power
+			item.fishingPole = 30;
+
+			//Sets the speed in which the bobbers are launched, Wooden Fishing Pole is 9f and Golden Fishing Rod is 17f
+			item.shootSpeed = 12f;
+
+			//The Bobber projectile
+			item.shoot = ProjectileType<ExampleBobber>();
+
+			// Change the item's draw color so that it is visually distinct from the vanilla Wooden Fishing Rod.
+			item.color = OverrideColor;
+        }
+
+		//Grants the High Test Fishing Line bool if holding the item
+		//NOTE: Only triggers through the hotbar, not if you hold the item by hand outside of the inventory
+		public override void HoldItem(Player player)
+        {
+            player.accFishingLine = true;
+        }
+
+		//Overrides the default shooting method to fire multiple bobbers
+        public override bool Shoot(Player player, ref Vector2 position, ref float speedX, ref float speedY, ref int type, ref int damage, ref float knockBack)
+        {
+			int bobberAmount = Main.rand.Next(3,6); //3 to 5 bobbers
+			float spreadAmount = 75f;
+            for (int index = 0; index < bobberAmount; ++index)
+            {
+                float SpeedX = speedX + Main.rand.NextFloat(-spreadAmount, spreadAmount) * 0.05f;
+                float SpeedY = speedY + Main.rand.NextFloat(-spreadAmount, spreadAmount) * 0.05f;
+                Projectile.NewProjectile(position.X, position.Y, SpeedX, SpeedY, type, 0, 0f, player.whoAmI, 0f, 0f);
+            }
+            return false;
+        }
+
+		public override void AddRecipes()
+		{
+			ModRecipe recipe = new ModRecipe(mod);
+			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
+			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.SetResult(this);
+			recipe.AddRecipe();
+		}
+    }
+}

--- a/ExampleMod/Items/ExampleFishingRod.cs
+++ b/ExampleMod/Items/ExampleFishingRod.cs
@@ -14,17 +14,15 @@ namespace ExampleMod.Items
 		public override string Texture => "Terraria/Item_" + ItemID.WoodFishingPole;
 		public static Color OverrideColor = Color.Coral;
 
-        public override void SetStaticDefaults()
-        {
-            DisplayName.SetDefault("Example Fishing Rod");
-            Tooltip.SetDefault("Fires multiple lines at once. Can fish in lava.\n" +
+		public override void SetStaticDefaults() {
+			DisplayName.SetDefault("Example Fishing Rod");
+			Tooltip.SetDefault("Fires multiple lines at once. Can fish in lava.\n" +
 				"The fishing line never snaps.");
 			//Allows the pole to fish in lava
 			ItemID.Sets.CanFishInLava[item.type] = true;
-        }
+		}
 
-        public override void SetDefaults()
-        {
+		public override void SetDefaults() {
 			//These are copied through the CloneDefaults method
 			//item.useStyle = 1;
 			//item.useAnimation = 8;
@@ -45,36 +43,32 @@ namespace ExampleMod.Items
 
 			// Change the item's draw color so that it is visually distinct from the vanilla Wooden Fishing Rod.
 			item.color = OverrideColor;
-        }
+		}
 
 		//Grants the High Test Fishing Line bool if holding the item
 		//NOTE: Only triggers through the hotbar, not if you hold the item by hand outside of the inventory
-		public override void HoldItem(Player player)
-        {
-            player.accFishingLine = true;
-        }
+		public override void HoldItem(Player player) {
+			player.accFishingLine = true;
+		}
 
 		//Overrides the default shooting method to fire multiple bobbers
-        public override bool Shoot(Player player, ref Vector2 position, ref float speedX, ref float speedY, ref int type, ref int damage, ref float knockBack)
-        {
+		public override bool Shoot(Player player, ref Vector2 position, ref float speedX, ref float speedY, ref int type, ref int damage, ref float knockBack) {
 			int bobberAmount = Main.rand.Next(3,6); //3 to 5 bobbers
 			float spreadAmount = 75f;
-            for (int index = 0; index < bobberAmount; ++index)
-            {
-                float SpeedX = speedX + Main.rand.NextFloat(-spreadAmount, spreadAmount) * 0.05f;
-                float SpeedY = speedY + Main.rand.NextFloat(-spreadAmount, spreadAmount) * 0.05f;
-                Projectile.NewProjectile(position.X, position.Y, SpeedX, SpeedY, type, 0, 0f, player.whoAmI, 0f, 0f);
-            }
-            return false;
-        }
+			for (int index = 0; index < bobberAmount; ++index) {
+				float SpeedX = speedX + Main.rand.NextFloat(-spreadAmount, spreadAmount) * 0.05f;
+				float SpeedY = speedY + Main.rand.NextFloat(-spreadAmount, spreadAmount) * 0.05f;
+				Projectile.NewProjectile(position.X, position.Y, SpeedX, SpeedY, type, 0, 0f, player.whoAmI, 0f, 0f);
+			}
+			return false;
+		}
 
-		public override void AddRecipes()
-		{
+		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
 			recipe.AddTile(TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}
-    }
+	}
 }

--- a/ExampleMod/Projectiles/ExampleBobber.cs
+++ b/ExampleMod/Projectiles/ExampleBobber.cs
@@ -1,0 +1,181 @@
+using ExampleMod.Items;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+using static Terraria.ModLoader.ModContent;
+
+namespace ExampleMod.Projectiles
+{
+    public class ExampleBobber : ModProjectile
+    {
+		// You can use vanilla textures by using the format: Terraria/Item_<ID>
+		public override string Texture => "Terraria/Projectile_" + ProjectileID.BobberWooden;
+		private bool initialized = false;
+		private int color = 0;
+		private static Color fishingLineColor = new Color(255, 215, 0);
+
+		public override void SetStaticDefaults()
+		{
+			DisplayName.SetDefault("Example Bobber");
+		}
+
+        public override void SetDefaults()
+        {
+			//These are copied through the CloneDefaults method
+			//projectile.width = 14;
+			//projectile.height = 14;
+			//projectile.aiStyle = 61;
+            //projectile.bobber = true;
+            //projectile.penetrate = -1;
+			projectile.CloneDefaults(ProjectileID.BobberWooden);
+        }
+
+		//What if we want to randomize the line color
+		public override void AI()
+		{
+			if (!initialized)
+			{
+				color = Main.rand.Next(2);
+				initialized = true;
+			}
+			//50% chance for the line to be blue instead of the default gold
+			if (color == 1)
+			{
+				fishingLineColor = new Color(0, 191, 255);
+			}
+		}
+
+        public override bool PreDrawExtras(SpriteBatch spriteBatch)
+        {
+			//Create some bluish light; this could also be in the AI function
+			Lighting.AddLight(projectile.Center, 0f, 0.45f, 0.46f);
+
+			//Change these two values in order to change the origin of where the line is being drawn
+			int xPositionAdditive = 45;
+			float yPositionAdditive = 35f;
+
+            Player player = Main.player[projectile.owner];
+            if (projectile.bobber && player.inventory[player.selectedItem].holdStyle > 0)
+            {
+                float originX = player.MountedCenter.X;
+                float originY = player.MountedCenter.Y;
+                originY += player.gfxOffY;
+                int type = player.inventory[player.selectedItem].type;
+                //This variable is used to account for Gravitation Potions
+                float gravity = player.gravDir;
+
+                if (type == ItemType<ExampleFishingRod>())
+                {
+                    originX += (float)(xPositionAdditive * player.direction);
+                    if (player.direction < 0)
+                    {
+                        originX -= 13f;
+                    }
+                    originY -= yPositionAdditive * gravity;
+                }
+
+                if (gravity == -1f)
+                {
+                    originY -= 12f;
+                }
+                Vector2 mountedCenter = new Vector2(originX, originY);
+                mountedCenter = player.RotatedRelativePoint(mountedCenter + new Vector2(8f), true) - new Vector2(8f);
+                float projPosX = projectile.Center.X - mountedCenter.X;
+                float projPosY = projectile.Center.Y - mountedCenter.Y;
+                bool canDraw = true;
+                if (projPosX == 0f && projPosY == 0f)
+                {
+                    canDraw = false;
+                }
+                else
+                {
+                    float projPosXY = (float)Math.Sqrt((double)(projPosX * projPosX + projPosY * projPosY));
+                    projPosXY = 12f / projPosXY;
+                    projPosX *= projPosXY;
+                    projPosY *= projPosXY;
+                    mountedCenter.X -= projPosX;
+                    mountedCenter.Y -= projPosY;
+                    projPosX = projectile.position.X + (float)projectile.width * 0.5f - mountedCenter.X;
+                    projPosY = projectile.position.Y + (float)projectile.height * 0.5f - mountedCenter.Y;
+                }
+                while (canDraw)
+                {
+                    float height = 12f;
+                    float positionMagnitude = (float)Math.Sqrt((double)(projPosX * projPosX + projPosY * projPosY));
+                    if (float.IsNaN(positionMagnitude) || float.IsNaN(positionMagnitude))
+                    {
+                        canDraw = false;
+                    }
+                    else
+                    {
+                        if (positionMagnitude < 20f)
+                        {
+                            height = positionMagnitude - 8f;
+                            canDraw = false;
+                        }
+                        positionMagnitude = 12f / positionMagnitude;
+                        projPosX *= positionMagnitude;
+                        projPosY *= positionMagnitude;
+                        mountedCenter.X += projPosX;
+                        mountedCenter.Y += projPosY;
+                        projPosX = projectile.position.X + (float)projectile.width * 0.5f - mountedCenter.X;
+                        projPosY = projectile.position.Y + (float)projectile.height * 0.1f - mountedCenter.Y;
+                        if (positionMagnitude > 12f)
+                        {
+                            float positionInverseMultiplier = 0.3f;
+                            float absVelocitySum = Math.Abs(projectile.velocity.X) + Math.Abs(projectile.velocity.Y);
+                            if (absVelocitySum > 16f)
+                            {
+                                absVelocitySum = 16f;
+                            }
+                            absVelocitySum = 1f - absVelocitySum / 16f;
+                            positionInverseMultiplier *= absVelocitySum;
+                            absVelocitySum = positionMagnitude / 80f;
+                            if (absVelocitySum > 1f)
+                            {
+                                absVelocitySum = 1f;
+                            }
+                            positionInverseMultiplier *= absVelocitySum;
+                            if (positionInverseMultiplier < 0f)
+                            {
+                                positionInverseMultiplier = 0f;
+                            }
+                            absVelocitySum = 1f - projectile.localAI[0] / 100f;
+                            positionInverseMultiplier *= absVelocitySum;
+                            if (projPosY > 0f)
+                            {
+                                projPosY *= 1f + positionInverseMultiplier;
+                                projPosX *= 1f - positionInverseMultiplier;
+                            }
+                            else
+                            {
+                                absVelocitySum = Math.Abs(projectile.velocity.X) / 3f;
+                                if (absVelocitySum > 1f)
+                                {
+                                    absVelocitySum = 1f;
+                                }
+                                absVelocitySum -= 0.5f;
+                                positionInverseMultiplier *= absVelocitySum;
+                                if (positionInverseMultiplier > 0f)
+                                {
+                                    positionInverseMultiplier *= 2f;
+                                }
+                                projPosY *= 1f + positionInverseMultiplier;
+                                projPosX *= 1f - positionInverseMultiplier;
+                            }
+                        }
+						//This color decides the color of the fishing line. It defaults to gold but has a 50% chance to be blue as decided in the AI.
+                        Color lineColor = Lighting.GetColor((int)mountedCenter.X / 16, (int)(mountedCenter.Y / 16f), fishingLineColor);
+                        float rotation = (float)Math.Atan2((double)projPosY, (double)projPosX) - MathHelper.PiOver2;
+
+                        Main.spriteBatch.Draw(Main.fishingLineTexture, new Vector2(mountedCenter.X - Main.screenPosition.X + (float)Main.fishingLineTexture.Width * 0.5f, mountedCenter.Y - Main.screenPosition.Y + (float)Main.fishingLineTexture.Height * 0.5f), new Rectangle?(new Rectangle(0, 0, Main.fishingLineTexture.Width, (int)height)), lineColor, rotation, new Vector2((float)Main.fishingLineTexture.Width * 0.5f, 0f), 1f, SpriteEffects.None, 0f);
+                    }
+                }
+            }
+            return false;
+		}
+    }
+}

--- a/ExampleMod/Projectiles/ExampleBobber.cs
+++ b/ExampleMod/Projectiles/ExampleBobber.cs
@@ -9,47 +9,41 @@ using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
-    public class ExampleBobber : ModProjectile
-    {
+	public class ExampleBobber : ModProjectile
+	{
 		// You can use vanilla textures by using the format: Terraria/Item_<ID>
 		public override string Texture => "Terraria/Projectile_" + ProjectileID.BobberWooden;
 		private bool initialized = false;
 		private int color = 0;
 		private static Color fishingLineColor = new Color(255, 215, 0);
 
-		public override void SetStaticDefaults()
-		{
+		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Example Bobber");
 		}
 
-        public override void SetDefaults()
-        {
+		public override void SetDefaults() {
 			//These are copied through the CloneDefaults method
 			//projectile.width = 14;
 			//projectile.height = 14;
 			//projectile.aiStyle = 61;
-            //projectile.bobber = true;
-            //projectile.penetrate = -1;
+			//projectile.bobber = true;
+			//projectile.penetrate = -1;
 			projectile.CloneDefaults(ProjectileID.BobberWooden);
-        }
+		}
 
 		//What if we want to randomize the line color
-		public override void AI()
-		{
-			if (!initialized)
-			{
+		public override void AI() {
+			if (!initialized) {
 				color = Main.rand.Next(2);
 				initialized = true;
 			}
 			//50% chance for the line to be blue instead of the default gold
-			if (color == 1)
-			{
+			if (color == 1) {
 				fishingLineColor = new Color(0, 191, 255);
 			}
 		}
 
-        public override bool PreDrawExtras(SpriteBatch spriteBatch)
-        {
+		public override bool PreDrawExtras(SpriteBatch spriteBatch) {
 			//Create some bluish light; this could also be in the AI function
 			Lighting.AddLight(projectile.Center, 0f, 0.45f, 0.46f);
 
@@ -57,125 +51,107 @@ namespace ExampleMod.Projectiles
 			int xPositionAdditive = 45;
 			float yPositionAdditive = 35f;
 
-            Player player = Main.player[projectile.owner];
-            if (projectile.bobber && player.inventory[player.selectedItem].holdStyle > 0)
-            {
-                float originX = player.MountedCenter.X;
-                float originY = player.MountedCenter.Y;
-                originY += player.gfxOffY;
-                int type = player.inventory[player.selectedItem].type;
-                //This variable is used to account for Gravitation Potions
-                float gravity = player.gravDir;
+			Player player = Main.player[projectile.owner];
+			if (projectile.bobber && player.inventory[player.selectedItem].holdStyle > 0) {
+				float originX = player.MountedCenter.X;
+				float originY = player.MountedCenter.Y;
+				originY += player.gfxOffY;
+				int type = player.inventory[player.selectedItem].type;
+				//This variable is used to account for Gravitation Potions
+				float gravity = player.gravDir;
 
-                if (type == ItemType<ExampleFishingRod>())
-                {
-                    originX += (float)(xPositionAdditive * player.direction);
-                    if (player.direction < 0)
-                    {
-                        originX -= 13f;
-                    }
-                    originY -= yPositionAdditive * gravity;
-                }
+				if (type == ItemType<ExampleFishingRod>()) {
+					originX += (float)(xPositionAdditive * player.direction);
+					if (player.direction < 0) {
+						originX -= 13f;
+					}
+					originY -= yPositionAdditive * gravity;
+				}
 
-                if (gravity == -1f)
-                {
-                    originY -= 12f;
-                }
-                Vector2 mountedCenter = new Vector2(originX, originY);
-                mountedCenter = player.RotatedRelativePoint(mountedCenter + new Vector2(8f), true) - new Vector2(8f);
-                float projPosX = projectile.Center.X - mountedCenter.X;
-                float projPosY = projectile.Center.Y - mountedCenter.Y;
-                bool canDraw = true;
-                if (projPosX == 0f && projPosY == 0f)
-                {
-                    canDraw = false;
-                }
-                else
-                {
-                    float projPosXY = (float)Math.Sqrt((double)(projPosX * projPosX + projPosY * projPosY));
-                    projPosXY = 12f / projPosXY;
-                    projPosX *= projPosXY;
-                    projPosY *= projPosXY;
-                    mountedCenter.X -= projPosX;
-                    mountedCenter.Y -= projPosY;
-                    projPosX = projectile.position.X + (float)projectile.width * 0.5f - mountedCenter.X;
-                    projPosY = projectile.position.Y + (float)projectile.height * 0.5f - mountedCenter.Y;
-                }
-                while (canDraw)
-                {
-                    float height = 12f;
-                    float positionMagnitude = (float)Math.Sqrt((double)(projPosX * projPosX + projPosY * projPosY));
-                    if (float.IsNaN(positionMagnitude) || float.IsNaN(positionMagnitude))
-                    {
-                        canDraw = false;
-                    }
-                    else
-                    {
-                        if (positionMagnitude < 20f)
-                        {
-                            height = positionMagnitude - 8f;
-                            canDraw = false;
-                        }
-                        positionMagnitude = 12f / positionMagnitude;
-                        projPosX *= positionMagnitude;
-                        projPosY *= positionMagnitude;
-                        mountedCenter.X += projPosX;
-                        mountedCenter.Y += projPosY;
-                        projPosX = projectile.position.X + (float)projectile.width * 0.5f - mountedCenter.X;
-                        projPosY = projectile.position.Y + (float)projectile.height * 0.1f - mountedCenter.Y;
-                        if (positionMagnitude > 12f)
-                        {
-                            float positionInverseMultiplier = 0.3f;
-                            float absVelocitySum = Math.Abs(projectile.velocity.X) + Math.Abs(projectile.velocity.Y);
-                            if (absVelocitySum > 16f)
-                            {
-                                absVelocitySum = 16f;
-                            }
-                            absVelocitySum = 1f - absVelocitySum / 16f;
-                            positionInverseMultiplier *= absVelocitySum;
-                            absVelocitySum = positionMagnitude / 80f;
-                            if (absVelocitySum > 1f)
-                            {
-                                absVelocitySum = 1f;
-                            }
-                            positionInverseMultiplier *= absVelocitySum;
-                            if (positionInverseMultiplier < 0f)
-                            {
-                                positionInverseMultiplier = 0f;
-                            }
-                            absVelocitySum = 1f - projectile.localAI[0] / 100f;
-                            positionInverseMultiplier *= absVelocitySum;
-                            if (projPosY > 0f)
-                            {
-                                projPosY *= 1f + positionInverseMultiplier;
-                                projPosX *= 1f - positionInverseMultiplier;
-                            }
-                            else
-                            {
-                                absVelocitySum = Math.Abs(projectile.velocity.X) / 3f;
-                                if (absVelocitySum > 1f)
-                                {
-                                    absVelocitySum = 1f;
-                                }
-                                absVelocitySum -= 0.5f;
-                                positionInverseMultiplier *= absVelocitySum;
-                                if (positionInverseMultiplier > 0f)
-                                {
-                                    positionInverseMultiplier *= 2f;
-                                }
-                                projPosY *= 1f + positionInverseMultiplier;
-                                projPosX *= 1f - positionInverseMultiplier;
-                            }
-                        }
+				if (gravity == -1f) {
+					originY -= 12f;
+				}
+				Vector2 mountedCenter = new Vector2(originX, originY);
+				mountedCenter = player.RotatedRelativePoint(mountedCenter + new Vector2(8f), true) - new Vector2(8f);
+				float projPosX = projectile.Center.X - mountedCenter.X;
+				float projPosY = projectile.Center.Y - mountedCenter.Y;
+				bool canDraw = true;
+				if (projPosX == 0f && projPosY == 0f) {
+					canDraw = false;
+				}
+				else {
+					float projPosXY = (float)Math.Sqrt((double)(projPosX * projPosX + projPosY * projPosY));
+					projPosXY = 12f / projPosXY;
+					projPosX *= projPosXY;
+					projPosY *= projPosXY;
+					mountedCenter.X -= projPosX;
+					mountedCenter.Y -= projPosY;
+					projPosX = projectile.position.X + (float)projectile.width * 0.5f - mountedCenter.X;
+					projPosY = projectile.position.Y + (float)projectile.height * 0.5f - mountedCenter.Y;
+				}
+				while (canDraw) {
+					float height = 12f;
+					float positionMagnitude = (float)Math.Sqrt((double)(projPosX * projPosX + projPosY * projPosY));
+					if (float.IsNaN(positionMagnitude) || float.IsNaN(positionMagnitude)) {
+						canDraw = false;
+					}
+					else {
+						if (positionMagnitude < 20f) {
+							height = positionMagnitude - 8f;
+							canDraw = false;
+						}
+						positionMagnitude = 12f / positionMagnitude;
+						projPosX *= positionMagnitude;
+						projPosY *= positionMagnitude;
+						mountedCenter.X += projPosX;
+						mountedCenter.Y += projPosY;
+						projPosX = projectile.position.X + (float)projectile.width * 0.5f - mountedCenter.X;
+						projPosY = projectile.position.Y + (float)projectile.height * 0.1f - mountedCenter.Y;
+						if (positionMagnitude > 12f) {
+							float positionInverseMultiplier = 0.3f;
+							float absVelocitySum = Math.Abs(projectile.velocity.X) + Math.Abs(projectile.velocity.Y);
+							if (absVelocitySum > 16f) {
+								absVelocitySum = 16f;
+							}
+							absVelocitySum = 1f - absVelocitySum / 16f;
+							positionInverseMultiplier *= absVelocitySum;
+							absVelocitySum = positionMagnitude / 80f;
+							if (absVelocitySum > 1f) {
+								absVelocitySum = 1f;
+							}
+							positionInverseMultiplier *= absVelocitySum;
+							if (positionInverseMultiplier < 0f) {
+								positionInverseMultiplier = 0f;
+							}
+							absVelocitySum = 1f - projectile.localAI[0] / 100f;
+							positionInverseMultiplier *= absVelocitySum;
+							if (projPosY > 0f) {
+								projPosY *= 1f + positionInverseMultiplier;
+								projPosX *= 1f - positionInverseMultiplier;
+							}
+							else {
+								absVelocitySum = Math.Abs(projectile.velocity.X) / 3f;
+								if (absVelocitySum > 1f) {
+									absVelocitySum = 1f;
+								}
+								absVelocitySum -= 0.5f;
+								positionInverseMultiplier *= absVelocitySum;
+								if (positionInverseMultiplier > 0f) {
+									positionInverseMultiplier *= 2f;
+								}
+								projPosY *= 1f + positionInverseMultiplier;
+								projPosX *= 1f - positionInverseMultiplier;
+							}
+						}
 						//This color decides the color of the fishing line. It defaults to gold but has a 50% chance to be blue as decided in the AI.
-                        Color lineColor = Lighting.GetColor((int)mountedCenter.X / 16, (int)(mountedCenter.Y / 16f), fishingLineColor);
-                        float rotation = (float)Math.Atan2((double)projPosY, (double)projPosX) - MathHelper.PiOver2;
+						Color lineColor = Lighting.GetColor((int)mountedCenter.X / 16, (int)(mountedCenter.Y / 16f), fishingLineColor);
+						float rotation = (float)Math.Atan2((double)projPosY, (double)projPosX) - MathHelper.PiOver2;
 
-                        Main.spriteBatch.Draw(Main.fishingLineTexture, new Vector2(mountedCenter.X - Main.screenPosition.X + (float)Main.fishingLineTexture.Width * 0.5f, mountedCenter.Y - Main.screenPosition.Y + (float)Main.fishingLineTexture.Height * 0.5f), new Rectangle?(new Rectangle(0, 0, Main.fishingLineTexture.Width, (int)height)), lineColor, rotation, new Vector2((float)Main.fishingLineTexture.Width * 0.5f, 0f), 1f, SpriteEffects.None, 0f);
-                    }
-                }
-            }
-            return false;
+						Main.spriteBatch.Draw(Main.fishingLineTexture, new Vector2(mountedCenter.X - Main.screenPosition.X + (float)Main.fishingLineTexture.Width * 0.5f, mountedCenter.Y - Main.screenPosition.Y + (float)Main.fishingLineTexture.Height * 0.5f), new Rectangle?(new Rectangle(0, 0, Main.fishingLineTexture.Width, (int)height)), lineColor, rotation, new Vector2((float)Main.fishingLineTexture.Width * 0.5f, 0f), 1f, SpriteEffects.None, 0f);
+					}
+				}
+			}
+			return false;
 		}
-    }
+	}
 }


### PR DESCRIPTION
### **Description of the Change**
Adds an example item to ExampleMod called Example Fishing Rod.
It gives examples of how to fish in lava, fire multiple lines, and randomize line colors.

### **Why this should be merged into tModLoader**
This is an example item for Example Mod which modders can reference to see how to make a fishing rod, specifically the draw code in the bobber file in order for the line to draw properly.

### **Benefits**
Provides an example of a fishing rod with various attributes
Provides an example of a bobber with a properly drawn line and can have randomized colors
### **Possible drawbacks**
**N/A**

### **Applicable Issues**
**N/A**

### **Sample Usage**
This item is in Example Mod. It is an example item, and it is its own sample usage.