### PR TITLE
Make MessageBox texts localizable

### DIFF
--- a/patches/Terraria/Terraria/Program.cs.patch
+++ b/patches/Terraria/Terraria/Program.cs.patch
@@ -78,8 +78,9 @@
  					streamWriter.WriteLine("");
  				}
  
+-				MessageBox.Show(e.ToString(), "Terraria: Error");
 +#if CLIENT
- 				MessageBox.Show(e.ToString(), "Terraria: Error");
++				MessageBox.Show(e.ToString(), Language.GetTextValue("Error.Error"));
 +#else
 +				Console.WriteLine(Language.GetTextValue("Error.ServerCrash"), DateTime.Now, e);
 +#endif

--- a/patches/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
@@ -343,6 +343,8 @@
 		"ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",
 		"MissingServerExecutable": "Looks like you didn't do a complete install. You are missing tModLoaderServer.exe. Check your install directory and read the install directions.",
 		"GraphicsEngineFailure": "Graphics Engine Failure",
+		"GraphicsEngineReportUnknown": "Unknown",
+		"GraphicsEngineReportFailure": "Failure",
 		"GraphicsEngineFailureMessage": "tML encountered a crash when testing some experimental graphics features. If this issue persists consistently, you may have to edit config.json and set the Support4K setting to false. \nPlease restart your game.\nReport Status: {0}",
 		"OutOfMemory": "Game ran out of memory. You'll have to find which mod is consuming lots of memory, and contact the devs or remove it.",
 		"ContentFolderNotFoundInstallCheck": "{0} directory could not be found.\r\n\r\nDid you forget to extract tModLoader's Content directory into the tModLoader folder?\r\n\r\nEnsure tModLoader is installed in a separate folder from Terraria.",

--- a/patches/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
@@ -337,7 +337,7 @@
 		"PatreonSetTooltip": "Thank you for your support!",
 		"WorldGenError": "A problem was encountered during world generation",
 		"WorldIODataException": "The game encountered a mod data problem for a world.",
-		"ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord"
+		"ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
 
 		// MessageBox
 		"ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",
@@ -351,7 +351,7 @@
 		"VanillaSteamInstallationNotFound": "Terraria Steam installation or Terraria Content directory not found.\r\n\r\nPlease ensure Terraria 1.4 is installed through Steam.",
 		"SteamAPIHashMismatch": "Steam API hash mismatch, assumed pirated.\n\ntModLoader requires a legitimate Terraria install to work.",
 		"VanillaGOGNotFound": "{0} could not be found.\r\n\r\nGOG installs must have the unmodified Terraria executable to function.",
