### PR TITLE
Enforce reload before publishing

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -162,6 +162,16 @@ namespace Terraria.ModLoader.UI
 			}
 			SoundEngine.PlaySound(10);
 			try {
+				if (ModLoader.GetMod(_builtMod.Name) == null) {
+					if (!_builtMod.Enabled)
+						_builtMod.Enabled = true;
+					Main.menuMode = Interface.reloadModsID;
+					ModLoader.OnSuccessfulLoad += () => {
+						PublishMod(null, null);
+					};
+					return;
+				}
+
 				var modFile = _builtMod.modFile;
 				var bp = _builtMod.properties;
 


### PR DESCRIPTION
### What is it?
Does what it says. Solves #1050, with very little code :^)

### Other implementations
To be honest, I'm not sure. This implementation definitely works but I dunno if it fits your guys' idea of good practice. In the future, maybe a new translation key that reads "Reload Before Publishing" or just "Reload" (which would fit a lot better actually) that can be used instead just reusing the "Reload Mods" one might be nice, but I think any modder who reads it should probably be able to figure it out based on context anyway.