### PR TITLE
Bestiary UI Bug

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -401,7 +401,6 @@ namespace Terraria.ModLoader
 			SetupRecipes(token);
 			
 			ContentSamples.Initialize();
-			ContentSamples.RebuildBestiarySortingIDsByBestiaryDatabaseContents(Main.BestiaryDB); //Reconstruct NpcBestiarySortingId
 			MenuLoader.GotoSavedModMenu();
 		}
 		
@@ -518,8 +517,7 @@ namespace Terraria.ModLoader
 			// BuffID.Search = IdDictionary.Create<BuffID, int>();
 			
 			ContentSamples.Initialize();
-			ContentSamples.RebuildBestiarySortingIDsByBestiaryDatabaseContents(Main.BestiaryDB); //Reconstruct NpcBestiarySortingId
-
+			
 			CleanupModReferences();
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -401,6 +401,7 @@ namespace Terraria.ModLoader
 			SetupRecipes(token);
 			
 			ContentSamples.Initialize();
+			ContentSamples.RebuildBestiarySortingIDsByBestiaryDatabaseContents(Main.BestiaryDB); //Reconstruct NpcBestiarySortingId
 			MenuLoader.GotoSavedModMenu();
 		}
 		
@@ -517,7 +518,8 @@ namespace Terraria.ModLoader
 			// BuffID.Search = IdDictionary.Create<BuffID, int>();
 			
 			ContentSamples.Initialize();
-			
+			ContentSamples.RebuildBestiarySortingIDsByBestiaryDatabaseContents(Main.BestiaryDB); //Reconstruct NpcBestiarySortingId
+
 			CleanupModReferences();
 		}
 


### PR DESCRIPTION
### What is the bug?
When viewing the Bestiary, the Bestiary is blank and tells the user that an error has occurred.

This is because `ContentSamples.NpcBestiarySortingId` is cleared when `ModContent` calls  `ContentSamples.Initialize()`.

### How did you fix the bug?
Rebuilding `NpcBestiarySortingId` after every call to `Initialize()` fixes the issue.

### Are there alternatives to your fix?
`Initialize()` could be patched to not clear `NpcBestiarySortingId`.