### PR TITLE
Extra Accessory Slot BugFix

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1207,8 +1207,8 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public static Item GetWing(Player player) {
 			Item item = null;
-			for (int k = 3; k < 8 + player.extraAccessorySlots; k++) {
-				if (player.armor[k].wingSlot == player.wingsLogic) {
+			for (int k = 3; k < 10; k++) {
+				if (player.armor[k].wingSlot == player.wingsLogic && player.IsAValidEquipmentSlotForIteration(k)) {
 					item = player.armor[k];
 				}
 			}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1113,14 +1113,14 @@
 +				VanillaUpdateInventory(inventory[j]);
 +			}
 +
-+			for (int k = 0; k < 10 + extraAccessorySlots; k++) {
++			for (int k = 0; k < 8 + extraAccessorySlots; k++) {
 +				VanillaUpdateEquip(armor[k]);
 +			}
 +
 +			bool flag = false;
 +			bool flag2 = false;
 +			bool flag3 = false;
-+			for (int l = 3; l < 10 + extraAccessorySlots; l++) {
++			for (int l = 3; l < 8 + extraAccessorySlots; l++) {
 +				VanillaUpdateAccessory(i, armor[l], hideVisibleAccessory[l], ref flag, ref flag2, ref flag3);
  			}
  
@@ -1387,6 +1387,17 @@
  								SmartSelect_SelectItem(i);
  								return;
  						}
+@@ -12322,7 +_,9 @@
+ 		public static float GetClosestRollLuck(int x, int y, int range) => Main.player[FindClosest(new Vector2(x * 16, y * 16), 1, 1)].RollLuck(range);
+ 
+ 		public void ResetEffects() {
+-			if (extraAccessory && (Main.expertMode || Main.gameMenu))
++			if (extraAccessory && Main.masterMode)
++				extraAccessorySlots = 2;
++			else if (Main.masterMode || (extraAccessory && (Main.expertMode || Main.gameMenu))
+ 				extraAccessorySlots = 1;
+ 			else
+ 				extraAccessorySlots = 0;
 @@ -12344,10 +_,16 @@
  			lifeRegen = 0;
  			manaCost = 1f;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -961,7 +961,7 @@
 +			Item[] armor = {item};
 +			int k = 0;
 +			{
-+				if (!IsAValidEquipmentSlotForIteration(k) || (armor[k].expertOnly && !Main.expertMode) || (armor[k].masterOnly && !Main.masterMode))
++				if (armor[k].expertOnly && !Main.expertMode || armor[k].masterOnly && !Main.masterMode)
 +					return;
  
  				int type2 = armor[k].type;
@@ -1038,7 +1038,7 @@
  				}
  
  				if (armor[k].prefix == 73)
-@@ -8990,12 +_,19 @@
+@@ -8990,13 +_,20 @@
  
  				if (armor[k].prefix == 80)
  					meleeSpeed += 0.04f;
@@ -1050,6 +1050,7 @@
 -			equippedAnyTileSpeedAcc = false;
 -			equippedAnyTileRangeAcc = false;
 -			for (int l = 3; l < 10; l++) {
+-				if (IsAValidEquipmentSlotForIteration(l))
 +			//equippedAnyWallSpeedAcc = false;
 +			//equippedAnyTileSpeedAcc = false;
 +			//equippedAnyTileRangeAcc = false;
@@ -1059,10 +1060,11 @@
 +			// fake array and loop to keep patches small
 +			var armor = new[] { item }; int l = 0;
 +			{
- 				if (IsAValidEquipmentSlotForIteration(l))
++				if (IsAValidEquipmentSlotForIteration(i))
  					ApplyEquipFunctional(l, armor[l]);
  			}
-@@ -9004,15 +_,58 @@
+ 
+@@ -9004,15 +_,60 @@
  				lifeRegen += 2;
  				statDefense += 4;
  				meleeSpeed += 0.1f;
@@ -1085,15 +1087,16 @@
 +					Main.musicBox2 = SoundLoader.itemToMusic[armor[l].type];
 +			}
 +
-+			if (armor[l].wingSlot > 0) {
++			if (armor[l].wingSlot > 0 && IsAValidEquipmentSlotForIteration(i)) {
 +				if (!hideVisual || velocity.Y != 0f && !mount.Active)
 +					wings = armor[l].wingSlot;
 +
 +				wingsLogic = armor[l].wingSlot;
 +			}
-+
-+			ApplyEquipVanity(l, armor[l]);
-+			ItemLoader.UpdateAccessory(armor[l], this, hideVisual);
++			if (IsAValidEquipmentSlotForIteration(i)) {
++				ApplyEquipVanity(l, armor[l]);
++				ItemLoader.UpdateAccessory(armor[l], this, hideVisual);
++			}
 +		}
 +
 +		public void VanillaUpdateVanityAccessory(Item item) {
@@ -1113,14 +1116,15 @@
 +				VanillaUpdateInventory(inventory[j]);
 +			}
 +
-+			for (int k = 0; k < 8 + extraAccessorySlots; k++) {
-+				VanillaUpdateEquip(armor[k]);
++			for (int k = 0; k < 10; k++) {
++				if(!IsAValidEquipmentSlotForIteration(k))
++					VanillaUpdateEquip(armor[k]);
 +			}
 +
 +			bool flag = false;
 +			bool flag2 = false;
 +			bool flag3 = false;
-+			for (int l = 3; l < 8 + extraAccessorySlots; l++) {
++			for (int l = 3; l < 10; l++) {
 +				VanillaUpdateAccessory(i, armor[l], hideVisibleAccessory[l], ref flag, ref flag2, ref flag3);
  			}
  

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1394,7 +1394,7 @@
 -			if (extraAccessory && (Main.expertMode || Main.gameMenu))
 +			if (extraAccessory && Main.masterMode)
 +				extraAccessorySlots = 2;
-+			else if (Main.masterMode || (extraAccessory && (Main.expertMode || Main.gameMenu))
++			else if (Main.masterMode || (extraAccessory && (Main.expertMode || Main.gameMenu)))
  				extraAccessorySlots = 1;
  			else
  				extraAccessorySlots = 0;


### PR DESCRIPTION
### What is the bug?
I discovered this because of a `IndexOutOfRange` error caused by indexing 10 of `player.hideVisibleAccessory`

It seems a previous patch used `player.extraAccessorySlots` to check the additional slot from a demon heart in `player.UpdateEquips`, which causes the error.

While digging, I found several related problems;
1) `extraAccessorySlots` doesn't account for master mode
2) `ItemLoader.GetWing` didn't use the 7th slot from master mode (due to not accounting for master mode)
3) `Player.VanillaUpdateEquip` ignored whether the item's accessory slot was allowed to be used
4) `Player.VanillaUpdateAccessory` ignored whether the item's accessory slot was allowed to be used


### How did you fix the bug?
Removed the use of `extraAccesorySlots`. Replaced them with the hardcoded limit of 10, and a call to `player.IsAValidEquipmentSlotForIteration` instead. This fixes the initial bug, as well as (2), (3), and (4)

This solution is how most of the game handles the additional accessory slots. A vanilla decompile of terraria shows that while extraAccessorySlots is set and updated in `player.ResetEffect`, its value is never used, so it might have been deprecated when they moved to 1.4.

To fix (1), a catch for master mode was added in `ResetEffect`, this shouldn't affect anything in vanilla Terraria or tModLoader.

### Are there alternatives to your fix?
The previous solution worked, but only addressed the IndexOutOfRange error and the related problems (1) and (2)

8 + extraAccessorySlots could be used instead of the hardcoded 10, but any non vanilla `extraAccessorySlots` value would not be handled, as nothing else considers it's value.

### Discussion?
Despite not being used anywhere, I fixed `extraAccessorySlots`, since there doesn't seem to be a good way for modders to read this value. But I'd suggest something to discourage its modification, as it doesn't affect anything else.
These were the two best alternatives I could find, but they don't behave exactly as the `extraAccessorySlots` variable does.
* `IsAValidEquipmentSlotForIteration` is clunky since it doesn't say how many slots are added, but whether a given slot is legal.
* `GetAmountOfExtraAccessorySlotsToShow` isn't a solution, as it will include a slot if there are any items present for that row.


***
## Old Report
### What is the bug?
`IndexOutOfRange` Error with demon heart / master mode extra accessory slots.
This appears to be caused by the game trying to check for an 8th accessory slot in `Player.hideVisibleAccessory`

### How did you fix the bug?
The bug was fixed in two parts; 
First, added a few lines to catch when playing master mode, which adds an accessory slot.
Second, altered some for loop limits of `UpdateEquips` in `Player`. Previously the limit was 10 plus the extra accessory slots. By using 8 and the extra accessory slots; we get the expected maximum of 10.

Related bonus fix; `GetWing` can now read from all accessory slots, instead of just the first 6.

### Are there alternatives to your fix?
You could use the hard limit of 10. I didn't do this to follow the style of the `GetWing` function.