### PR TITLE
1.3 Potential Fix #1087

### DIFF
--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -112,7 +112,7 @@
  							Main.StopSlimeRain();
  
  						Main.invasionType = reader.ReadSByte();
-+						if (!ModNet.AllowVanillaClients)
++						if (!ModNet.AllowVanillaClients && Netplay.Connection.State > 4)
 +							WorldIO.ReceiveModData(reader);
 +
  						Main.LobbyId = reader.ReadUInt64();


### PR DESCRIPTION
### What is the bug?
Fixes #1087
`ModWorld.NetReceive` is ran before `ModWorld.Initialize`

### How did you fix the bug?
1.3 Port of the fix used for 1.4 from #1090

### Are there alternatives to your fix?
See #1090