### PR TITLE
New item constructor that lets you specify a type.

### DIFF
--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -48,6 +48,19 @@
  		public bool isAShopItem;
  		public short hairDye = -1;
  		public byte paint;
+@@ -156,6 +_,12 @@
+ 		public const int WALL_PLACEMENT_USETIME = 7;
+ 		public static int numberOfNewItems = 0;
+ 
++		public Item() { } // EntryFilter complains if item doesn't have a parameterless constructor (even when the parameter is optional).
++
++		public Item(int setDefaultsToType) {
++			SetDefaults(setDefaultsToType);
++		}
++
+ 		public string Name => _nameOverride ?? Lang.GetItemNameValue(type);
+ 
+ 		public string HoverName {
 @@ -177,11 +_,11 @@
  			}
  		}


### PR DESCRIPTION
### What is the new feature?
A new constructor for Item that lets you supply a type.

### Why should this be part of tModLoader?
It prevents unnecessary extra code, since with this it is now possible to do:
`Item item = new Item(ItemID.Whatever);`
instead of:
`Item item = new Item();`
`item.SetDefaults(ItemID.Whatever);`
