### PR TITLE
Public ModCompile

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Core/ModCompile.cs
@@ -16,14 +16,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Terraria.Localization;
 using Terraria.ModLoader.Exceptions;
-using Terraria.ModLoader.UI;
 using Terraria.Utilities;
 
 namespace Terraria.ModLoader.Core
 {
 	// TODO further documentation
 	// TODO too many inner classes
-	internal class ModCompile
+	public class ModCompile
 	{
 		public interface IBuildStatus
 		{
@@ -55,8 +54,8 @@ namespace Terraria.ModLoader.Core
 
 		public static readonly string ModSourcePath = Path.Combine(Program.SavePath, "Mod Sources");
 
-		internal static readonly string modCompileDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "ModCompile");
-		internal static readonly string modCompileVersionPath = Path.Combine(modCompileDir, "version");
+		public static readonly string modCompileDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "ModCompile");
+		public static readonly string modCompileVersionPath = Path.Combine(modCompileDir, "version");
 
 		internal static string[] FindModSources()
 		{
@@ -67,11 +66,7 @@ namespace Terraria.ModLoader.Core
 		// Silence exception reporting in the chat unless actively modding.
 		public static bool activelyModding;
 
-		public static bool DeveloperMode {
-			get {
-				return Debugger.IsAttached || File.Exists(modCompileVersionPath) || Directory.Exists(ModSourcePath) && FindModSources().Length > 0;
-			}
-		}
+		public static bool DeveloperMode => Debugger.IsAttached || File.Exists(modCompileVersionPath) || Directory.Exists(ModSourcePath) && FindModSources().Length > 0;
 
 		internal static bool DeveloperModeReady(out string msg)
 		{


### PR DESCRIPTION
### What is the new feature?
Changed `ModCompile`, `modCompileDir` and `modCompileVersionPath` to `public`. I don't think paths can hurt anyone! They just wouldn't have to copy-paste the fields themselves :p

### Why should this be part of tModLoader?
Currently, a modder has to use reflection to see if a user is in developer mode or not. I know most people will never need to know stuff like that, but this caters towards the people who do.

### Are there alternative designs?
Making some of the fields/methods inside `ModCompile` `internal`

### Sample usage for the new feature
```cs
if (ModCompile.DeveloperMode)
    Main.NewText("The user is in developer mode!");
```

### ExampleMod updates
<!-- If you also updated ExampleMod for your new feature, let us know here -->
N/A

### Notes
Removed the unused `using Terraria.ModLoader.UI;` because VS had it underlined
Changed `DeveloperMode` to be a one-liner since VS had it underlined (I assume that means it's preferable?)
