### PR TITLE
Added download/upload telemetry to mod downloads and uploads

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -41,7 +41,7 @@ namespace Terraria.ModLoader
 		public static readonly string branchName = "1.4";
 		// beta > 0 cannot publish to mod browser
 		internal const bool IsBeta = true;
-		public static readonly int beta = 1;
+		public static readonly int beta = 0;
 
 		// SteamApps.GetCurrentBetaName(out string betaName, 100) ? betaName :
 		public static readonly string versionedName = $"tModLoader v{version}" +

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -41,7 +41,7 @@ namespace Terraria.ModLoader
 		public static readonly string branchName = "1.4";
 		// beta > 0 cannot publish to mod browser
 		internal const bool IsBeta = true;
-		public static readonly int beta = 0;
+		public static readonly int beta = 1;
 
 		// SteamApps.GetCurrentBetaName(out string betaName, 100) ? betaName :
 		public static readonly string versionedName = $"tModLoader v{version}" +

--- a/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/DownloadFile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/DownloadFile.cs
@@ -16,7 +16,7 @@ namespace Terraria.ModLoader.UI.DownloadManager
 
 		public HttpWebRequest Request { get; private set; }
 
-		public event Action<float, float, float> OnUpdateProgress;
+		public event ProgressUpdated OnUpdateProgress;
 		public event Action OnComplete;
 
 		public readonly string Url;
@@ -28,6 +28,8 @@ namespace Terraria.ModLoader.UI.DownloadManager
 		// Note: these will be completely ignored on old Mono versions
 		public SecurityProtocolType SecurityProtocol = Tls12;
 		public Version ProtocolVersion = HttpVersion.Version11;
+
+		public delegate void ProgressUpdated(float progress, long bytesReceived, long totalBytesNeeded);
 
 		public DownloadFile(string url, string filePath, string displayText) {
 			Url = url;
@@ -42,7 +44,7 @@ namespace Terraria.ModLoader.UI.DownloadManager
 			return true;
 		}
 
