### PR TITLE
Added filling of textures' Name and Tag properties to ease debugging of spritebatch issues

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/ModInternals.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModInternals.cs
@@ -69,7 +69,10 @@ namespace Terraria.ModLoader
 							Language.GetTextValue("tModLoader.LoadErrorTextureFailedToLoad", path), t.Exception);
 
 					var tex = t.Result;
+					
 					tex.Name = Name + "/" + path;
+					tex.Tag = Name;
+
 					lock (textures)
 						textures[path] = tex;
 				}));

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -741,7 +741,7 @@
  		}
  
  		private void ClientInitialize() {
-@@ -6674,41 +_,48 @@
+@@ -6674,41 +_,58 @@
  			}
  
  			if (autoJoin) {
@@ -760,16 +760,30 @@
  
  		public T OurLoad<T>(string path) {
 -			lock (globalTextureLocker) {
+-				if (TexturePackSupport.Enabled && typeof(T) == t2d && TexturePackSupport.FetchTexture(path + ".png", out Texture2D tex))
+-					return (T)(object)tex;
+-
+-				return base.Content.Load<T>(path);
 +			GLCallLocker.Enter(globalTextureLocker);
 +			try {
- 				if (TexturePackSupport.Enabled && typeof(T) == t2d && TexturePackSupport.FetchTexture(path + ".png", out Texture2D tex))
- 					return (T)(object)tex;
- 
- 				return base.Content.Load<T>(path);
- 			}
++				T content;
++
++				if (TexturePackSupport.Enabled && typeof(T) == t2d && TexturePackSupport.FetchTexture(path + ".png", out Texture2D tex)) {
++					content = (T)(object)tex;
++				} else {
++					content = base.Content.Load<T>(path);
++				}
++
++				if(content is GraphicsResource graphicsResource) {
++					graphicsResource.Name = path;
++					graphicsResource.Tag = "Terraria";
++				}
++
++				return content;
++			}
 +			finally {
 +				Monitor.Exit(globalTextureLocker);
-+			}
+ 			}
  		}
  
  		protected override void LoadContent() {


### PR DESCRIPTION
This PR modifiers Main.OurLoad so that it fills GraphicsResource.Name & Tag properties with texture path and Terraria strings. Additionally, mod textures will now have their Tag property set to the mod's name.

This should help modders easily identify faulty textures passed to SpriteBatch methods during, for example, an ObjectDisposedException, which previously frequently forced modders to guess what the texture was only based on its width & height properties, if the texture used was vanilla.