### PR TITLE
Fix ModTileEntities not unloading properly

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModContent.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Terraria.DataStructures;
 using Terraria.GameContent.UI;
 using Terraria.GameInput;
 using Terraria.Localization;
@@ -613,6 +614,8 @@ namespace Terraria.ModLoader
 				Main.projectile[i] = new Projectile();
 				// projectile.whoAmI is only set for active projectiles
 			}
+
+			TileEntity.Clear(); // drop all possible references to mod TEs
 		}
 
 		public static Stream OpenRead(string assetName, bool newFileStream = false) {


### PR DESCRIPTION
### What is the bug?

Tile Entities would not unload properly when mods are unloaded - this causes mods that add ModTileEntities to display the "not fully unloaded" warning (and the TEs would still nastily live on in memory, causing issues for some mods). Issue is documented in #762.

### How did you fix the bug?

Add a `TileEntity.Clear();` in `ModContent.CleanupModReferences`

### Are there alternatives to your fix?

maybe?