### PR TITLE
Better Log Archiving

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.Core/LogArchiver.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Core/LogArchiver.cs
@@ -13,6 +13,9 @@ namespace Terraria.ModLoader.Core
 	internal static class LogArchiver
 	{
 		internal static void ArchiveLogs() {
+			if (!Directory.Exists(Logging.LogArchiveDir))
+				Directory.CreateDirectory(Logging.LogArchiveDir);
+
 			foreach (var logFile in Directory.GetFiles(Logging.LogDir, "*.old*"))
 				Archive(logFile, Path.GetFileNameWithoutExtension(logFile));
 
@@ -24,11 +27,11 @@ namespace Terraria.ModLoader.Core
 			int n = 1;
 
 			var pattern = new Regex($"{time:yyyy-MM-dd}-(\\d+)\\.zip");
-			var existingLogs = Directory.GetFiles(Logging.LogDir).Where(s => pattern.IsMatch(Path.GetFileName(s))).ToList();
+			var existingLogs = Directory.GetFiles(Logging.LogArchiveDir).Where(s => pattern.IsMatch(Path.GetFileName(s))).ToList();
 			if (existingLogs.Count > 0)
 				n = existingLogs.Select(s => int.Parse(pattern.Match(Path.GetFileName(s)).Groups[1].Value)).Max() + 1;
 
-			using (var zip = new ZipFile(Path.Combine(Logging.LogDir, $"{time:yyyy-MM-dd}-{n}.zip"), Encoding.UTF8)) {
+			using (var zip = new ZipFile(Path.Combine(Logging.LogArchiveDir, $"{time:yyyy-MM-dd}-{n}.zip"), Encoding.UTF8)) {
 				using (var stream = File.OpenRead(logFile)) {
 					zip.AddEntry(entryName, stream);
 					zip.Save();
@@ -41,8 +44,15 @@ namespace Terraria.ModLoader.Core
 		private const int MAX_LOGS = 20;
 		private static void DeleteOldArchives() {
 			var pattern = new Regex(".*\\.zip");
-			var existingLogs = Directory.GetFiles(Logging.LogDir).Where(s => pattern.IsMatch(Path.GetFileName(s))).OrderBy(File.GetCreationTime).ToList();
+			var existingLogs = Directory.GetFiles(Logging.LogArchiveDir).Where(s => pattern.IsMatch(Path.GetFileName(s))).OrderBy(File.GetCreationTime).ToList();
+			var existingOldLogs = Directory.GetFiles(Logging.LogDir).Where(s => pattern.IsMatch(Path.GetFileName(s))).ToList();
 			foreach (var f in existingLogs.Take(existingLogs.Count - MAX_LOGS)) {
+				try {
+					File.Delete(f);
+				}
+				catch (IOException) { }
+			}
+			foreach (var f in existingOldLogs) {
 				try {
 					File.Delete(f);
 				}

--- a/patches/tModLoader/Terraria.ModLoader.Core/LogArchiver.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Core/LogArchiver.cs
@@ -13,8 +13,19 @@ namespace Terraria.ModLoader.Core
 	internal static class LogArchiver
 	{
 		internal static void ArchiveLogs() {
-			if (!Directory.Exists(Logging.LogArchiveDir))
+			if (!Directory.Exists(Logging.LogArchiveDir)) {
+				var pattern = new Regex(".*\\.zip");
+				var existingOldLogs = Directory.GetFiles(Logging.LogDir).Where(s => pattern.IsMatch(Path.GetFileName(s))).ToList();
+
+				foreach (string f in existingOldLogs) {
+					try {
+						File.Delete(f);
+					}
+					catch (IOException) { }
+				}
+
 				Directory.CreateDirectory(Logging.LogArchiveDir);
+			}
 
 			foreach (var logFile in Directory.GetFiles(Logging.LogDir, "*.old*"))
 				Archive(logFile, Path.GetFileNameWithoutExtension(logFile));
@@ -45,14 +56,7 @@ namespace Terraria.ModLoader.Core
 		private static void DeleteOldArchives() {
 			var pattern = new Regex(".*\\.zip");
 			var existingLogs = Directory.GetFiles(Logging.LogArchiveDir).Where(s => pattern.IsMatch(Path.GetFileName(s))).OrderBy(File.GetCreationTime).ToList();
-			var existingOldLogs = Directory.GetFiles(Logging.LogDir).Where(s => pattern.IsMatch(Path.GetFileName(s))).ToList();
 			foreach (var f in existingLogs.Take(existingLogs.Count - MAX_LOGS)) {
-				try {
-					File.Delete(f);
-				}
-				catch (IOException) { }
-			}
-			foreach (var f in existingOldLogs) {
 				try {
 					File.Delete(f);
 				}

--- a/patches/tModLoader/Terraria.ModLoader.Core/LogArchiver.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Core/LogArchiver.cs
@@ -16,14 +16,14 @@ namespace Terraria.ModLoader.Core
 			if (!Directory.Exists(Logging.LogArchiveDir)) {
 				string[] existingOldLogs = Directory.GetFiles(Logging.LogDir, "*.zip");
 
+				Directory.CreateDirectory(Logging.LogArchiveDir);
+
 				for (int i = 0; i < existingOldLogs.Length; i++) {
 					try {
-						File.Delete(existingOldLogs[i]);
+						File.Move(existingOldLogs[i], Path.Combine(Logging.LogArchiveDir, Path.GetFileName(existingOldLogs[i])));
 					}
 					catch (IOException) { }
 				}
-
-				Directory.CreateDirectory(Logging.LogArchiveDir);
 			}
 
 			foreach (string logFile in Directory.GetFiles(Logging.LogDir, "*.old*")) {

--- a/patches/tModLoader/Terraria.ModLoader.Core/LogArchiver.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Core/LogArchiver.cs
@@ -14,12 +14,11 @@ namespace Terraria.ModLoader.Core
 	{
 		internal static void ArchiveLogs() {
 			if (!Directory.Exists(Logging.LogArchiveDir)) {
-				var pattern = new Regex(".*\\.zip");
-				var existingOldLogs = Directory.GetFiles(Logging.LogDir).Where(s => pattern.IsMatch(Path.GetFileName(s))).ToList();
+				string[] existingOldLogs = Directory.GetFiles(Logging.LogDir, "*.zip");
 
-				foreach (string f in existingOldLogs) {
+				for (int i = 0; i < existingOldLogs.Length; i++) {
 					try {
-						File.Delete(f);
+						File.Delete(existingOldLogs[i]);
 					}
 					catch (IOException) { }
 				}
@@ -27,8 +26,9 @@ namespace Terraria.ModLoader.Core
 				Directory.CreateDirectory(Logging.LogArchiveDir);
 			}
 
-			foreach (var logFile in Directory.GetFiles(Logging.LogDir, "*.old*"))
+			foreach (string logFile in Directory.GetFiles(Logging.LogDir, "*.old*")) {
 				Archive(logFile, Path.GetFileNameWithoutExtension(logFile));
+			}
 
 			DeleteOldArchives();
 		}
@@ -53,10 +53,11 @@ namespace Terraria.ModLoader.Core
 		}
 
 		private const int MAX_LOGS = 20;
+
 		private static void DeleteOldArchives() {
-			var pattern = new Regex(".*\\.zip");
-			var existingLogs = Directory.GetFiles(Logging.LogArchiveDir).Where(s => pattern.IsMatch(Path.GetFileName(s))).OrderBy(File.GetCreationTime).ToList();
-			foreach (var f in existingLogs.Take(existingLogs.Count - MAX_LOGS)) {
+			var existingLogs = Directory.GetFiles(Logging.LogArchiveDir, "*.zip").OrderBy(File.GetCreationTime).ToList();
+
+			foreach (string f in existingLogs.Take(existingLogs.Count - MAX_LOGS)) {
 				try {
 					File.Delete(f);
 				}

--- a/patches/tModLoader/Terraria.ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria.ModLoader/Logging.cs
@@ -23,6 +23,7 @@ namespace Terraria.ModLoader
 	public static class Logging
 	{
 		public static readonly string LogDir = Path.Combine(Program.SavePath, "Logs");
+		public static readonly string LogArchiveDir = Path.Combine(Path.Combine(Program.SavePath, "Logs"), "Old");
 		public static string LogPath { get; private set; }
 
 		internal static ILog Terraria { get; } = LogManager.GetLogger("Terraria");

--- a/patches/tModLoader/Terraria.ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria.ModLoader/Logging.cs
@@ -23,7 +23,7 @@ namespace Terraria.ModLoader
 	public static class Logging
 	{
 		public static readonly string LogDir = Path.Combine(Program.SavePath, "Logs");
-		public static readonly string LogArchiveDir = Path.Combine(Path.Combine(Program.SavePath, "Logs"), "Old");
+		public static readonly string LogArchiveDir = Path.Combine(LogDir, "Old");
 		public static string LogPath { get; private set; }
 
 		internal static ILog Terraria { get; } = LogManager.GetLogger("Terraria");


### PR DESCRIPTION
### What is this change to tModLoader?
This pull request changes the way log archiving works, making archived logs go to Logs/Old and not Logs

![image](https://user-images.githubusercontent.com/45357714/81464780-ef927280-9207-11ea-8947-83a8e91c2999.png)

### Why should this be a part of tModLoader?
This should be a change seen in tModLoader because
- It helps declutter the Logs folder
The logs folder seems quite cluttered and adding that folder for old logs seems necessary.
- It will cause less confusion
When others and myself ask users to send their logs, they sometimes get confused and send an archived log zip when they should have sent their client.log.

### Do you have any different design thoughts?
A design choice I chose not to implement was zipping up the Old folder. I chose not to do this because it could be harder to access archived logs.
Another choice I chose to not implement was moving old archived logs to the Old folder and not just deleting them. I chose not to do this because I thought no one would want to view logs they had from another version of tModLoader because they would most likely be irrelevant.
Another choice was to put LogsArchiveDir in LogArchiver but I put it in Logging for consistency.

### How did you test this to make sure it worked?
I tested this through my own built version of tModLoader. It worked perfectly with no problems.

### Do you have any other things you would like to mention?
The first commit changes nothing because I stuffed up, and that's why I committed a new commit fixing that. 