### PR TITLE
Fix CraftItem not creating new instances of items

### DIFF
--- a/ExampleMod/Content/Items/ExampleDataItem.cs
+++ b/ExampleMod/Content/Items/ExampleDataItem.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.ModLoader;
+
+namespace ExampleMod.Content.Items
+{
+	public class ExampleDataItem : ModItem
+	{
+		public override string Texture => "ExampleMod/Content/Items/ExampleItem";
+
+		public override bool CloneNewInstances => true;
+
+		public int timer;
+
+		public override void SetStaticDefaults() {
+			DisplayName.SetDefault("Hot Potato");
+			Tooltip.SetDefault("Something magical happens when the timer runs out...");
+		}
+
+		public override void ModifyTooltips(List<TooltipLine> tooltips) {
+			TooltipLine tooltip = new TooltipLine(Mod, "ExampleMod: HotPatato", $"You have {timer / 60f:N1} seconds left!");
+			tooltip.overrideColor = Color.Red;
+			tooltips.Add(tooltip);
+		}
+
+		public override void UpdateInventory(Player player) {
+			if (--timer <= 0) {
+				player.statLife += 100;
+				if (player.statLife > player.statLifeMax2) player.statLife = player.statLifeMax2;
+				player.HealEffect(100);
+				item.TurnToAir();
+			}
+		}
+
+		public override void AddRecipes() {
+			Recipe recipe = CreateRecipe();
+			recipe.AddIngredient<ExampleItem>(100);
+			(recipe.createItem.modItem as ExampleDataItem).timer = 300;
+			recipe.Register();
+		}
+	}
+}

--- a/ExampleMod/Content/Items/ExampleInstancedItem.cs
+++ b/ExampleMod/Content/Items/ExampleInstancedItem.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.ModLoader;
+using Terraria.ModLoader.IO;
+
+namespace ExampleMod.Content.Items
+{
+	public class ExampleInstancedItem : ModItem
+	{
+		public override string Texture => "ExampleMod/Content/Items/ExampleItem";
+
+		public override bool CloneNewInstances => false;
+
+		public override ModItem Clone(Item item) {
+			ExampleInstancedItem clone = (ExampleInstancedItem)base.Clone(item);
+			clone.colors = (Color[])colors.Clone();
+			return clone;
+		}
+
+		public Color[] colors;
+
+		public ExampleInstancedItem() {
+			colors = new Color[5];
+			for (int i = 0; i < 5; i++) {
+				colors[i] = Main.hslToRgb(Main.rand.NextFloat(), 1f, 0.7f);
+			}
+		}
+
+		public override void ModifyTooltips(List<TooltipLine> tooltips) {
+			for (int i = 0; i < colors.Length; i++) {
+				TooltipLine tooltipLine = new TooltipLine(Mod, "EM" + i, "Example " + i);
+				tooltipLine.overrideColor = colors[i];
+				tooltips.Add(tooltipLine);
+			}
+		}
+
+		public override TagCompound Save() =>
+			new TagCompound { ["Colors"] = colors.ToList() };
+
+		public override void Load(TagCompound tag) {
+			colors = tag.GetList<Color>("Colors").ToArray();
+		}
+
+		public override void AddRecipes() => CreateRecipe().AddIngredient<ExampleItem>(10).Register();
+	}
+}

