### PR TITLE
Fix for water CTD

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
@@ -5,7 +5,7 @@
  		public const float MIN_LIQUID_SIZE = 0.25f;
  		public static LiquidRenderer Instance;
 -		private readonly Asset<Texture2D>[] _liquidTextures = new Asset<Texture2D>[13];
-+		public Asset<Texture2D>[] _liquidTextures = new Asset<Texture2D>[12];
++		public Asset<Texture2D>[] _liquidTextures = new Asset<Texture2D>[13];
  		private LiquidCache[] _cache = new LiquidCache[1];
  		private LiquidDrawCache[] _drawCache = new LiquidDrawCache[1];
  		private int _animationFrame;


### PR DESCRIPTION
### What is the bug?
A missing water asset causes a `NullReferenceException` resulting in a CTD. Specifically, `Water_12`.

### How did you fix the bug?
By changing the # of water textures to load from 12 to 13.
On 1.4.0.5; I can confirm there are 13 water files, so I'm not sure if this was a mistake, or if a version of 1.4 only has 12 assets.

### Are there alternatives to your fix?
The draw code for water could be patched to fail safely when missing a water asset.