### PR TITLE
Improved stability of OutOfMemory handling

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria.ModLoader/Logging.cs
@@ -201,7 +201,7 @@ namespace Terraria.ModLoader
 			try {
 				handlerActive.Value = true;
 
-				if (oom)
+				if (!oom)
 					if (args.Exception == previousException ||
 						args.Exception is ThreadAbortException ||
 						ignoreSources.Contains(args.Exception.Source) ||
@@ -213,13 +213,13 @@ namespace Terraria.ModLoader
 				PrettifyStackTraceSources(stackTrace.GetFrames());
 				var traceString = stackTrace.ToString();
 
-				if (oom && ignoreContents.Any(traceString.Contains))
+				if (!oom && ignoreContents.Any(traceString.Contains))
 					return;
 
 				traceString = traceString.Substring(traceString.IndexOf('\n'));
 				var exString = args.Exception.GetType() + ": " + args.Exception.Message + traceString;
 				lock (pastExceptions) {
-					if (!pastExceptions.Add(exString) && oom)
+					if (!pastExceptions.Add(exString) && !oom)
 						return;
 				}
 

--- a/patches/tModLoader/Terraria.ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria.ModLoader/Logging.cs
@@ -201,13 +201,14 @@ namespace Terraria.ModLoader
 			try {
 				handlerActive.Value = true;
 
-				if (!oom)
+				if (!oom) {
 					if (args.Exception == previousException ||
 						args.Exception is ThreadAbortException ||
 						ignoreSources.Contains(args.Exception.Source) ||
 						ignoreMessages.Any(str => args.Exception.Message?.Contains(str) ?? false) ||
 						ignoreThrowingMethods.Any(str => args.Exception.StackTrace?.Contains(str) ?? false))
 						return;
+				}
 
 				var stackTrace = new StackTrace(true);
 				PrettifyStackTraceSources(stackTrace.GetFrames());

--- a/patches/tModLoader/Terraria.ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria.ModLoader/Logging.cs
@@ -220,7 +220,7 @@ namespace Terraria.ModLoader
 				traceString = traceString.Substring(traceString.IndexOf('\n'));
 				var exString = args.Exception.GetType() + ": " + args.Exception.Message + traceString;
 				lock (pastExceptions) {
-					if (!pastExceptions.Add(exString) && !oom)
+					if (!pastExceptions.Add(exString))
 						return;
 				}
 

--- a/patches/tModLoader/Terraria.ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria.ModLoader/Logging.cs
@@ -196,8 +196,6 @@ namespace Terraria.ModLoader
 				Main.tile = null;
 
 				GC.Collect();
-
-				oom = false;
 			}
 
 			try {


### PR DESCRIPTION
### What is the bug?
OutOfMemory may occur inside FirstChanceException when, for example, trying to allocate enough memory to show the message box.

### How did you fix the bug?
I added code to unload Main.tile array and call GC.Collect() as early in the method as possible, and also disabled any ways of blocking the handling of the exception.

### Are there alternatives to your fix?
This is the most practical solution, but not the most good looking.