### PR TITLE
Fix issue with BasicSword not clearing during Mod Creation

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.UI/UICreateMod.cs
+++ b/patches/tModLoader/Terraria.ModLoader.UI/UICreateMod.cs
@@ -124,6 +124,7 @@ namespace Terraria.ModLoader.UI
 		{
 			base.OnActivate();
 			_modName.SetText("");
+			_basicSword.SetText("");
 			_modDiplayName.SetText("");
 			_modAuthor.SetText("");
 			_messagePanel.SetText("");


### PR DESCRIPTION
Resolves tModLoader/tModLoader#987

### What is the bug?
The BasicSword input does not clear properly from the Mod Sources > Create Mod screen

### How did you fix the bug?
Added a SetText("") reset to the OnActivate() function that matches how we are resetting the other inputs on this screen.

### Are there alternatives to your fix?
None known. This is a simple change that matches existing patterns.