### PR TITLE
Proposal: Use multiple cores to pre-JIT methods

### DIFF
--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/Program.cs
 +++ src/tModLoader/Terraria/Program.cs
-@@ -2,6 +_,7 @@
+@@ -2,20 +_,24 @@
  using ReLogic.OS;
  using System;
  using System.Collections.Generic;
@@ -8,7 +8,10 @@
  #if CLIENT
  using System.Diagnostics;
  #endif
-@@ -11,11 +_,13 @@
+ using System.IO;
++using System.Linq;
+ using System.Reflection;
+ using System.Runtime.CompilerServices;
  using System.Runtime.ExceptionServices;
  using System.Text;
  using System.Threading;
@@ -35,14 +38,107 @@
  		private static int ThingsToLoad = 0;
  		private static int ThingsLoaded = 0;
  		public static bool LoadedEverything = false;
-@@ -53,6 +_,7 @@
+@@ -53,27 +_,68 @@
  		public static void ForceLoadThread(object ThreadContext) {
  			ForceLoadAssembly(Assembly.GetExecutingAssembly(), initializeStaticMembers: true);
  			LoadedEverything = true;
 +			Logging.Terraria.Info("JIT loading finished");
  		}
  
- 		private static void ForceJITOnAssembly(Assembly assembly) {
+-		private static void ForceJITOnAssembly(Assembly assembly) {
+-			Type[] types = assembly.GetTypes();
+-			for (int i = 0; i < types.Length; i++) {
+-#if WINDOWS
+-				MethodInfo[] methods = types[i].GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+-#else
+-				MethodInfo[] methods = types[i].GetMethods();
+-#endif
+-				foreach (MethodInfo methodInfo in methods) {
+-					if (!methodInfo.IsAbstract && !methodInfo.ContainsGenericParameters && methodInfo.GetMethodBody() != null)
+-#if WINDOWS
+-						RuntimeHelpers.PrepareMethod(methodInfo.MethodHandle);
+-#else
+-						JitForcedMethodCache = methodInfo.MethodHandle.GetFunctionPointer();
+-#endif
++		private static void ForceJITOnAssembly(IEnumerable<Type> types)
++		{
++			var methodsToJIT = CollectMethodsToJIT(types);
++
++			if (Environment.ProcessorCount > 1) {
++				methodsToJIT.AsParallel().AsUnordered().ForAll(ForceJITOnMethod);
++			}
++			else {
++				foreach (var method in methodsToJIT) {
++					ForceJITOnMethod(method);
+ 				}
+-
+-				ThingsLoaded++;
+-			}
++			}
++		}
++
++		private static void ForceStaticInitializers(Type[] types)
++		{
++			foreach (Type type in types) {
++				if (!type.IsGenericType)
++					RuntimeHelpers.RunClassConstructor(type.TypeHandle);
++			}
++		}
++
++		private static void ForceLoadAssembly(Assembly assembly, bool initializeStaticMembers)
++		{
++			var types = assembly.GetTypes();
++			ThingsToLoad = types.Select(type => GetMethodsCrossPlatform(type).Count()).Sum();
++
++			ForceJITOnAssembly(types);
++			if (initializeStaticMembers) {
++				ForceStaticInitializers(types);
++			}
++		}
++
++		private static IEnumerable<MethodInfo> CollectMethodsToJIT(IEnumerable<Type> types) =>
++			from type in types
++			from method in GetMethodsCrossPlatform(type)
++			where !method.IsAbstract && !method.ContainsGenericParameters && method.GetMethodBody() != null
++			select method;
++
++		private static void ForceJITOnMethod(MethodInfo method)
++		{
++#if WINDOWS
++			RuntimeHelpers.PrepareMethod(method.MethodHandle);
++#else
++			// We don't synchronize access to JitForcedMethodCache because no one ever needs to read its value.
++			var methodPointer = method.MethodHandle.GetFunctionPointer();
++			JitForcedMethodCache = methodPointer;
++#endif
++
++			Interlocked.Increment(ref ThingsLoaded);
++		}
++
++		private static IEnumerable<MethodInfo> GetMethodsCrossPlatform(Type type)
++		{
++#if WINDOWS
++			return type.GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
++#else
++			return type.GetMethods();
++#endif
+ 		}
+ 
+ 		private static void ForceStaticInitializers(Assembly assembly) {
+@@ -84,13 +_,6 @@
+ 			}
+ 		}
+ 
+-		private static void ForceLoadAssembly(Assembly assembly, bool initializeStaticMembers) {
+-			ThingsToLoad = assembly.GetTypes().Length;
+-			ForceJITOnAssembly(assembly);
+-			if (initializeStaticMembers)
+-				ForceStaticInitializers(assembly);
+-		}
+-
+ 		private static void ForceLoadAssembly(string name, bool initializeStaticMembers) {
+ 			Assembly assembly = null;
+ 			Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
 @@ -160,25 +_,47 @@
  			}
  		}


### PR DESCRIPTION
Terraria uses only a single core to pre-JIT its methods during startup. Using multiple cores can speed this up. The difference is quite noticeable on my i7-4800MQ (8 cores) with tML 1.3 or vanilla 1.4. I expect that the time spent loading mods will dwarf the pre-JIT time on most end-user machines, but every little bit helps, especially when you're developing or testing code.

Topics for discussion:

- Is this of interest to tML at all? If all developers are assumed to be using the QuickLaunch startup option to bypass the pre-JIT step entirely, there won't be as much point to having it.
- The number of cores used is at the TPL's discretion. There could be configuration for this.
- Projectile.VanillaAI and (especially) NPC.VanillaAI take much longer to JIT than anything else does. They could be started before the rest of the methods, given priority, and be configured to not block the loading process from finishing; they would probably be done by the time anyone needs to call them. When I tested this with tML on my machine, Terraria went straight from the splash screen to loading tML without having to show the "Loading: x%" message in between. This would add complexity, though; tasks would need to be created individually since AsParallel doesn't allow TaskCreationOptions.PreferFairness to be used or await some tasks but not others.