--- a/ExampleMod/Content/Items/ExampleItem.cs
+++ b/ExampleMod/Content/Items/ExampleItem.cs
@@ -7,7 +7,7 @@ namespace ExampleMod.Content.Items
 	public class ExampleItem : ModItem
 	{
 		public override void SetStaticDefaults() {
-			Tooltip.SetDefault("This is a modded item."); //The (English) text shown below your weapon's name
+			Tooltip.SetDefault("This is a modded item."); //The (English) text shown below your item's name
 		}
 
 		public override void SetDefaults() {
@@ -16,12 +16,11 @@ namespace ExampleMod.Content.Items
 
 			item.maxStack = 999; //The item's max stack value
 			item.value = Item.buyPrice(silver: 1); //The value of the item in copper coins. Item.buyPrice & Item.sellPrice are helper methods that returns costs in copper coins based on platinum/gold/silver/copper arguments provided to it.
-			item.rare = ItemRarityID.Blue; // The rarity of the weapon.
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.
 		public override void AddRecipes() {
-			CreateRecipe()
+			CreateRecipe(999)
 				.AddIngredient(ItemID.DirtBlock, 10)
 				.AddTile(TileID.WorkBenches)
 				.Register();

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -454,10 +454,12 @@
  						if (type == 4143)
  							num3 -= (float)manaGrabRange;
  
-@@ -45777,9 +_,28 @@
+@@ -45777,8 +_,25 @@
  			}
  		}
  
+-		public Item Clone() => (Item)MemberwiseClone();
+-		public Item DeepClone() => (Item)MemberwiseClone();
 +		public Item Clone() {
 +			Item newItem = (Item)MemberwiseClone();
 +			newItem.modItem = modItem?.Clone(newItem);
@@ -473,18 +475,13 @@
 +			newItem.globalItems = dataSource.globalItems.Select(g => g.Clone(dataSource, newItem)).ToArray();
 +			return newItem;
 +		}
--		public Item Clone() => (Item)MemberwiseClone();
 +
--		public Item DeepClone() => (Item)MemberwiseClone();
-+		public Item DeepClone() => Clone();
++		internal Item DeepClone() => Clone();
++
++		internal Item ShallowClone() => (Item)MemberwiseClone();
  
-+		internal Item ShallowClone() {
-+			return (Item)MemberwiseClone();
-+		}
-+		
  		public bool IsTheSameAs(Item compareItem) {
  			if (netID == compareItem.netID)
- 				return type == compareItem.type;
 @@ -45809,6 +_,8 @@
  			dye = 0;
  			shoot = 0;

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -454,12 +454,10 @@
  						if (type == 4143)
  							num3 -= (float)manaGrabRange;
  
-@@ -45777,8 +_,23 @@
+@@ -45777,9 +_,28 @@
  			}
  		}
  
--		public Item Clone() => (Item)MemberwiseClone();
--		public Item DeepClone() => (Item)MemberwiseClone();
 +		public Item Clone() {
 +			Item newItem = (Item)MemberwiseClone();
 +			newItem.modItem = modItem?.Clone(newItem);
@@ -475,11 +473,18 @@
 +			newItem.globalItems = dataSource.globalItems.Select(g => g.Clone(dataSource, newItem)).ToArray();
 +			return newItem;
 +		}
+-		public Item Clone() => (Item)MemberwiseClone();
 +
+-		public Item DeepClone() => (Item)MemberwiseClone();
 +		public Item DeepClone() => Clone();
  