-		"GOGHashMismatch": "{0} is not the unmodified Terraria executable.\r\n\r\nGOG installs must have the unmodified Terraria executable to function.\r\n\r\nIf you patched the .exe, you can create a copy of the original exe and name it \"Terraria_v<VERSION>.exe\"",
+		"GOGHashMismatch": "{0} is not the unmodified Terraria executable.\r\n\r\nGOG installs must have the unmodified Terraria executable to function.\r\n\r\nIf you patched the .exe, you can create a copy of the original exe and name it \"Terraria_v<VERSION>.exe\""
 	},
 	"CommonItemTooltip": {
 		"PercentIncreasedDamage": "{0}% increased damage"

--- a/patches/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
@@ -338,6 +338,18 @@
 		"WorldGenError": "A problem was encountered during world generation",
 		"WorldIODataException": "The game encountered a mod data problem for a world.",
 		"ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord"
+
+		// MessageBox
+		"ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",
+		"MissingServerExecutable": "Looks like you didn't do a complete install. You are missing tModLoaderServer.exe. Check your install directory and read the install directions.",
+		"GraphicsEngineFailure": "Graphics Engine Failure",
+		"GraphicsEngineFailureMessage": "tML encountered a crash when testing some experimental graphics features. If this issue persists consistently, you may have to edit config.json and set the Support4K setting to false. \nPlease restart your game.\nReport Status: {0}",
+		"OutOfMemory": "Game ran out of memory. You'll have to find which mod is consuming lots of memory, and contact the devs or remove it.",
+		"ContentFolderNotFoundInstallCheck": "{0} directory could not be found.\r\n\r\nDid you forget to extract tModLoader's Content directory into the tModLoader folder?\r\n\r\nEnsure tModLoader is installed in a separate folder from Terraria.",
+		"VanillaSteamInstallationNotFound": "Terraria Steam installation or Terraria Content directory not found.\r\n\r\nPlease ensure Terraria 1.4 is installed through Steam.",
+		"SteamAPIHashMismatch": "Steam API hash mismatch, assumed pirated.\n\ntModLoader requires a legitimate Terraria install to work.",
+		"VanillaGOGNotFound": "{0} could not be found.\r\n\r\nGOG installs must have the unmodified Terraria executable to function.",
+		"GOGHashMismatch": "{0} is not the unmodified Terraria executable.\r\n\r\nGOG installs must have the unmodified Terraria executable to function.\r\n\r\nIf you patched the .exe, you can create a copy of the original exe and name it \"Terraria_v<VERSION>.exe\"",
 	},
 	"CommonItemTooltip": {
 		"PercentIncreasedDamage": "{0}% increased damage"

--- a/patches/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
@@ -351,7 +351,8 @@
 		"VanillaSteamInstallationNotFound": "Terraria Steam installation or Terraria Content directory not found.\r\n\r\nPlease ensure Terraria 1.4 is installed through Steam.",
 		"SteamAPIHashMismatch": "Steam API hash mismatch, assumed pirated.\n\ntModLoader requires a legitimate Terraria install to work.",
 		"VanillaGOGNotFound": "{0} could not be found.\r\n\r\nGOG installs must have the unmodified Terraria executable to function.",
-		"GOGHashMismatch": "{0} is not the unmodified Terraria executable.\r\n\r\nGOG installs must have the unmodified Terraria executable to function.\r\n\r\nIf you patched the .exe, you can create a copy of the original exe and name it \"Terraria_v<VERSION>.exe\""
+		"GOGHashMismatch": "{0} is not the unmodified Terraria executable.\r\n\r\nGOG installs must have the unmodified Terraria executable to function.\r\n\r\nIf you patched the .exe, you can create a copy of the original exe and name it \"Terraria_v<VERSION>.exe\"",
+		"DefaultExtraMessage": "Please restore your Terraria install, then install tModLoader on Steam or by following the README.txt instructions for manual installation."
 	},
 	"CommonItemTooltip": {
 		"PercentIncreasedDamage": "{0}% increased damage"

--- a/patches/tModLoader/Terraria.ModLoader.Engine/HiDefGraphicsIssues.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Engine/HiDefGraphicsIssues.cs
@@ -12,6 +12,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
+using Terraria.Localization;
 using Terraria.ModLoader.IO;
 
 namespace Terraria.ModLoader.Engine

--- a/patches/tModLoader/Terraria.ModLoader.Engine/HiDefGraphicsIssues.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Engine/HiDefGraphicsIssues.cs
@@ -134,11 +134,11 @@ namespace Terraria.ModLoader.Engine
 			}
 
 			//var modsAffected = ModContent.HiDefMods.Count == 0 ? "No mods will be affected." : $"The following mods will be affected {string.Join(", ", ModContent.HiDefMods.Select(m => m.DisplayName))}";
-			string message = $"tML encountered a crash when testing some experimental graphics features. If this issue persists consistently, you may have to edit config.json and set the Support4K setting to false. \nPlease restart your game.\nReport Status: {reportStatus}";
+			string message = Language.GetTextValue("tModLoader.GraphicsEngineFailureMessage", reportStatus);
 #if !MAC
-			MessageBox.Show(message, "Graphics Engine Failure", MessageBoxButtons.OK, MessageBoxIcon.Error);
+			MessageBox.Show(message, Language.GetTextValue("tModLoader.GraphicsEngineFailure"), MessageBoxButtons.OK, MessageBoxIcon.Error);
 #else
-			UI.Interface.MessageBoxShow(message, "Graphics Engine Failure");
+			UI.Interface.MessageBoxShow(message, Language.GetTextValue("tModLoader.GraphicsEngineFailure"));
 #endif
 			Environment.Exit(1);
 		}

--- a/patches/tModLoader/Terraria.ModLoader.Engine/HiDefGraphicsIssues.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Engine/HiDefGraphicsIssues.cs
@@ -112,7 +112,7 @@ namespace Terraria.ModLoader.Engine
 			Logging.tML.Debug("Disabled Main.Support4K");
 			*/
 
-			string reportStatus = "Unknown";
+			string reportStatus = Language.GetTextValue("tModLoader.GraphicsEngineReportUnknown");
 			log4net.LogManager.Shutdown();
 			string logContents = System.IO.File.ReadAllText(Logging.LogPath);
 			try {
@@ -130,7 +130,7 @@ namespace Terraria.ModLoader.Engine
 			}
 			catch {
 				// Can't log since log4net.LogManager.Shutdown happened.
-				reportStatus = "Failure";
+				reportStatus = Language.GetTextValue("tModLoader.GraphicsEngineReportFailure");
 			}
 
 			//var modsAffected = ModContent.HiDefMods.Count == 0 ? "No mods will be affected." : $"The following mods will be affected {string.Join(", ", ModContent.HiDefMods.Select(m => m.DisplayName))}";

