### PR TITLE
Add PaintID

### DIFF
--- a/patches/tModLoader/Terraria.ID/PaintID.cs
+++ b/patches/tModLoader/Terraria.ID/PaintID.cs
@@ -1,0 +1,38 @@
+﻿namespace Terraria.ID
+{
+	public static class PaintID
+	{
+		// Name derived from the item name associated with the paint
+		public const byte Red = 1;
+		public const byte Orange = 2;
+		public const byte Yellow = 3;
+		public const byte Lime = 4;
+		public const byte Green = 5;
+		public const byte Teal = 6;
+		public const byte Cyan = 7;
+		public const byte SkyBlue = 8;
+		public const byte Blue = 9;
+		public const byte Purple = 10;
+		public const byte Violet = 11;
+		public const byte Pink = 12;
+		public const byte DeepRed = 13;
+		public const byte DeepOrange = 14;
+		public const byte DeepYellow = 15;
+		public const byte DeepLime = 16;
+		public const byte DeepGreen = 17;
+		public const byte DeepTeal = 18;
+		public const byte DeepCyan = 19;
+		public const byte DeepSkyBlue = 20;
+		public const byte DeepBlue = 21;
+		public const byte DeepPurple = 22;
+		public const byte DeepViolet = 23;
+		public const byte DeepPink = 24;
+		public const byte Black = 25;
+		public const byte White = 26;
+		public const byte Gray = 27;
+		public const byte Brown = 28;
+		public const byte Shadow = 29;
+		public const byte Negative = 30;
+		public const byte Count = 30;
+	}
+}


### PR DESCRIPTION
### What is the new feature?
Adds a class containing magic numbers associated with paints for tiles and walls, such as:
`public const byte Violet = 11;`

### Why should this be part of tModLoader?
Heavily improves access to paints and their readability.

### Are there alternative designs?
How I did it before this to sort of "humanize" paints is create an item cache of valid paint items, and then access their paint through a dictionary so it would look like this: 
`byte paint = PaintCache[ItemID.RedPaint];`

### Sample usage for the new feature
```cs
byte paint = PaintID.Red;
WorldGen.paintTile(i, j, paint);
WorldGen.paintWall(i, j, paint);
```

### ExampleMod updates
Doesn't seem like something needing a showcase as it's a simple replacement for magic numbers