++		internal Item ShallowClone() {
++			return (Item)MemberwiseClone();
++		}
++		
  		public bool IsTheSameAs(Item compareItem) {
  			if (netID == compareItem.netID)
+ 				return type == compareItem.type;
 @@ -45809,6 +_,8 @@
  			dye = 0;
  			shoot = 0;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2438,9 +2438,25 @@
  
  			new Microsoft.Xna.Framework.Color(150, 150, 150, 150);
  			if (mouseX >= num && (float)mouseX <= (float)num + (float)TextureAssets.InventoryBack.Width() * inventoryScale && mouseY >= num2 && (float)mouseY <= (float)num2 + (float)TextureAssets.InventoryBack.Height() * inventoryScale && !PlayerInput.IgnoreMouseInterface) {
-@@ -31247,8 +_,11 @@
+@@ -31236,19 +_,26 @@
+ 			UILinkPointNavigator.SetPosition(6000 + gamepadPointOffset, vector + rectangle.Size() * 0.65f);
+ 		}
+ 
++		// while in SetDefaults it should be a clone of the base modItem or a new instance
++
+ 		public static void CraftItem(Recipe r) {
+ 			int stack = mouseItem.stack;
+-			mouseItem = r.createItem.Clone();
++			mouseItem = (Item)mouseItem.ShallowClone();
++			mouseItem.modItem = r.createItem.modItem?.NewInstance(mouseItem);
++			mouseItem.globalItems = r.createItem.globalItems.Select(g => g.NewInstance(mouseItem)).ToArray();
+ 			mouseItem.stack += stack;
+ 			if (stack <= 0)
+ 				mouseItem.Prefix(-1);
+ 
+ 			mouseItem.position.X = player[myPlayer].position.X + (float)(player[myPlayer].width / 2) - (float)(mouseItem.width / 2);
  			mouseItem.position.Y = player[myPlayer].position.Y + (float)(player[myPlayer].height / 2) - (float)(mouseItem.height / 2);
- 			PopupText.NewText(PopupTextContext.ItemCraft, mouseItem, r.createItem.stack);
+-			PopupText.NewText(PopupTextContext.ItemCraft, mouseItem, r.createItem.stack);
  			r.Create();
 -			if (mouseItem.type > 0 || r.createItem.type > 0)
 +			if (mouseItem.type > 0 || r.createItem.type > 0) {
@@ -2448,6 +2464,7 @@
 +				ItemLoader.OnCraft(mouseItem, r);
  				SoundEngine.PlaySound(7);
 +			}
++			PopupText.NewText(PopupTextContext.ItemCraft, mouseItem, r.createItem.stack);
  		}
  
  		private static void DrawPVPIcons() {

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2447,7 +2447,7 @@
  		public static void CraftItem(Recipe r) {
  			int stack = mouseItem.stack;
 -			mouseItem = r.createItem.Clone();
-+			mouseItem = (Item)mouseItem.ShallowClone();
++			mouseItem = (Item)r.createItem.ShallowClone();
 +			mouseItem.modItem = r.createItem.modItem?.NewInstance(mouseItem);
 +			mouseItem.globalItems = r.createItem.globalItems.Select(g => g.NewInstance(mouseItem)).ToArray();
  			mouseItem.stack += stack;

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedItem.cs
@@ -64,8 +64,8 @@ namespace Terraria.ModLoader.Default
 
 		public override bool CloneNewInstances => true;
 
-		public override ModItem Clone() {
-			var clone = (UnloadedItem)base.Clone();
+		public override ModItem Clone(Item item) {
+			var clone = (UnloadedItem)base.Clone(item);
 			clone.data = (TagCompound)data?.Clone();
 			return clone;
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -79,7 +79,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Whether instances of this ModItem are created through Clone or constructor (by default implementations of NewInstance and Clone(Item, Item)). 
+		/// Whether instances of this ModItem are created through Clone or constructor
 		/// Defaults to false (using default constructor).
 		/// </summary>
 		public virtual bool CloneNewInstances => false;
@@ -88,21 +88,15 @@ namespace Terraria.ModLoader
 		/// Returns a clone of this ModItem. 
 		/// Allows you to decide which fields of your ModItem class are copied over when an item stack is split or something similar happens. 
 		/// By default this will return a memberwise clone; you will want to override this if your ModItem contains object references. 
-		/// Only called if CloneNewInstances is set to true.
 		/// Since several ModItem class fields are also set by the default implementation of this method, you'll most likely want to call base.Clone() as the first statement of your override.
-		/// </summary>
-		/// <example><code>var clone = (ExampleHookItem)base.Clone();
-		/// clone.targets = (int[])this.targets.Clone(); // Or whatever deep copy operations are relevant.
-		/// return clone;</code></example>
-		public virtual ModItem Clone() => (ModItem)MemberwiseClone();
-
-		/// <summary>
-		/// Create a copy of this instanced ModItem. Called when an item is cloned.
-		/// Defaults to NewInstance(item)
 		/// </summary>
 		/// <param name="item">The item being cloned</param>
 		/// <param name="itemClone">The new item</param>
-		public virtual ModItem Clone(Item item) => NewInstance(item);
+		public virtual ModItem Clone(Item item) {
+			ModItem clone = (ModItem)MemberwiseClone();
+			clone.item = item;
+			return clone;
+		}
 
 		/// <summary>
 		/// Create a new instance of this ModItem for an Item instance. 
@@ -110,11 +104,9 @@ namespace Terraria.ModLoader
 		/// If CloneNewInstances is true, just calls Clone()
 		/// Otherwise calls the default constructor and copies fields
 		/// </summary>
-		public virtual ModItem NewInstance(Item itemClone) {
+		public ModItem NewInstance(Item itemClone) {
 			if (CloneNewInstances) {
-				var clone = Clone();
-				clone.item = itemClone;
-				return clone;
+				return Clone(itemClone);
 			}
 
 			var copy = (ModItem)Activator.CreateInstance(GetType());


### PR DESCRIPTION
Main.CraftItem now creates a new instance of an item. Also adds several ModItem Clone and NewInstance changes.

Previously the only way for an instanced item to work with crafting was to override `OnCraft` and re-implement your constructor. This way crafting respects the `CloneNewInstances` flag