### PR TITLE
Add improved MessageBoxShow error messages

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.UI/Interface.cs
+++ b/patches/tModLoader/Terraria.ModLoader.UI/Interface.cs
@@ -378,12 +378,36 @@ namespace Terraria.ModLoader.UI
 		internal static void MessageBoxShow(string text, string caption = null) {
 			// MessageBox.Show fails on Mac, this method will open a text file to show a message.
 			caption = caption ?? "Terraria: Error" + $" ({ModLoader.versionedName})";
+			string message = $"{text}\n\nA client.log file containing error information has been generated in\n{Path.Combine(Main.SavePath, "Logs")}\n(You will need to share this file if asking for help)";
 #if !MAC
-			System.Windows.Forms.MessageBox.Show(text, caption);
+			System.Windows.Forms.MessageBox.Show(message, caption);
 #else
 			File.WriteAllText("fake-messagebox.txt", $"{caption}\n\n{text}");
 			Process.Start("fake-messagebox.txt");
 #endif
+		}
+
+		internal static void MessageBoxShow(Exception e, string caption = null, bool generateTip = false) {
+			string tip = "";
+
+			if (generateTip) {
+				if (e is OutOfMemoryException)
+					tip = "Try running less mods at once, or determine if a mod is taking up too much memory. Optionally, install 64-bit tModLoader";
+				else if (e is InvalidOperationException || e is NullReferenceException || e is IndexOutOfRangeException || e is ArgumentNullException)
+					tip = "This is likely a mod's fault. Disable mods one by one and check if the issue persists";
+				else if (e is IOException && e.Message.Contains("cloud file provider"))
+					tip = "Try installing/enabling OneDrive. Right click your Documents folder and enable \"Always save on this device\"";
+				else if (e is System.Threading.SynchronizationLockException)
+					tip = "If you have an antivirus, try adding Terraria to its whitelist/exclusion list";
+				else if (e is TypeInitializationException)
+					tip = "Restart the game. If this issue persists, try uninstalling Terraria completely, then reinstalling through Steam, and then reinstalling tModLoader";
+			}
+
+			string message = e.ToString();
+			if (tip != "")
+				message += $"\n\nTip: {tip}";
+
+			MessageBoxShow(message, caption);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -213,7 +213,7 @@
  
  #if CLIENT
 -				MessageBox.Show(e.ToString(), "Terraria: Error");
-+				ModLoader.UI.Interface.MessageBoxShow(e.ToString());
++				ModLoader.UI.Interface.MessageBoxShow(e, generateTip: true);
 +
 +				if (e is FolderCreationFailedException)
 +					Process.Start(e.HelpLink);


### PR DESCRIPTION
### What is the new feature?
Improving upon the error messages that are shown by `ModLoader.UI.Interface.MessageBoxShow` to point users towards their client.log file and, depending on the exception, provides a unique tip that may fix it.
(If tModLoader does not recognize the exception, no tip is shown, but it will still point you towards client.log)

### Why should this be part of tModLoader?
It may help alleviate constantly needing to provide users with the same solutions for frequent errors/exceptions by pointing them in the right direction immediately, allowing them to give it a shot at fixing the error themselves (or at least letting them know the importance of your client.log file 😛 ).

### Are there alternative designs?
Changing error messages, adding/removing exception tips, or just modifying what is shown in general.

### Sample usage for the new feature
These are examples of some of the new error messages (all exceptions shown here are manually thrown as Terraria is launching). There are other exception messages not shown here.
![image](https://user-images.githubusercontent.com/13611030/81501155-69e1f600-92df-11ea-8c74-0d716735a4f1.png)
![image](https://user-images.githubusercontent.com/13611030/81501201-a1e93900-92df-11ea-8642-a68ceb2da9fd.png)
![image](https://user-images.githubusercontent.com/13611030/81501222-c9400600-92df-11ea-8421-7bc0f2de04f1.png)
![image](https://user-images.githubusercontent.com/13611030/81501408-ec1eea00-92e0-11ea-8855-c70af6c74b93.png)


(P.S: The changes git detected are a little weird... not sure why. Sorry about that 😅 )