-		public Task<DownloadFile> Download(CancellationToken token, Action<float, float, float> updateProgressAction = null) {
+		public Task<DownloadFile> Download(CancellationToken token, ProgressUpdated updateProgressAction = null) {
 			SetupDownloadRequest();
 			if (updateProgressAction != null) OnUpdateProgress = updateProgressAction;
 			return Task.Factory.FromAsync(

--- a/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/DownloadFile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/DownloadFile.cs
@@ -16,7 +16,7 @@ namespace Terraria.ModLoader.UI.DownloadManager
 
 		public HttpWebRequest Request { get; private set; }
 
-		public event Action<float> OnUpdateProgress;
+		public event Action<float, float, float> OnUpdateProgress;
 		public event Action OnComplete;
 
 		public readonly string Url;
@@ -42,7 +42,7 @@ namespace Terraria.ModLoader.UI.DownloadManager
 			return true;
 		}
 
-		public Task<DownloadFile> Download(CancellationToken token, Action<float> updateProgressAction = null) {
+		public Task<DownloadFile> Download(CancellationToken token, Action<float, float, float> updateProgressAction = null) {
 			SetupDownloadRequest();
 			if (updateProgressAction != null) OnUpdateProgress = updateProgressAction;
 			return Task.Factory.FromAsync(
@@ -85,7 +85,7 @@ namespace Terraria.ModLoader.UI.DownloadManager
 					token.ThrowIfCancellationRequested();
 					_fileStream.Write(buf, 0, r);
 					currentIndex += r;
-					OnUpdateProgress?.Invoke((float)(currentIndex / (double)contentLength));
+					OnUpdateProgress?.Invoke((float)(currentIndex / (double)contentLength), currentIndex, response.ContentLength);
 				}
 			}
 			catch (OperationCanceledException e) {

--- a/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/UIDownloadProgress.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/UIDownloadProgress.cs
@@ -21,6 +21,8 @@ namespace Terraria.ModLoader.UI.DownloadManager
 		public override void OnActivate() {
 			base.OnActivate();
 
+			downloadTimer = new Stopwatch();
+
 			if (_downloads.Count <= 0) {
 				Logging.tML.Warn("UIDownloadProgress was activated but no downloads were present.");
 				Main.menuMode = gotoMenu;
@@ -31,6 +33,7 @@ namespace Terraria.ModLoader.UI.DownloadManager
 			OnCancel += () => {
 				_cts.Cancel();
 			};
+			downloadTimer.Restart();
 			DownloadMods();
 		}
 
@@ -63,7 +66,7 @@ namespace Terraria.ModLoader.UI.DownloadManager
 		}
 
 		private void DownloadMods() {
-			downloadTimer = new Stopwatch();
+			downloadTimer.Start();
 			_downloadFile = _downloads.First();
 			if (_downloadFile == null) return;
 			_progressBar.UpdateProgress(0f);
@@ -73,14 +76,12 @@ namespace Terraria.ModLoader.UI.DownloadManager
 		}
 
 		private void UpdateDownloadProgress(float progress, long bytesReceived, long totalBytesNeeded) {
-			downloadTimer.Stop();
 			_progressBar.UpdateProgress(progress);
 
 			double elapsedSeconds = downloadTimer.Elapsed.TotalSeconds;
 			double speed = elapsedSeconds > 0.0 ? bytesReceived / elapsedSeconds : 0.0;
 
 			SubProgressText = $"{UIMemoryBar.SizeSuffix(bytesReceived, 2)} / {UIMemoryBar.SizeSuffix(totalBytesNeeded, 2)} ({UIMemoryBar.SizeSuffix((long)speed, 2)}/s)";
-			downloadTimer.Start();
 		}
 
 		private void HandleNextDownload(Task<DownloadFile> task) {
@@ -92,6 +93,8 @@ namespace Terraria.ModLoader.UI.DownloadManager
 				OnDownloadsComplete?.Invoke();
 				return;
 			}
+
+			downloadTimer.Restart();
 
 			DownloadMods();
 		}

--- a/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/UIDownloadProgress.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/UIDownloadProgress.cs
@@ -72,11 +72,10 @@ namespace Terraria.ModLoader.UI.DownloadManager
 				.ContinueWith(HandleNextDownload, _cts.Token);
 		}
 
-		private void UpdateDownloadProgressAndTelemetry(float progress, float bytesRecieved, float totalBytesNeeded) {
+		private void UpdateDownloadProgressAndTelemetry(float progress, long bytesReceived, long totalBytesNeeded) {
 			downloadTimer.Stop();
 			_progressBar.UpdateProgress(progress);
-			SubProgressText = $"{bytesRecieved / 1000000:N2} MB / {totalBytesNeeded / 1000000:N2} MB " +
-							$"({bytesRecieved / 1000 / downloadTimer.Elapsed.TotalSeconds:N2} KB/s)";
+			SubProgressText = $"{UIMemoryBar.SizeSuffix(bytesReceived, 2)} / {UIMemoryBar.SizeSuffix(totalBytesNeeded, 2)} ({UIMemoryBar.SizeSuffix((long)(bytesReceived / downloadTimer.Elapsed.TotalSeconds), 2, true)}/s)";
 			downloadTimer.Start();
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/UIDownloadProgress.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/UIDownloadProgress.cs
@@ -68,11 +68,11 @@ namespace Terraria.ModLoader.UI.DownloadManager
 			if (_downloadFile == null) return;
 			_progressBar.UpdateProgress(0f);
 			_progressBar.DisplayText = Language.GetTextValue("tModLoader.MBDownloadingMod", _downloadFile.DisplayText);
-			_downloadFile.Download(_cts.Token, UpdateDownloadProgressAndTelemetry)
+			_downloadFile.Download(_cts.Token, UpdateDownloadProgress)
 				.ContinueWith(HandleNextDownload, _cts.Token);
 		}
 
-		private void UpdateDownloadProgressAndTelemetry(float progress, long bytesReceived, long totalBytesNeeded) {
+		private void UpdateDownloadProgress(float progress, long bytesReceived, long totalBytesNeeded) {
 			downloadTimer.Stop();
 			_progressBar.UpdateProgress(progress);
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/UIDownloadProgress.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/UIDownloadProgress.cs
@@ -75,7 +75,11 @@ namespace Terraria.ModLoader.UI.DownloadManager
 		private void UpdateDownloadProgressAndTelemetry(float progress, long bytesReceived, long totalBytesNeeded) {
 			downloadTimer.Stop();
 			_progressBar.UpdateProgress(progress);
-			SubProgressText = $"{UIMemoryBar.SizeSuffix(bytesReceived, 2)} / {UIMemoryBar.SizeSuffix(totalBytesNeeded, 2)} ({UIMemoryBar.SizeSuffix((long)(bytesReceived / downloadTimer.Elapsed.TotalSeconds), 2, true)}/s)";
+
+			double elapsedSeconds = downloadTimer.Elapsed.TotalSeconds;
+			double speed = elapsedSeconds > 0.0 ? bytesReceived / elapsedSeconds : 0.0;
+
+			SubProgressText = $"{UIMemoryBar.SizeSuffix(bytesReceived, 2)} / {UIMemoryBar.SizeSuffix(totalBytesNeeded, 2)} ({UIMemoryBar.SizeSuffix((long)speed, 2)}/s)";
 			downloadTimer.Start();
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/UILoadMods.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UILoadMods.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using System;
 using System.Threading;
-using Terraria.GameContent.UI.Elements;
 using Terraria.Localization;
 using Terraria.ModLoader.Engine;
 
@@ -11,20 +10,9 @@ namespace Terraria.ModLoader.UI
 	{
 		public int modCount;
 
-		private UIText subProgress;
 		private string stageText;
 
 		private CancellationTokenSource _cts;
-
-		public override void OnInitialize() {
-			base.OnInitialize();
-			subProgress = new UIText("", 0.5f, true) {
-				Top = { Pixels = 65 },
-				HAlign = 0.5f,
-				VAlign = 0.5f
-			};
-			Append(subProgress);
-		}
 
 		public override void OnActivate() {
 			base.OnActivate();
@@ -48,10 +36,6 @@ namespace Terraria.ModLoader.UI
 		public override void Update(GameTime gameTime) {
 			base.Update(gameTime);
 			GLCallLocker.SpeedrunActions();
-		}
-
-		public string SubProgressText {
-			set => subProgress?.SetText(value);
 		}
 
 		public void SetLoadStage(string stageText, int modCount = -1) {

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIMemoryBar.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIMemoryBar.cs
@@ -162,14 +162,8 @@ namespace Terraria.ModLoader.UI
 
 		private static readonly string[] SizeSuffixes = { "bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };
 
-		internal static string SizeSuffix(long value, int decimalPlaces = 1, bool dontStackOverFlow = false) {
-			if (value < 0) { 
-				if (dontStackOverFlow) { // A StackOverflowException is sometimes caused by values being too large, passed from the mod upload/download telemetry
-					return "0.0 bytes";
-				}
-
-				return "-" + SizeSuffix(-value); 
-			}
+		internal static string SizeSuffix(long value, int decimalPlaces = 1) {
+			if (value < 0) { return "-" + SizeSuffix(-value); }
 			if (value == 0) { return "0.0 bytes"; }
 
 			// mag is 0 for bytes, 1 for KB, 2, for MB, etc.

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIMemoryBar.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIMemoryBar.cs
@@ -162,8 +162,14 @@ namespace Terraria.ModLoader.UI
 
 		private static readonly string[] SizeSuffixes = { "bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };
 
-		private static string SizeSuffix(long value, int decimalPlaces = 1) {
-			if (value < 0) { return "-" + SizeSuffix(-value); }
+		internal static string SizeSuffix(long value, int decimalPlaces = 1, bool dontStackOverFlow = false) {
+			if (value < 0) { 
+				if (dontStackOverFlow) { // A StackOverflowException is sometimes caused by values being too large, passed from the mod upload/download telemetry
+					return "0.0 bytes";
+				}
+
+				return "-" + SizeSuffix(-value); 
+			}
 			if (value == 0) { return "0.0 bytes"; }
 
 			// mag is 0 for bytes, 1 for KB, 2, for MB, etc.

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -213,8 +213,10 @@ namespace Terraria.ModLoader.UI
 					client.UploadProgressChanged += (s, e) => {
 						uploadTimer.Stop();
 
-						Interface.progress.SubProgressText = $"{(float)e.BytesSent / 1000000:N2} MB / {(float)e.TotalBytesToSend / 1000000:N2} MB " +
-							$"({e.BytesSent / 1000 / uploadTimer.Elapsed.TotalSeconds:N2} KB/s)";
+						double speed = e.BytesSent / uploadTimer.Elapsed.TotalSeconds;
+
+						Interface.progress.SubProgressText = $"{UIMemoryBar.SizeSuffix(e.BytesSent, 2)} / {UIMemoryBar.SizeSuffix(e.TotalBytesToSend, 2)}" + 
+						$"({ UIMemoryBar.SizeSuffix((long)(e.BytesSent / uploadTimer.Elapsed.TotalSeconds), 2, true)}/s)";
 
 						Interface.progress.Show(displayText: $"Uploading: {modFile.name}", gotoMenu: Interface.modSourcesID, cancel: client.CancelAsync);
 						Interface.progress.Progress = (float)e.BytesSent / e.TotalBytesToSend;

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -180,7 +180,7 @@ namespace Terraria.ModLoader.UI
 							Content = modFile.GetBytes("icon.png")
 						});
 				}
-				if (bp.beta)
+				if (bp.beta && false)
 					throw new WebException(Language.GetTextValue("tModLoader.BetaModCantPublishError"));
 				if (bp.buildVersion != modFile.tModLoaderVersion)
 					throw new WebException(Language.GetTextValue("OutdatedModCantPublishError.BetaModCantPublishError"));
@@ -207,20 +207,18 @@ namespace Terraria.ModLoader.UI
 				ServicePointManager.Expect100Continue = false;
 				string url = "http://javid.ddns.net/tModLoader/publishmod.php";
 				uploadTimer = new Stopwatch();
+				uploadTimer.Start();
 				using (PatientWebClient client = new PatientWebClient()) {
 					ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, policyErrors) => true;
+					Interface.progress.Show(displayText: $"Uploading: {modFile.name}", gotoMenu: Interface.modSourcesID, cancel: client.CancelAsync);
 					client.UploadProgressChanged += (s, e) => {
-						uploadTimer.Stop();
-
 						double elapsedSeconds = uploadTimer.Elapsed.TotalSeconds;
 						double speed = elapsedSeconds > 0.0 ? e.BytesSent / elapsedSeconds : 0.0;
 
-						Interface.progress.SubProgressText = $"{UIMemoryBar.SizeSuffix(e.BytesSent, 2)} / {UIMemoryBar.SizeSuffix(e.TotalBytesToSend, 2)}" + 
+						Interface.progress.SubProgressText = $"{UIMemoryBar.SizeSuffix(e.BytesSent, 2)} / {UIMemoryBar.SizeSuffix(e.TotalBytesToSend, 2)} " + 
 						$"({UIMemoryBar.SizeSuffix((long)speed, 2)}/s)";
 
-						Interface.progress.Show(displayText: $"Uploading: {modFile.name}", gotoMenu: Interface.modSourcesID, cancel: client.CancelAsync);
 						Interface.progress.Progress = (float)e.BytesSent / e.TotalBytesToSend;
-						uploadTimer.Start();
 					};
 					client.UploadDataCompleted += (s, e) => PublishUploadDataComplete(s, e, modFile);
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -209,7 +209,6 @@ namespace Terraria.ModLoader.UI
 				uploadTimer = new Stopwatch();
 				using (PatientWebClient client = new PatientWebClient()) {
 					ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, policyErrors) => true;
-					Interface.progress.Show(displayText: $"Uploading: {modFile.name}", gotoMenu: Interface.modSourcesID, cancel: client.CancelAsync);
 					client.UploadProgressChanged += (s, e) => {
 						uploadTimer.Stop();
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -180,7 +180,7 @@ namespace Terraria.ModLoader.UI
 							Content = modFile.GetBytes("icon.png")
 						});
 				}
-				if (bp.beta && false)
+				if (bp.beta)
 					throw new WebException(Language.GetTextValue("tModLoader.BetaModCantPublishError"));
 				if (bp.buildVersion != modFile.tModLoaderVersion)
 					throw new WebException(Language.GetTextValue("OutdatedModCantPublishError.BetaModCantPublishError"));

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -213,10 +213,11 @@ namespace Terraria.ModLoader.UI
 					client.UploadProgressChanged += (s, e) => {
 						uploadTimer.Stop();
 
-						double speed = e.BytesSent / uploadTimer.Elapsed.TotalSeconds;
+						double elapsedSeconds = uploadTimer.Elapsed.TotalSeconds;
+						double speed = elapsedSeconds > 0.0 ? e.BytesSent / elapsedSeconds : 0.0;
 
 						Interface.progress.SubProgressText = $"{UIMemoryBar.SizeSuffix(e.BytesSent, 2)} / {UIMemoryBar.SizeSuffix(e.TotalBytesToSend, 2)}" + 
-						$"({ UIMemoryBar.SizeSuffix((long)(e.BytesSent / uploadTimer.Elapsed.TotalSeconds), 2, true)}/s)";
+						$"({UIMemoryBar.SizeSuffix((long)speed, 2)}/s)";
 
 						Interface.progress.Show(displayText: $"Uploading: {modFile.name}", gotoMenu: Interface.modSourcesID, cancel: client.CancelAsync);
 						Interface.progress.Progress = (float)e.BytesSent / e.TotalBytesToSend;

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIProgress.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIProgress.cs
@@ -19,9 +19,16 @@ namespace Terraria.ModLoader.UI
 		// separate variable copied to progress bar in Update, allows for thread safety and setting display text before UI initialization
 		public string DisplayText;
 
+		// Little text used by the mod loading progress and mod upload progress
+		protected UIText subProgress;
+
 		public float Progress {
 			get => _progressBar?.Progress ?? 0f;
 			set => _progressBar?.UpdateProgress(value);
+		}
+
+		public string SubProgressText {
+			set => subProgress?.SetText(value);
 		}
 
 		public override void OnInitialize() {
@@ -41,6 +48,13 @@ namespace Terraria.ModLoader.UI
 			}.WithFadedMouseOver();
 			_cancelButton.OnClick += CancelClick;
 			Append(_cancelButton);
+
+			subProgress = new UIText("", 0.5f, true) {
+				Top = { Pixels = 65 },
+				HAlign = 0.5f,
+				VAlign = 0.5f
+			};
+			Append(subProgress);
 		}
 
 		private void CancelClick(UIMouseEvent evt, UIElement listeningElement) {


### PR DESCRIPTION
### What is the new feature?
Shows the total download/upload progress in KB or MB based on size, as well as the average speed in the appropriate unit per second. Additionally, moved some code from UILoadMods to UIProgress so that the small text below the bar exists on all UIProgress instances.

### Why should this be part of tModLoader?
Because of https://github.com/tModLoader/tModLoader/issues/775 (can now be marked as complete).
### Are there alternative designs?
No.
### Sample usage for the new feature
https://cdn.discordapp.com/attachments/445276626352209920/738089021133160578/unknown.png
https://cdn.discordapp.com/attachments/445276626352209920/738094672039248023/unknown.png