### PR TITLE
Fixed 'File already exists' in LogArchiver.MoveOldLogs()

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.Core/LogArchiver.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Core/LogArchiver.cs
@@ -68,7 +68,7 @@ namespace Terraria.ModLoader.Core
 				try {
 					string destination = Path.Combine(Logging.LogArchiveDir, Path.GetFileName(log));
 
-					if(File.Exists(destination)) {
+					if (File.Exists(destination)) {
 						File.Delete(destination);
 					}
 

--- a/patches/tModLoader/Terraria.ModLoader.Core/LogArchiver.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Core/LogArchiver.cs
@@ -66,7 +66,13 @@ namespace Terraria.ModLoader.Core
 		{
 			foreach (string log in GetLogs()) {
 				try {
-					File.Move(log, Path.Combine(Logging.LogArchiveDir, Path.GetFileName(log)));
+					string destination = Path.Combine(Logging.LogArchiveDir, Path.GetFileName(log));
+
+					if(File.Exists(destination)) {
+						File.Delete(destination);
+					}
+
+					File.Move(log, destination);
 				}
 				catch (Exception e) {
 					Logging.tML.Error(e);
@@ -80,7 +86,6 @@ namespace Terraria.ModLoader.Core
 
 		private static void Archive(string logFile, string entryName)
 		{
-
 			DateTime time;
 			try {
 				time = File.GetCreationTime(logFile);


### PR DESCRIPTION
Simple fix for [this log](https://paste.mod.gg/gitiqazoji.cs), i.e:
```
System.IO.IOException: Cannot create a file when that file already exists.

   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.__Error.WinIOError()
   at System.IO.File.InternalMove(String sourceFileName, String destFileName, Boolean checkHost)
   at Terraria.ModLoader.Core.LogArchiver.MoveOldLogs()
   at Terraria.ModLoader.Logging.Init()
   at Terraria.Program.LaunchGame(String[] args, Boolean monoArgs)
   at Terraria.WindowsLaunch.Main(String[] args)
```