--- a/patches/tModLoader/Terraria.ModLoader.Engine/InstallVerifier.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Engine/InstallVerifier.cs
@@ -48,7 +48,7 @@ namespace Terraria.ModLoader.Engine
 			else {
 				string message = "Unknown OS platform: unable to verify installation.";
 				Logging.tML.Fatal(message);
-				Exit(message, string.Empty);
+				Exit(Language.GetTextValue("tModLoader.UnknownVerificationOS"), string.Empty);
 			}
 		}
 
@@ -79,7 +79,7 @@ namespace Terraria.ModLoader.Engine
 #if CLIENT
 			// Check if the content directory is present which is required
 			if (!Directory.Exists(ContentDirectory)) {
-				Exit($"{ContentDirectory} directory could not be found.\r\n\r\nDid you forget to extract tModLoader's Content directory into the tModLoader folder?\r\n\r\nEnsure tModLoader is installed in a separate folder from Terraria.");
+				Exit(Language.GetTextValue("tModLoader.ContentFolderNotFoundInstallCheck", ContentDirectory));
 				return false;
 			}
 #endif
@@ -100,13 +100,13 @@ namespace Terraria.ModLoader.Engine
 			string terrariaInstallLocation = Steam.GetSteamTerrariaInstallDir();
 
 			if (!Directory.Exists(Path.Combine(terrariaInstallLocation, ContentDirectory))) {
-				Exit($"Terraria Steam installation or Terraria Content directory not found.\r\n\r\nPlease ensure Terraria 1.4 is installed through Steam.");
+				Exit(Language.GetTextValue("tModLoader.VanillaSteamInstallationNotFound"));
 				return false;
 			}
 #endif
 			if (!HashMatchesFile(steamAPIPath, steamAPIHash)) {
 				Process.Start(@"https://terraria.org");
-				Exit("Steam API hash mismatch, assumed pirated.\n\ntModLoader requires a legitimate Terraria install to work.", string.Empty);
+				Exit(Language.GetTextValue("tModLoader.SteamAPIHashMismatch"), string.Empty);
 				return false;
 			}
 
@@ -142,13 +142,13 @@ namespace Terraria.ModLoader.Engine
 #if SERVER
 				return false;
 #else
-				Exit($"{vanillaPath} could not be found.\r\n\r\nGOG installs must have the unmodified Terraria executable to function.", string.Empty);
+				Exit(Language.GetTextValue("tModLoader.VanillaGOGNotFound", vanillaPath), string.Empty);
 				return false;
 #endif
 			}
 
 			if (!HashMatchesFile(vanillaPath, gogHash)) {
-				Exit($"{vanillaPath} is not the unmodified Terraria executable.\r\n\r\nGOG installs must have the unmodified Terraria executable to function.\r\n\r\nIf you patched the .exe, you can create a copy of the original exe and name it \"Terraria_v<VERSION>.exe\"", string.Empty);
+				Exit(Language.GetTextValue("tModLoader.GOGHashMismatch", vanillaPath), string.Empty);
 				return false;
 			}
 
@@ -157,3 +157,4 @@ namespace Terraria.ModLoader.Engine
 		}
 	}
 }
+l

--- a/patches/tModLoader/Terraria.ModLoader.Engine/InstallVerifier.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Engine/InstallVerifier.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
+using Terraria.Localization;
 using Terraria.Social;
 
 namespace Terraria.ModLoader.Engine

--- a/patches/tModLoader/Terraria.ModLoader.Engine/InstallVerifier.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Engine/InstallVerifier.cs
@@ -14,7 +14,6 @@ namespace Terraria.ModLoader.Engine
 	internal static class InstallVerifier
 	{
 		const string ContentDirectory = "Content";
-		const string InstallInstructions = "Please restore your Terraria install, then install tModLoader on Steam or by following the README.txt instructions for manual installation.";
 
 		private static bool? isValid;
 		public static bool IsValid => isValid ?? (isValid = InstallCheck()).Value;
@@ -47,9 +46,9 @@ namespace Terraria.ModLoader.Engine
 				steamHash = ToByteArray("6c496fa6d23f200eed209544c6c12502");
 			}
 			else {
-				string message = "Unknown OS platform: unable to verify installation.";
+				string message = Language.GetTextValue("tModLoader.UnknownVerificationOS");
 				Logging.tML.Fatal(message);
-				Exit(Language.GetTextValue("tModLoader.UnknownVerificationOS"), string.Empty);
+				Exit(message, string.Empty);
 			}
 		}
 
