### PR TITLE
Grapple target point hook + aiType

### DIFF
--- a/ExampleMod/Items/ExampleHook.cs
+++ b/ExampleMod/Items/ExampleHook.cs
@@ -122,6 +122,13 @@ namespace ExampleMod.Items
 			speed = 4;
 		}
 
+		public override void GrappleTargetPoint(Player player, ref float grappleX, ref float grappleY) {
+			Vector2 dirToPlayer = projectile.DirectionTo(player.Center);
+			float hangDist = 50f;
+			grappleX += dirToPlayer.X * hangDist;
+			grappleY += dirToPlayer.Y * hangDist;
+		}
+
 		public override bool PreDraw(SpriteBatch spriteBatch, Color lightColor) {
 			Vector2 playerCenter = Main.player[projectile.owner].MountedCenter;
 			Vector2 center = projectile.Center;

--- a/patches/tModLoader/Terraria.ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalProjectile.cs
@@ -396,9 +396,6 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// The location that the grappling hook pulls the player to. Defaults to the center of the hook projectile.
 		/// </summary>
-		/// <param name="player">The player</param>
-		/// <param name="grappleX">X coordinate of the position to grapple to</param>
-		/// <param name="grappleY">Y coordinate of the position to grapple to</param>
 		public virtual void GrappleTargetPoint(Projectile projectile, Player player, ref float grappleX, ref float grappleY) {
 		}
 	}

--- a/patches/tModLoader/Terraria.ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalProjectile.cs
@@ -392,5 +392,14 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public virtual void GrapplePullSpeed(Projectile projectile, Player player, ref float speed) {
 		}
+
+		/// <summary>
+		/// The location that the grappling hook pulls the player to. Defaults to the center of the hook projectile.
+		/// </summary>
+		/// <param name="player">The player</param>
+		/// <param name="grappleX">X coordinate of the position to grapple to</param>
+		/// <param name="grappleY">Y coordinate of the position to grapple to</param>
+		public virtual void GrappleTargetPoint(Projectile projectile, Player player, ref float grappleX, ref float grappleY) {
+		}
 	}
 }

--- a/patches/tModLoader/Terraria.ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModProjectile.cs
@@ -436,6 +436,15 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// The location that the grappling hook pulls the player to. Defaults to the center of the hook projectile.
+		/// </summary>
+		/// <param name="player">The player</param>
+		/// <param name="grappleX">X coordinate of the position to grapple to</param>
+		/// <param name="grappleY">Y coordinate of the position to grapple to</param>
+		public virtual void GrappleTargetPoint(Player player, ref float grappleX, ref float grappleY) {
+		}
+
+		/// <summary>
 		/// When used in conjunction with "projectile.hide = true", allows you to specify that this projectile should be drawn behind certain elements. Add the index to one and only one of the lists. For example, the Nebula Arcanum projectile draws behind NPCs and tiles.
 		/// </summary>
 		public virtual void DrawBehind(int index, List<int> drawCacheProjsBehindNPCsAndTiles, List<int> drawCacheProjsBehindNPCs, List<int> drawCacheProjsBehindProjectiles, List<int> drawCacheProjsOverWiresUI) {

--- a/patches/tModLoader/Terraria.ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModProjectile.cs
@@ -438,9 +438,6 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// The location that the grappling hook pulls the player to. Defaults to the center of the hook projectile.
 		/// </summary>
-		/// <param name="player">The player</param>
-		/// <param name="grappleX">X coordinate of the position to grapple to</param>
-		/// <param name="grappleY">Y coordinate of the position to grapple to</param>
 		public virtual void GrappleTargetPoint(Player player, ref float grappleX, ref float grappleY) {
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ProjectileLoader.cs
@@ -626,6 +626,17 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		private delegate void DelegateGrappleTargetPoint(Projectile projectile, Player player, ref float grappleX, ref float grappleY);
+		private static HookList HookGrappleTargetPoint = AddHook<DelegateGrappleTargetPoint>(g => g.GrappleTargetPoint);
+
+		public static void GrappleTargetPoint(Projectile projectile, Player player, ref float grappleX, ref float grappleY) {
+			projectile.modProjectile?.GrappleTargetPoint(player, ref grappleX, ref grappleY);
+
+			foreach(GlobalProjectile g in HookGrappleTargetPoint.arr) {
+				g.Instance(projectile).GrappleTargetPoint(projectile, player, ref grappleX, ref grappleY);
+			}
+		}
+
 		private static HookList HookDrawBehind = AddHook<Action<Projectile, int, List<int>, List<int>, List<int>, List<int>>>(g => g.DrawBehind);
 
 		internal static void DrawBehind(Projectile projectile, int index, List<int> drawCacheProjsBehindNPCsAndTiles, List<int> drawCacheProjsBehindNPCs, List<int> drawCacheProjsBehindProjectiles, List<int> drawCacheProjsOverWiresUI) {

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1658,6 +1658,29 @@
  			velocity.Y -= num * gravDir;
  			if (gravDir == 1f) {
  				if (velocity.Y > 0f)
+@@ -13977,6 +_,11 @@
+ 			float num3 = 0f;
+ 			for (int i = 0; i < grapCount; i++) {
+ 				Projectile projectile = Main.projectile[grappling[i]];
++				int type = projectile.type;
++				bool useAiType = projectile.modProjectile != null && projectile.modProjectile.aiType > 0;
++				if(useAiType) {
++					projectile.type = projectile.modProjectile.aiType;
++				}
+ 				num2 += projectile.position.X + (float)(projectile.width / 2);
+ 				num3 += projectile.position.Y + (float)(projectile.height / 2);
+ 				if (projectile.type == 403) {
+@@ -14017,6 +_,10 @@
+ 					num2 += 0f - vector4.X + value.X * num5;
+ 					num3 += 0f - vector4.Y + value.Y * num5;
+ 				}
++				if(useAiType) {
++					projectile.type = type;
++				}
++				ProjectileLoader.GrappleTargetPoint(projectile, this, ref num2, ref num3);
+ 			}
+ 
+ 			num2 /= (float)grapCount;
 @@ -14032,6 +_,7 @@
  			if (Main.projectile[grappling[0]].type >= 646 && Main.projectile[grappling[0]].type <= 649)
  				num9 = 13f;


### PR DESCRIPTION
### What is the new feature?
Adds a new hook, called `GrappleTargetPoint`, which allows changing the position a grappling hook pulls the player towards.
Also adds the ability to use `ModProjectile.aiType` to use the vanilla implementations of `TrackHook`, `AntiGravityHook`, and `StaticHook`.
### Why should this be part of tModLoader?
Currently it is not possible to create grappling hooks similar to the Anti-Gravity Hook or Static Hook without IL editing or completely overriding the regular grapple code. This would allow it.
### Are there alternative designs?
Using IL patches or completely overriding the `Player.GrappleMovement` functionality with custom code
### Sample usage for the new feature
See included ExampleMod example
### ExampleMod updates
<!-- If you also updated ExampleMod for your new feature, let us know here -->
Updated `ExampleHook.cs` to include a sample usage of this feature, which causes ExampleHook to suspend the player 50px away from the hook's position rather than pulling them all the way.
![hoooook](https://user-images.githubusercontent.com/577969/84597957-4148a100-ae35-11ea-8017-3f282f8e2997.gif)
