### PR TITLE
Better Autoloading 2

### DIFF
--- a/ExampleMod/Content/Items/Accessories/WaspNest.cs
+++ b/ExampleMod/Content/Items/Accessories/WaspNest.cs
@@ -11,8 +11,7 @@ namespace ExampleMod.Content.Items.Accessories
 	public class WaspNest : ModItem
 	{
 		// Only gets run once per type
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		public override void Load() {
 			IL.Terraria.Player.beeType += HookBeeType;
 		}
 

--- a/ExampleMod/Content/Items/Accessories/WaspNest.cs
+++ b/ExampleMod/Content/Items/Accessories/WaspNest.cs
@@ -11,7 +11,8 @@ namespace ExampleMod.Content.Items.Accessories
 	public class WaspNest : ModItem
 	{
 		// Only gets run once per type
-		public override void Load() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			IL.Terraria.Player.beeType += HookBeeType;
 		}
 

--- a/ExampleMod/Content/Items/Tools/ExampleHook.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleHook.cs
@@ -1,6 +1,7 @@
 ﻿using ExampleMod.Content.Tiles.Furniture;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -100,7 +101,7 @@ namespace ExampleMod.Content.Items.Tools
 			speed = 10;
 		}
 
-		private Texture2D chainTexture = GetTexture("ExampleMod/Content/Items/Tools/ExampleHookChain").Value;
+		private Asset<Texture2D> chainTexture = GetTexture("ExampleMod/Content/Items/Tools/ExampleHookChain");
 
 		public override bool PreDraw(SpriteBatch spriteBatch, Color lightColor) {
 			Vector2 playerCenter = Main.player[projectile.owner].MountedCenter;
@@ -117,8 +118,8 @@ namespace ExampleMod.Content.Items.Tools
 				Color drawColor = lightColor;
 
 				//Draw chain
-				spriteBatch.Draw(chainTexture, new Vector2(center.X - Main.screenPosition.X, center.Y - Main.screenPosition.Y),
-					new Rectangle(0, 0, chainTexture.Width, chainTexture.Height), drawColor, projRotation,
+				spriteBatch.Draw(chainTexture.Value, new Vector2(center.X - Main.screenPosition.X, center.Y - Main.screenPosition.Y),
+					new Rectangle(0, 0, chainTexture.Width(), chainTexture.Height()), drawColor, projRotation,
 					chainTexture.Size() * 0.5f, 1f, SpriteEffects.None, 0f);
 			}
 

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -134,6 +134,20 @@
  		public static string worldName = "";
  		public static int worldID;
  		public static int background;
+@@ -820,7 +_,12 @@
+ 		public static float invAlpha = 1f;
+ 		public static float invDir = 1f;
+ 		[ThreadStatic]
++		private static UnifiedRandom _rand;
+-		public static UnifiedRandom rand;
++		public static UnifiedRandom rand
++		{
++			get => _rand ??= new UnifiedRandom((int)DateTime.Now.Ticks);
++			set => _rand = value;
++		}
+ 		public static bool allChestStackHover;
+ 		public static bool inventorySortMouseOver;
+ 		public static float GraveyardVisualIntensity;
 @@ -837,7 +_,7 @@
  		public static AudioEngine engine;
  		public static SoundBank soundBank;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -134,20 +134,6 @@
  		public static string worldName = "";
  		public static int worldID;
  		public static int background;
-@@ -820,7 +_,12 @@
- 		public static float invAlpha = 1f;
- 		public static float invDir = 1f;
- 		[ThreadStatic]
-+		private static UnifiedRandom _rand;
--		public static UnifiedRandom rand;
-+		public static UnifiedRandom rand
-+		{
-+			get => _rand ??= new UnifiedRandom((int)DateTime.Now.Ticks);
-+			set => _rand = value;
-+		}
- 		public static bool allChestStackHover;
- 		public static bool inventorySortMouseOver;
- 		public static float GraveyardVisualIntensity;
 @@ -837,7 +_,7 @@
  		public static AudioEngine engine;
  		public static SoundBank soundBank;

--- a/patches/tModLoader/Terraria/ModLoader/AutoloadAttribute.cs
+++ b/patches/tModLoader/Terraria/ModLoader/AutoloadAttribute.cs
@@ -8,19 +8,26 @@ namespace Terraria.ModLoader
 	/// True to always autoload, false to never autoload, null to use mod default.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true, Inherited = true)]
-	public class AutoloadAttribute : Attribute
+	public sealed class AutoloadAttribute : Attribute
 	{
+		private static readonly AutoloadAttribute Default = new AutoloadAttribute();
+
 		public readonly bool Value;
+		public ModSide Side{get;set;} = ModSide.Both;
 
-		public AutoloadAttribute(bool value = true) { Value = value; }
+		public bool NeedsAutoloading => Value && Core.ModOrganizer.LoadSide(Side);
 
-		public static bool? GetValue(Type type) {
+		public AutoloadAttribute(bool value = true) {
+			Value = value;
+		}
+
+		public static AutoloadAttribute GetValue(Type type) {
 			//Get all AutoloadAttributes on the type.
 			object[] all = type.GetCustomAttributes(typeof(AutoloadAttribute), true);
 			//The first should be the most derived attribute.
 			var mostDerived = (AutoloadAttribute)all.FirstOrDefault();
 			//If there were no declarations, then return null.
-			return mostDerived?.Value;
+			return mostDerived??Default;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -70,7 +70,8 @@ namespace Terraria.ModLoader.Core
 				.Union(Directory.GetFiles(ModLoader.ModPath, "temporaryDownload.tmod", SearchOption.TopDirectoryOnly)); // Old tML remnant
 		}
 
-		private static bool LoadSide(ModSide side) => side != (Main.dedServ ? ModSide.Client : ModSide.Server);
+		//TODO: Find a good common place for this code.
+		internal static bool LoadSide(ModSide side) => side != (Main.dedServ ? ModSide.Client : ModSide.Server);
 
 		internal static List<Mod> LoadMods(CancellationToken token) {
 			CommandLineModPackOverride();

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -70,7 +70,6 @@ namespace Terraria.ModLoader.Core
 				.Union(Directory.GetFiles(ModLoader.ModPath, "temporaryDownload.tmod", SearchOption.TopDirectoryOnly)); // Old tML remnant
 		}
 
-		//TODO: Find a good common place for this code.
 		internal static bool LoadSide(ModSide side) => side != (Main.dedServ ? ModSide.Client : ModSide.Server);
 
 		internal static List<Mod> LoadMods(CancellationToken token) {

--- a/patches/tModLoader/Terraria/ModLoader/GlobalBuff.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalBuff.cs
@@ -9,8 +9,7 @@ namespace Terraria.ModLoader
 	/// </summary>
 	public class GlobalBuff:ModType
 	{
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			Mod.globalBuffs[Name] = this;
 			BuffLoader.globalBuffs.Add(this);
 			ContentInstance.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalBuff.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalBuff.cs
@@ -9,7 +9,8 @@ namespace Terraria.ModLoader
 	/// </summary>
 	public class GlobalBuff:ModType
 	{
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			Mod.globalBuffs[Name] = this;
 			BuffLoader.globalBuffs.Add(this);
 			ContentInstance.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -17,8 +17,7 @@ namespace Terraria.ModLoader
 		internal int index;
 		internal int instanceIndex;
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			ItemLoader.VerifyGlobalItem(this);
 
 			Mod.globalItems[Name] = this;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -17,7 +17,8 @@ namespace Terraria.ModLoader
 		internal int index;
 		internal int instanceIndex;
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			ItemLoader.VerifyGlobalItem(this);
 
 			Mod.globalItems[Name] = this;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -13,8 +13,7 @@ namespace Terraria.ModLoader
 		internal int index;
 		internal int instanceIndex;
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			NPCLoader.VerifyGlobalNPC(this);
 
 			Mod.globalNPCs[Name] = this;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -13,7 +13,8 @@ namespace Terraria.ModLoader
 		internal int index;
 		internal int instanceIndex;
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			NPCLoader.VerifyGlobalNPC(this);
 
 			Mod.globalNPCs[Name] = this;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -13,8 +13,7 @@ namespace Terraria.ModLoader
 		internal int index;
 		internal int instanceIndex;
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			ProjectileLoader.VerifyGlobalProjectile(this);
 
 			Mod.globalProjectiles[Name] = this;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -13,7 +13,8 @@ namespace Terraria.ModLoader
 		internal int index;
 		internal int instanceIndex;
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			ProjectileLoader.VerifyGlobalProjectile(this);
 
 			Mod.globalProjectiles[Name] = this;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalRecipe.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalRecipe.cs
@@ -5,8 +5,7 @@
 	/// </summary>
 	public class GlobalRecipe:ModType
 	{
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			Mod.globalRecipes[Name] = this;
 			RecipeHooks.Add(this);
 			ContentInstance.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalRecipe.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalRecipe.cs
@@ -5,7 +5,8 @@
 	/// </summary>
 	public class GlobalRecipe:ModType
 	{
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			Mod.globalRecipes[Name] = this;
 			RecipeHooks.Add(this);
 			ContentInstance.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -46,8 +46,7 @@ namespace Terraria.ModLoader
 			TileLoader.cacti[soilType] = cactus;
 		}
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			Mod.globalTiles[Name] = this;
 			TileLoader.globalTiles.Add(this);
 			ContentInstance.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -46,7 +46,8 @@ namespace Terraria.ModLoader
 			TileLoader.cacti[soilType] = cactus;
 		}
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			Mod.globalTiles[Name] = this;
 			TileLoader.globalTiles.Add(this);
 			ContentInstance.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalWall.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalWall.cs
@@ -7,7 +7,8 @@ namespace Terraria.ModLoader
 	/// </summary>
 	public class GlobalWall:ModType
 	{
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			Mod.globalWalls[Name] = this;
 			WallLoader.globalWalls.Add(this);
 			ContentInstance.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalWall.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalWall.cs
@@ -7,8 +7,7 @@ namespace Terraria.ModLoader
 	/// </summary>
 	public class GlobalWall:ModType
 	{
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			Mod.globalWalls[Name] = this;
 			WallLoader.globalWalls.Add(this);
 			ContentInstance.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -296,6 +296,7 @@ namespace Terraria.ModLoader
 			IList<Type> modGores = new List<Type>();
 			IList<Type> modSounds = new List<Type>();
 
+
 			Type modType = GetType();
 			foreach (Type type in Code.GetTypes().OrderBy(type => type.FullName, StringComparer.InvariantCulture)) {
 				if (type == modType){continue;}
@@ -309,8 +310,8 @@ namespace Terraria.ModLoader
 					modSounds.Add(type);
 				}
 				else if (typeof(ILoadable).IsAssignableFrom(type)) {
-					bool? autoload = AutoloadAttribute.GetValue(type);
-					if (autoload ?? Properties.Autoload) {
+					var autoload = AutoloadAttribute.GetValue(type);
+					if (autoload.NeedsAutoloading) {
 						AutoloadInstance(type);
 					}
 				}

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -312,7 +312,7 @@ namespace Terraria.ModLoader
 				else if (typeof(ILoadable).IsAssignableFrom(type)) {
 					var autoload = AutoloadAttribute.GetValue(type);
 					if (autoload.NeedsAutoloading) {
-						AutoloadInstance(type);
+						AddContent((ILoadable)Activator.CreateInstance(type));
 					}
 				}
 			}
@@ -367,12 +367,6 @@ namespace Terraria.ModLoader
 			var assetLoader = new AssetLoader(assetReaderCollection);
 
 			Assets = new ModAssetRepository(assetReaderCollection, assetLoader, asyncAssetLoader, sources.ToArray());
-		}
-
-		private void AutoloadInstance(Type type) {
-			var loadable = (ILoadable)Activator.CreateInstance(type);
-			loadable.Load(this);
-			loadables.Add(loadable);
 		}
 
 		private void AutoloadBackgrounds() {

--- a/patches/tModLoader/Terraria/ModLoader/ModBackgroundStyle.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBackgroundStyle.cs
@@ -12,8 +12,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public int Slot {get;internal set;}
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected override void Register() {
 			Slot = UgBgStyleLoader.ReserveBackgroundSlot();
 
 			Mod.ugBgStyles[Name] = this;
@@ -44,8 +43,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public int Slot {get;internal set;}
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected override void Register() {
 			Slot = SurfaceBgStyleLoader.ReserveBackgroundSlot();
 
 			Mod.surfaceBgStyles[Name] = this;
@@ -104,8 +102,7 @@ namespace Terraria.ModLoader
 	/// </summary>
 	public class GlobalBgStyle:ModType
 	{
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected override void Register() {
 			Mod.globalBgStyles[Name] = this;
 			GlobalBgStyleLoader.globalBgStyles.Add(this);
 			ContentInstance.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/ModBackgroundStyle.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBackgroundStyle.cs
@@ -12,7 +12,8 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public int Slot {get;internal set;}
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			Slot = UgBgStyleLoader.ReserveBackgroundSlot();
 
 			Mod.ugBgStyles[Name] = this;
@@ -43,7 +44,8 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public int Slot {get;internal set;}
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			Slot = SurfaceBgStyleLoader.ReserveBackgroundSlot();
 
 			Mod.surfaceBgStyles[Name] = this;
@@ -102,7 +104,8 @@ namespace Terraria.ModLoader
 	/// </summary>
 	public class GlobalBgStyle:ModType
 	{
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			Mod.globalBgStyles[Name] = this;
 			GlobalBgStyleLoader.globalBgStyles.Add(this);
 			ContentInstance.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/ModBuff.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBuff.cs
@@ -27,7 +27,8 @@ namespace Terraria.ModLoader
 		/// <summary>Whether or not it is always safe to call Player.DelBuff on this buff. Setting this to false will prevent the nurse from being able to remove this debuff. Defaults to true.</summary>
 		public bool canBeCleared = true;
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			if (Mod.buffs.ContainsKey(Name))
 				throw new Exception("You tried to add 2 ModBuff with the same name: " + Name + ". Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddBuff with 2 buffs of the same name.");
 

--- a/patches/tModLoader/Terraria/ModLoader/ModBuff.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBuff.cs
@@ -27,8 +27,7 @@ namespace Terraria.ModLoader
 		/// <summary>Whether or not it is always safe to call Player.DelBuff on this buff. Setting this to false will prevent the nurse from being able to remove this debuff. Defaults to true.</summary>
 		public bool canBeCleared = true;
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected override void Register() {
 			if (Mod.buffs.ContainsKey(Name))
 				throw new Exception("You tried to add 2 ModBuff with the same name: " + Name + ". Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddBuff with 2 buffs of the same name.");
 

--- a/patches/tModLoader/Terraria/ModLoader/ModCommand.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModCommand.cs
@@ -49,9 +49,8 @@ namespace Terraria.ModLoader
 		public virtual string Usage => "/" + Command;
 		/// <summary>A short description of this command.</summary>
 		public virtual string Description => "";
-		
-		public override void Load(Mod mod) {
-			base.Load(mod);
+
+		protected override void Register() {
 			CommandManager.Add(this);
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModCommand.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModCommand.cs
@@ -50,7 +50,8 @@ namespace Terraria.ModLoader
 		/// <summary>A short description of this command.</summary>
 		public virtual string Description => "";
 		
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			CommandManager.Add(this);
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -456,7 +456,7 @@ namespace Terraria.ModLoader
 			ModPrefix.Unload();
 			ModDust.Unload();
 			TileLoader.Unload();
-			ModTileEntity.Unload();
+			ModTileEntity.UnloadAll();
 			WallLoader.Unload();
 			ProjectileLoader.Unload();
 			NPCLoader.Unload();

--- a/patches/tModLoader/Terraria/ModLoader/ModDust.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModDust.cs
@@ -10,6 +10,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class represents a type of dust that is added by a mod. Only one instance of this class will ever exist for each type of dust you add.
 	/// </summary>
+	[Autoload(Side = ModSide.Client)]
 	public class ModDust:ModTexturedType
 	{
 		private static int nextDust = DustID.Count;
@@ -92,18 +93,14 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public sealed override void Load()
-		{
-			base.Load();
-			Texture2D = !string.IsNullOrEmpty(Texture) ? ModContent.GetTexture(Texture).Value : TextureAssets.Dust.Value;
-		}
-
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			Type = ModDust.ReserveDustID();
 
 			Mod.dusts[Name] = this;
 			ModDust.dusts.Add(this);
 			ContentInstance.Register(this);
+			Texture2D = !string.IsNullOrEmpty(Texture) ? ModContent.GetTexture(Texture).Value : TextureAssets.Dust.Value;
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModDust.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModDust.cs
@@ -93,8 +93,7 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected override void Register() {
 			Type = ModDust.ReserveDustID();
 
 			Mod.dusts[Name] = this;

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -46,8 +46,7 @@ namespace Terraria.ModLoader
 			item = new Item { modItem = this };
 		}
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			if (Mod.items.ContainsKey(Name))
 				throw new Exception(Language.GetTextValue("tModLoader.LoadError2ModItemSameName", Name));
 

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -46,7 +46,8 @@ namespace Terraria.ModLoader
 			item = new Item { modItem = this };
 		}
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			if (Mod.items.ContainsKey(Name))
 				throw new Exception(Language.GetTextValue("tModLoader.LoadError2ModItemSameName", Name));
 

--- a/patches/tModLoader/Terraria/ModLoader/ModMountData.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMountData.cs
@@ -31,8 +31,7 @@ namespace Terraria.ModLoader
 			mountData = new Mount.MountData();
 		}
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			if (Mount.mounts == null || Mount.mounts.Length == MountID.Count)
 				Mount.Initialize();
 

--- a/patches/tModLoader/Terraria/ModLoader/ModMountData.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMountData.cs
@@ -31,7 +31,8 @@ namespace Terraria.ModLoader
 			mountData = new Mount.MountData();
 		}
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			if (Mount.mounts == null || Mount.mounts.Length == MountID.Count)
 				Mount.Initialize();
 

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -84,7 +84,8 @@ namespace Terraria.ModLoader
 			npc = new NPC{modNPC = this};
 		}
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			if (Mod.npcs.ContainsKey(Name))
 				throw new Exception("You tried to add 2 ModNPC with the same name: " + Name + ". Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddNPC with 2 npcs of the same name.");
 

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -84,8 +84,7 @@ namespace Terraria.ModLoader
 			npc = new NPC{modNPC = this};
 		}
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			if (Mod.npcs.ContainsKey(Name))
 				throw new Exception("You tried to add 2 ModNPC with the same name: " + Name + ". Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddNPC with 2 npcs of the same name.");
 

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -39,8 +39,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public virtual bool CloneNewInstances => true;
 		
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			Mod.players[Name] = this;
 			PlayerHooks.Add(this);
 			ContentInstance.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -39,7 +39,8 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public virtual bool CloneNewInstances => true;
 		
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			Mod.players[Name] = this;
 			PlayerHooks.Add(this);
 			ContentInstance.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/ModPrefix.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPrefix.cs
@@ -107,8 +107,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public virtual PrefixCategory Category => PrefixCategory.Custom;
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			if (!Mod.loading)
 				throw new Exception("AddPrefix can only be called from Mod.Load or Mod.Autoload");
 

--- a/patches/tModLoader/Terraria/ModLoader/ModPrefix.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPrefix.cs
@@ -107,7 +107,8 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public virtual PrefixCategory Category => PrefixCategory.Custom;
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			if (!Mod.loading)
 				throw new Exception("AddPrefix can only be called from Mod.Load or Mod.Autoload");
 

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -61,7 +61,8 @@ namespace Terraria.ModLoader
 			projectile = new Projectile { modProjectile = this };
 		}
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			if (Mod.projectiles.ContainsKey(projectile.Name))
 				throw new Exception("You tried to add 2 ModProjectile with the same name: " + Name + ". Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddProjectile with 2 projectiles of the same name.");
 

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -61,8 +61,7 @@ namespace Terraria.ModLoader
 			projectile = new Projectile { modProjectile = this };
 		}
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			if (Mod.projectiles.ContainsKey(projectile.Name))
 				throw new Exception("You tried to add 2 ModProjectile with the same name: " + Name + ". Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddProjectile with 2 projectiles of the same name.");
 

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -199,8 +199,7 @@ namespace Terraria.ModLoader
 			TileLoader.cacti[Type] = cactus;
 		}
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			if (Mod.tiles.ContainsKey(Name))
 				throw new Exception("You tried to add 2 ModTile with the same name: " + Name + ". Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddTile with 2 tiles of the same name.");
 

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -199,7 +199,8 @@ namespace Terraria.ModLoader
 			TileLoader.cacti[Type] = cactus;
 		}
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			if (Mod.tiles.ContainsKey(Name))
 				throw new Exception("You tried to add 2 ModTile with the same name: " + Name + ". Maybe 2 classes share a classname but in different namespaces while autoloading or you manually called AddTile with 2 tiles of the same name.");
 

--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -50,7 +50,7 @@ namespace Terraria.ModLoader
 			return type >= numVanilla && type < nextTileEntity ? tileEntities[type - numVanilla] : null;
 		}
 
-		internal static void Unload() {
+		internal static void UnloadAll() {
 			nextTileEntity = numVanilla;
 			tileEntities.Clear();
 		}
@@ -182,9 +182,8 @@ namespace Terraria.ModLoader
 			NetReceive(reader, networkSend);
 		}
 
-		void ILoadable.Load(Mod mod) {
+		public virtual void Load(Mod mod) {
 			Mod = mod;
-			Load();
 
 			if (!Mod.loading)
 				throw new Exception("AddTileEntity can only be called from Mod.Load or Mod.Autoload");
@@ -198,8 +197,7 @@ namespace Terraria.ModLoader
 			ContentInstance.Register(this);
 		}
 
-		public virtual void Load() {}
-		void ILoadable.Unload(){}
+		public virtual void Unload(){}
 
 		/// <summary>
 		/// Allows you to save custom data for this tile entity.

--- a/patches/tModLoader/Terraria/ModLoader/ModType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModType.cs
@@ -15,10 +15,17 @@
 		/// </summary>
 		public virtual string Name => GetType().Name;
 
-		/// <summary>Make sure to call base.Mod(mod) to load in your type.</summary>
-		public virtual void Load(Mod mod) => Mod = mod;
+		void ILoadable.Load(Mod mod) {
+			Mod = mod;
+			Load();
+			Register();
+		}
+
+		public virtual void Load(){}
 
 		public virtual void Unload(){}
+
+		protected abstract void Register();
 	}
 
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModType.cs
@@ -15,20 +15,10 @@
 		/// </summary>
 		public virtual string Name => GetType().Name;
 
-		void ILoadable.Load(Mod mod) {
-			Mod = mod;
-			Load();
-			AddInstance();
-		}
-
-		public virtual void Load(){}
+		/// <summary>Make sure to call base.Mod(mod) to load in your type.</summary>
+		public virtual void Load(Mod mod) => Mod = mod;
 
 		public virtual void Unload(){}
-
-		/// <summary>
-		/// DO NOT CALL THIS! This is called automatically in ILoadable.Load
-		/// </summary>
-		internal virtual void AddInstance(){}
 	}
 
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModWall.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWall.cs
@@ -97,8 +97,7 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected override void Register() {
 			Type = (ushort)WallLoader.ReserveWallID();
 
 			Mod.walls[Name] = this;

--- a/patches/tModLoader/Terraria/ModLoader/ModWall.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWall.cs
@@ -97,7 +97,8 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			Type = (ushort)WallLoader.ReserveWallID();
 
 			Mod.walls[Name] = this;

--- a/patches/tModLoader/Terraria/ModLoader/ModWaterStyle.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWaterStyle.cs
@@ -14,7 +14,8 @@ namespace Terraria.ModLoader
 
 		public virtual string BlockTexture => Texture + "_Block";
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			Type = WaterStyleLoader.ReserveStyle();
 			
 			Mod.waterStyles[Name] = this;
@@ -71,7 +72,8 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public int Type {get;internal set;}
 
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			Type = WaterfallStyleLoader.ReserveStyle();
 
 			Mod.waterfallStyles[Name] = this;

--- a/patches/tModLoader/Terraria/ModLoader/ModWaterStyle.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWaterStyle.cs
@@ -14,8 +14,7 @@ namespace Terraria.ModLoader
 
 		public virtual string BlockTexture => Texture + "_Block";
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			Type = WaterStyleLoader.ReserveStyle();
 			
 			Mod.waterStyles[Name] = this;
@@ -72,8 +71,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public int Type {get;internal set;}
 
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			Type = WaterfallStyleLoader.ReserveStyle();
 
 			Mod.waterfallStyles[Name] = this;

--- a/patches/tModLoader/Terraria/ModLoader/ModWorld.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWorld.cs
@@ -10,7 +10,8 @@ namespace Terraria.ModLoader
 	/// </summary>
 	public class ModWorld:ModType
 	{
-		internal sealed override void AddInstance() {
+		public override void Load(Mod mod) {
+			base.Load(mod);
 			Mod.worlds[Name] = this;
 			WorldHooks.Add(this);
 			ContentInstance.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/ModWorld.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWorld.cs
@@ -10,8 +10,7 @@ namespace Terraria.ModLoader
 	/// </summary>
 	public class ModWorld:ModType
 	{
-		public override void Load(Mod mod) {
-			base.Load(mod);
+		protected sealed override void Register() {
 			Mod.worlds[Name] = this;
 			WorldHooks.Add(this);
 			ContentInstance.Register(this);


### PR DESCRIPTION
Changes to my last autoloading system:
- `AutoloadAttribute` now allows you to specify a `ModSide` which will control when a type can be autoloaded (client side, server side, or both).
- The base tML ModTypes now expose the implemented `Load(Mod)` method. This unifies the loading and removes the `Load()` and `AddInstance()` methods. Anyone wanting to overload `Load(Mod)` will need to call `base.Load(mod)` to ensure their ModType is loaded.

Remaining things todo/discuss before merging:
- [ ] Make ModConfig use ILoadable?
- [ ] Removing mod.Properties (currently `Properties.Autoload` does nothing, the other autoloads still do though).
  - [ ] Should ModGore and ModSound use ILoadable?
- [ ] Ideas for unifying duplicate-name checking. Perhaps using the IModType interface.
- [ ] Moving `ModOrganizer.LoadSide` to a more generalize location as it is now needed during autoloading. There may be other places that could use it as well.