@@ -67,7 +66,7 @@ namespace Terraria.ModLoader.Engine
 				retval[i / 2] = Convert.ToByte(hexString.Substring(i, 2), 16);
 			return retval;
 		}
-		private static void Exit(string errorMessage, string extraMessage = InstallInstructions)
+		private static void Exit(string errorMessage, string extraMessage)
 		{
 			errorMessage += $"\r\n\r\n{extraMessage}";
 			Logging.tML.Fatal(errorMessage);
@@ -80,7 +79,7 @@ namespace Terraria.ModLoader.Engine
 #if CLIENT
 			// Check if the content directory is present which is required
 			if (!Directory.Exists(ContentDirectory)) {
-				Exit(Language.GetTextValue("tModLoader.ContentFolderNotFoundInstallCheck", ContentDirectory));
+				Exit(Language.GetTextValue("tModLoader.ContentFolderNotFoundInstallCheck", ContentDirectory), Language.GetTextValue("tModLoader.DefaultExtraMessage"));
 				return false;
 			}
 #endif
@@ -101,7 +100,7 @@ namespace Terraria.ModLoader.Engine
 			string terrariaInstallLocation = Steam.GetSteamTerrariaInstallDir();
 
 			if (!Directory.Exists(Path.Combine(terrariaInstallLocation, ContentDirectory))) {
-				Exit(Language.GetTextValue("tModLoader.VanillaSteamInstallationNotFound"));
+				Exit(Language.GetTextValue("tModLoader.VanillaSteamInstallationNotFound"), Language.GetTextValue("tModLoader.DefaultExtraMessage"));
 				return false;
 			}
 #endif
@@ -158,4 +157,3 @@ namespace Terraria.ModLoader.Engine
 		}
 	}
 }
-l

--- a/patches/tModLoader/Terraria.ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria.ModLoader/Logging.cs
@@ -238,9 +238,9 @@ namespace Terraria.ModLoader
 				tML.Warn(Language.GetTextValue("tModLoader.RuntimeErrorSilentlyCaughtException") + '\n' + exString);
 
 				if (oom) {
-					const string error = "Game ran out of memory. You'll have to find which mod is consuming lots of memory, and contact the devs or remove it.";
+					string error = Language.GetTextValue("tModLoader.OutOfMemory");
 					Logging.tML.Fatal(error);
-					Interface.MessageBoxShow(Language.GetTextValue("tModLoader.OutOfMemory"));
+					Interface.MessageBoxShow(error);
 					Environment.Exit(1);
 				}
 			}

--- a/patches/tModLoader/Terraria.ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria.ModLoader/Logging.cs
@@ -240,7 +240,7 @@ namespace Terraria.ModLoader
 				if (oom) {
 					const string error = "Game ran out of memory. You'll have to find which mod is consuming lots of memory, and contact the devs or remove it.";
 					Logging.tML.Fatal(error);
-					Interface.MessageBoxShow(error);
+					Interface.MessageBoxShow(Language.GetTextValue("tModLoader.OutOfMemory"));
 					Environment.Exit(1);
 				}
 			}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -799,7 +799,7 @@
 +				Logging.Terraria.Info($"Steam Cloud Quota: {UIMemoryBar.SizeSuffix((long)puAvailableBytes)} available");
 +			}
 +			if (!Directory.Exists(vanillaContentFolder)) {
-+				Interface.MessageBoxShow("Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.");
++				Interface.MessageBoxShow(Language.GetTextValue("tModLoader.ContentFolderNotFound"));
 +				Environment.Exit(1);
 +			}
 +

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -222,7 +222,7 @@
 +					Process.Start(@"https://github.com/tModLoader/tModLoader/wiki/Basic-tModLoader-Usage-FAQ#systemdllnotfoundexception-unable-to-load-dllcsteamworks");
 +
 +				if (e.StackTrace.Contains("LaunchLocalServer")) {
-+					ModLoader.UI.Interface.MessageBoxShow("Looks like you didn't do a complete install. You are missing tModLoaderServer.exe. Check your install directory and read the install directions.");
++					ModLoader.UI.Interface.MessageBoxShow(Language.GetTextValue("tModLoader.MissingServerExecutable"));
 +
 +					Process.Start(@"https://github.com/tModLoader/tModLoader/wiki/Basic-tModLoader-Usage-FAQ#host-and-play-the-system-cannot-find-the-file-specified");
 +				}


### PR DESCRIPTION
Make `MessageBox` texts localizable, resolves #955

I'm not sure if the logging part should be localizable (which might break some format), so only `MessageBox` related strings were added right now.