### PR TITLE
Remove hash check, serves no useful purpose

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.Engine/InstallVerifier.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Engine/InstallVerifier.cs
@@ -104,11 +104,6 @@ namespace Terraria.ModLoader.Engine
 				return false;
 			}
 #endif
-			if (!HashMatchesFile(steamAPIPath, steamAPIHash)) {
-				Process.Start(@"https://terraria.org");
-				Exit("Steam API hash mismatch, assumed pirated.\n\ntModLoader requires a legitimate Terraria install to work.", string.Empty);
-				return false;
-			}
 
 			Logging.tML.Info("Steam installation OK.");
 			return true;


### PR DESCRIPTION
Simply put, it is not our job to make pirates' lives difficult. That is Re-Logic's job, if they choose to do so. This hash check has a zero chance of helping the end user, and a nonzero chance of causing frustration, even if the game is not pirated. What if the user bought it on Steam and wants to replace it with a cracked DLL to avoid difficulties with offline mode? What if there's an update that changes the DLL, but wouldn't otherwise break compatibility with tModLoader? Having it exit with an error in these cases is bad enough, and if it happens for a reason like this, that just adds insult to injury.