### PR TITLE
Lowered main menu button Y position

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.UI/Interface.cs
+++ b/patches/tModLoader/Terraria.ModLoader.UI/Interface.cs
@@ -74,7 +74,7 @@ namespace Terraria.ModLoader.UI
 				buttonNames[buttonIndex] = Language.GetTextValue("tModLoader.MenuModSources");
 				if (selectedMenu == buttonIndex) {
 					Main.PlaySound(10, -1, -1, 1);
-					Main.menuMode = ModCompile.DeveloperModeReady(out var _) ? modSourcesID : developerModeHelpID;
+					Main.menuMode = ModCompile.DeveloperModeReady(out _) ? modSourcesID : developerModeHelpID;
 				}
 				buttonIndex++;
 				numButtons++;
@@ -86,7 +86,7 @@ namespace Terraria.ModLoader.UI
 			}
 			buttonIndex++;
 			numButtons++;
-			offY = 220;
+			offY = 240; //220
 			for (int k = 0; k < numButtons; k++) {
 				buttonScales[k] = 0.82f;
 			}


### PR DESCRIPTION
### What is the new feature?
Lowered the Y position of the buttons on the main screen of the main menu by 20 pixels.

New:
![image](https://user-images.githubusercontent.com/45357714/83868275-f0b6b100-a76d-11ea-9a26-e3bf12bcdca3.png)

### Why should this be part of tModLoader?
Currently, the buttons clash with the new large tModLoader logo and it looks improper.

### Are there alternative designs?
Reduce how much the logo can scale up to.

### Sample usage for the new feature
N/A

### ExampleMod updates
<!-- If you also updated ExampleMod for your new feature, let us know here -->
N/A

### Notes
Also "fixed" a tiny mistake with `out var _` creating a variable when it doesn't need to :p
