### PR TITLE
Removed "using static" from ExampleMod (1.4)

### DIFF
--- a/ExampleMod/Common/Players/ExampleInventoryPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleInventoryPlayer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Common.Players
 {
@@ -23,7 +22,7 @@ namespace ExampleMod.Common.Players
 			}
 
 			return new[] {
-				new Item(ItemType<ExampleItem>()),
+				new Item(ModContent.ItemType<ExampleItem>()),
 				new Item(ItemID.GoldOre) {
 					stack = 256
 				}

--- a/ExampleMod/Content/ExampleRecipes.cs
+++ b/ExampleMod/Content/ExampleRecipes.cs
@@ -2,7 +2,6 @@
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content
 {
@@ -13,7 +12,7 @@ namespace ExampleMod.Content
 
 		public static void AddRecipeGroups() {
 			//  Store this recipe group in a variable so we can use it later
-			ExampleRecipeGroup = new RecipeGroup(() => $"{Language.GetTextValue("LegacyMisc.37")} {Lang.GetItemNameValue(ItemType<Items.ExampleItem>())}", ItemType<Items.ExampleItem>());
+			ExampleRecipeGroup = new RecipeGroup(() => $"{Language.GetTextValue("LegacyMisc.37")} {Lang.GetItemNameValue(ModContent.ItemType<Items.ExampleItem>())}", ModContent.ItemType<Items.ExampleItem>());
 
 			RecipeGroup.RegisterGroup("ExampleMod:ExampleItem", ExampleRecipeGroup);
 		}
@@ -39,7 +38,7 @@ namespace ExampleMod.Content
 			//which lets you call subsequent methods on that return value, without having to type a local variable's name.
 			//When using chaining, note that only the last line is supposed to have a semicolon (;).
 
-			var resultItem = GetInstance<Items.ExampleItem>();
+			var resultItem = ModContent.GetInstance<Items.ExampleItem>();
 
 			// Start a new Recipe.
 			resultItem.CreateRecipe()

--- a/ExampleMod/Content/Items/Accessories/ExampleShield.cs
+++ b/ExampleMod/Content/Items/Accessories/ExampleShield.cs
@@ -4,7 +4,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Accessories
 {
@@ -132,7 +131,7 @@ namespace ExampleMod.Content.Items.Accessories
 
 				//Set the flag for the ExampleDashAccessory being equipped if we have it equipped OR immediately return if any of the accessories are
 				// one of the higher-priority ones
-				if (item.type == ItemType<ExampleShield>()) {
+				if (item.type == ModContent.ItemType<ExampleShield>()) {
 					dashAccessoryEquipped = true;
 				}
 				else if (item.type == ItemID.EoCShield || item.type == ItemID.MasterNinjaGear || item.type == ItemID.Tabi) {

--- a/ExampleMod/Content/Items/Accessories/WaspNest.cs
+++ b/ExampleMod/Content/Items/Accessories/WaspNest.cs
@@ -4,7 +4,7 @@ using Terraria;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Mono.Cecil.Cil.OpCodes;
+using Mono.Cecil.Cil;
 
 namespace ExampleMod.Content.Items.Accessories
 {
@@ -28,7 +28,7 @@ namespace ExampleMod.Content.Items.Accessories
 			// Move the cursor after 566 and onto the ret op.
 			c.Index++;
 			// Push the Player instance onto the stack
-			c.Emit(Ldarg_0);
+			c.Emit(OpCodes.Ldarg_0);
 			// Call a delegate using the int and Player from the stack.
 			c.EmitDelegate<Func<int, Player, int>>((returnValue, player) => {
 				// Regular c# code

--- a/ExampleMod/Content/Items/Ammo/ExampleBullet.cs
+++ b/ExampleMod/Content/Items/Ammo/ExampleBullet.cs
@@ -2,7 +2,6 @@ using ExampleMod.Content.Tiles.Furniture;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Ammo
 {
@@ -23,7 +22,7 @@ namespace ExampleMod.Content.Items.Ammo
 			item.knockBack = 1.5f;
 			item.value = 10;
 			item.rare = ItemRarityID.Green;
-			item.shoot = ProjectileType<Projectiles.ExampleBullet>(); //The projectile that weapons fire when using this item as ammunition.
+			item.shoot = ModContent.ProjectileType<Projectiles.ExampleBullet>(); //The projectile that weapons fire when using this item as ammunition.
 			item.shootSpeed = 16f; // The speed of the projectile.
 			item.ammo = AmmoID.Bullet; // The ammo class this ammo belongs to.
 		}

--- a/ExampleMod/Content/Items/Ammo/ExampleSolution.cs
+++ b/ExampleMod/Content/Items/Ammo/ExampleSolution.cs
@@ -8,7 +8,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Ammo
 {
@@ -23,7 +22,7 @@ namespace ExampleMod.Content.Items.Ammo
 		}
 
 		public override void SetDefaults() {
-			item.shoot = ProjectileType<ExampleSolutionProjectile>() - ProjectileID.PureSpray;
+			item.shoot = ModContent.ProjectileType<ExampleSolutionProjectile>() - ProjectileID.PureSpray;
 			item.ammo = AmmoID.Solution;
 			item.width = 10;
 			item.height = 12;
@@ -65,7 +64,7 @@ namespace ExampleMod.Content.Items.Ammo
 
 		public override void AI() {
 			//Set the dust type to ExampleSolution
-			int dustType = DustType<Dusts.ExampleSolution>();
+			int dustType = ModContent.DustType<Dusts.ExampleSolution>();
 
 			if (projectile.owner == Main.myPlayer) {
 				Convert((int)(projectile.position.X + (projectile.width * 0.5f)) / 16, (int)(projectile.position.Y + (projectile.height * 0.5f)) / 16, 2);
@@ -117,14 +116,14 @@ namespace ExampleMod.Content.Items.Ammo
 
 						//Convert all walls to ExampleWall
 						if (wall != 0) {
-							Main.tile[k, l].wall = (ushort)WallType<ExampleWall>();
+							Main.tile[k, l].wall = (ushort)ModContent.WallType<ExampleWall>();
 							WorldGen.SquareWallFrame(k, l);
 							NetMessage.SendTileSquare(-1, k, l, 1);
 						}
 
 						//If the tile is stone, convert to ExampleBlock
 						if (TileID.Sets.Conversion.Stone[type]) {
-							Main.tile[k, l].type = (ushort)TileType<ExampleBlock>();
+							Main.tile[k, l].type = (ushort)ModContent.TileType<ExampleBlock>();
 							WorldGen.SquareTileFrame(k, l);
 							NetMessage.SendTileSquare(-1, k, l, 1);
 						}
@@ -136,15 +135,15 @@ namespace ExampleMod.Content.Items.Ammo
 						// }
 						//If the tile is a chair, convert to ExampleChair
 						else if (type == TileID.Chairs && Main.tile[k, l - 1].type == TileID.Chairs) {
-							Main.tile[k, l].type = (ushort)TileType<ExampleChair>();
-							Main.tile[k, l - 1].type = (ushort)TileType<ExampleChair>();
+							Main.tile[k, l].type = (ushort)ModContent.TileType<ExampleChair>();
+							Main.tile[k, l - 1].type = (ushort)ModContent.TileType<ExampleChair>();
 							WorldGen.SquareTileFrame(k, l);
 							NetMessage.SendTileSquare(-1, k, l, 1);
 						}
 						//If the tile is a workbench, convert to ExampleWorkBench
 						else if (type == TileID.WorkBenches && Main.tile[k - 1, l].type == TileID.WorkBenches) {
-							Main.tile[k, l].type = (ushort)TileType<ExampleWorkbench>();
-							Main.tile[k - 1, l].type = (ushort)TileType<ExampleWorkbench>();
+							Main.tile[k, l].type = (ushort)ModContent.TileType<ExampleWorkbench>();
+							Main.tile[k - 1, l].type = (ushort)ModContent.TileType<ExampleWorkbench>();
 							WorldGen.SquareTileFrame(k, l);
 							NetMessage.SendTileSquare(-1, k, l, 1);
 						}

--- a/ExampleMod/Content/Items/Consumables/ExampleBuffPotion.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleBuffPotion.cs
@@ -2,7 +2,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Consumables
 {
@@ -25,7 +24,7 @@ namespace ExampleMod.Content.Items.Consumables
 			item.consumable = true;
 			item.rare = ItemRarityID.Orange;
 			item.value = Item.buyPrice(gold: 1);
-			item.buffType = BuffType<Buffs.ExampleDefenseBuff>(); //Specify an existing buff to be applied when used.
+			item.buffType = ModContent.BuffType<Buffs.ExampleDefenseBuff>(); //Specify an existing buff to be applied when used.
 			item.buffTime = 5400; //The amount of time the buff declared in item.buffType will last in ticks. 5400 / 60 is 90, so this buff will last 90 seconds.
 		}
 	}

--- a/ExampleMod/Content/Items/Placeable/ExampleBar.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleBar.cs
@@ -1,7 +1,6 @@
 ﻿using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Placeable
 {
@@ -23,7 +22,7 @@ namespace ExampleMod.Content.Items.Placeable
 			item.useTime = 10;
 			item.autoReuse = true;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.ExampleBar>(); // The ID of the wall that this item should place when used. ModContent.TileType<T>() method returns an integer ID of the wall provided to it through its generic type argument (the type in angle brackets)..
+			item.createTile = ModContent.TileType<Tiles.ExampleBar>(); // The ID of the wall that this item should place when used. ModContent.TileType<T>() method returns an integer ID of the wall provided to it through its generic type argument (the type in angle brackets)..
 			item.placeStyle = 0;
 		}
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Content/Items/Placeable/ExampleBlock.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleBlock.cs
@@ -3,7 +3,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Placeable
 {
@@ -45,7 +44,7 @@ namespace ExampleMod.Content.Items.Placeable
 			item.useTime = 10;
 			item.useStyle = ItemUseStyleID.Swing;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.ExampleBlock>();
+			item.createTile = ModContent.TileType<Tiles.ExampleBlock>();
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.
@@ -68,7 +67,7 @@ namespace ExampleMod.Content.Items.Placeable
 
 		public override void ExtractinatorUse(ref int resultType, ref int resultStack) { // Calls upon use of an extractinator. Below is the chance you will get ExampleOre from the extractinator.
 			if (Main.rand.NextBool(3)) {
-				resultType = ItemType<ExampleOre>();  // Get this from the extractinator with a 1 in 3 chance.
+				resultType = ModContent.ItemType<ExampleOre>();  // Get this from the extractinator with a 1 in 3 chance.
 				if (Main.rand.NextBool(5)) {
 					resultStack += Main.rand.Next(2); // Add a chance to get more than one of ExampleOre from the extractinator.
 				}

--- a/ExampleMod/Content/Items/Placeable/ExampleLamp.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleLamp.cs
@@ -1,7 +1,6 @@
 ﻿using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.GameContent.Creative;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Placeable
 {
@@ -19,7 +18,7 @@ namespace ExampleMod.Content.Items.Placeable
 			item.autoReuse = true;
 			item.maxStack = 99;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.ExampleLamp>();
+			item.createTile = ModContent.TileType<Tiles.ExampleLamp>();
 			item.width = 10;
 			item.height = 24;
 			item.value = 500;

--- a/ExampleMod/Content/Items/Placeable/ExampleOre.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleOre.cs
@@ -1,7 +1,6 @@
 ﻿using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Placeable
 {
@@ -20,7 +19,7 @@ namespace ExampleMod.Content.Items.Placeable
 			item.autoReuse = true;
 			item.maxStack = 999;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.ExampleOre>();
+			item.createTile = ModContent.TileType<Tiles.ExampleOre>();
 			item.width = 12;
 			item.height = 12;
 			item.value = 3000;

--- a/ExampleMod/Content/Items/Placeable/ExampleTorch.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleTorch.cs
@@ -4,7 +4,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Placeable
 {
@@ -26,7 +25,7 @@ namespace ExampleMod.Content.Items.Placeable
 			item.autoReuse = true;
 			item.maxStack = 999;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.ExampleTorch>();
+			item.createTile = ModContent.TileType<Tiles.ExampleTorch>();
 			item.width = 10;
 			item.height = 12;
 			item.value = 50;
@@ -39,7 +38,7 @@ namespace ExampleMod.Content.Items.Placeable
 		public override void HoldItem(Player player) {
 			// Randomly spawn sparkles when the torch is held. Twice bigger chance to spawn them when swinging the torch.
 			if (Main.rand.Next(player.itemAnimation > 0 ? 40 : 80) == 0) {
-				Dust.NewDust(new Vector2(player.itemLocation.X + 16f * player.direction, player.itemLocation.Y - 14f * player.gravDir), 4, 4, DustType<Sparkle>());
+				Dust.NewDust(new Vector2(player.itemLocation.X + 16f * player.direction, player.itemLocation.Y - 14f * player.gravDir), 4, 4, ModContent.DustType<Sparkle>());
 			}
 
 			// Create a white (1.0, 1.0, 1.0) light at the torch's approximate position, when the item is held.

--- a/ExampleMod/Content/Items/Placeable/ExampleWall.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleWall.cs
@@ -2,7 +2,6 @@ using ExampleMod.Content.Tiles.Furniture;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Placeable
 {
@@ -23,7 +22,7 @@ namespace ExampleMod.Content.Items.Placeable
 			item.useTime = 7;
 			item.useStyle = ItemUseStyleID.Swing;
 			item.consumable = true;
-			item.createWall = WallType<Walls.ExampleWall>(); // The ID of the wall that this item should place when used. ModContent.WallType<T>() method returns an integer ID of the wall provided to it through its generic type argument (the type in angle brackets).
+			item.createWall = ModContent.WallType<Walls.ExampleWall>(); // The ID of the wall that this item should place when used. ModContent.WallType<T>() method returns an integer ID of the wall provided to it through its generic type argument (the type in angle brackets).
 
 		}
 

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleBed.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleBed.cs
@@ -1,7 +1,6 @@
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.GameContent.Creative;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Placeable.Furniture
 {
@@ -23,7 +22,7 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 			item.useStyle = ItemUseStyleID.Swing;
 			item.consumable = true;
 			item.value = 2000;
-			item.createTile = TileType<Tiles.Furniture.ExampleBed>();
+			item.createTile = ModContent.TileType<Tiles.Furniture.ExampleBed>();
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleChair.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleChair.cs
@@ -1,7 +1,6 @@
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Placeable.Furniture
 {
@@ -23,7 +22,7 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 			item.useStyle = ItemUseStyleID.Swing;
 			item.consumable = true;
 			item.value = 150;
-			item.createTile = TileType<Tiles.Furniture.ExampleChair>();
+			item.createTile = ModContent.TileType<Tiles.Furniture.ExampleChair>();
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleChest.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleChest.cs
@@ -1,7 +1,6 @@
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Placeable.Furniture
 {
@@ -23,7 +22,7 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 			item.useStyle = ItemUseStyleID.Swing;
 			item.consumable = true;
 			item.value = 500;
-			item.createTile = TileType<Tiles.Furniture.ExampleChest>();
+			item.createTile = ModContent.TileType<Tiles.Furniture.ExampleChest>();
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleClock.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleClock.cs
@@ -1,7 +1,6 @@
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Placeable.Furniture
 {
@@ -23,7 +22,7 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 			item.useStyle = ItemUseStyleID.Swing;
 			item.consumable = true;
 			item.value = 500;
-			item.createTile = TileType<Tiles.Furniture.ExampleClock>();
+			item.createTile = ModContent.TileType<Tiles.Furniture.ExampleClock>();
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleDoor.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleDoor.cs
@@ -2,7 +2,6 @@ using ExampleMod.Content.Tiles.Furniture;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Placeable.Furniture
 {
@@ -24,7 +23,7 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 			item.useStyle = ItemUseStyleID.Swing;
 			item.consumable = true;
 			item.value = 150;
-			item.createTile = TileType<ExampleDoorClosed>();
+			item.createTile = ModContent.TileType<ExampleDoorClosed>();
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExamplePlatform.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExamplePlatform.cs
@@ -1,7 +1,6 @@
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Placeable.Furniture
 {
@@ -22,7 +21,7 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 			item.useTime = 10;
 			item.useStyle = ItemUseStyleID.Swing;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.Furniture.ExamplePlatform>();
+			item.createTile = ModContent.TileType<Tiles.Furniture.ExamplePlatform>();
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleWorkbench.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleWorkbench.cs
@@ -1,7 +1,6 @@
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent; //This lets us access methods (like ItemType) from ModContent without having to type its name.
 
 namespace ExampleMod.Content.Items.Placeable.Furniture
 {
@@ -13,7 +12,7 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 		}
 
 		public override void SetDefaults() {
-			item.createTile = TileType<Tiles.Furniture.ExampleWorkbench>(); //This sets the id of the tile that this item should place when used.
+			item.createTile = ModContent.TileType<Tiles.Furniture.ExampleWorkbench>(); //This sets the id of the tile that this item should place when used.
 
 			item.width = 28; //The item texture's width
 			item.height = 14; //The item texture's height

--- a/ExampleMod/Content/Items/Tools/ExampleHamaxe.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleHamaxe.cs
@@ -4,7 +4,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Tools
 {
@@ -35,7 +34,7 @@ namespace ExampleMod.Content.Items.Tools
 
 		public override void MeleeEffects(Player player, Rectangle hitbox) {
 			if (Main.rand.NextBool(10)) { // This creates a 1/10 chance that a dust will spawn every frame that this item is in its 'Swinging' animation.
-				Dust.NewDust(new Vector2(hitbox.X, hitbox.Y), hitbox.Width, hitbox.Height, DustType<Sparkle>()); //Creates a dust at the hitbox rectangle, following the rules of our 'if' conditional.
+				Dust.NewDust(new Vector2(hitbox.X, hitbox.Y), hitbox.Width, hitbox.Height, ModContent.DustType<Sparkle>()); //Creates a dust at the hitbox rectangle, following the rules of our 'if' conditional.
 			}
 		}
 

--- a/ExampleMod/Content/Items/Tools/ExampleHook.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleHook.cs
@@ -5,7 +5,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Tools
 {
@@ -20,7 +19,7 @@ namespace ExampleMod.Content.Items.Tools
 			// Copy values from the Amethyst Hook
 			item.CloneDefaults(ItemID.AmethystHook);
 			item.shootSpeed = 18f; // This defines how quickly the hook is shot.
-			item.shoot = ProjectileType<ExampleHookProjectile>(); // Makes the item shoot the hook's projectile when used.
+			item.shoot = ModContent.ProjectileType<ExampleHookProjectile>(); // Makes the item shoot the hook's projectile when used.
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.
@@ -38,7 +37,7 @@ namespace ExampleMod.Content.Items.Tools
 
 		public override void Load() { //This is called once on mod (re)load when this piece of content is being loaded.
 			// This is the path to the texture that we'll use for the hook's chain. Make sure to update it.
-			chainTexture = GetTexture("ExampleMod/Content/Items/Tools/ExampleHookChain");
+			chainTexture = ModContent.GetTexture("ExampleMod/Content/Items/Tools/ExampleHookChain");
 		}
 
 		public override void Unload() { //This is called once on mod reload when this piece of content is being unloaded.

--- a/ExampleMod/Content/Items/Tools/ExamplePickaxe.cs
+++ b/ExampleMod/Content/Items/Tools/ExamplePickaxe.cs
@@ -4,7 +4,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Tools
 {
@@ -34,7 +33,7 @@ namespace ExampleMod.Content.Items.Tools
 
 		public override void MeleeEffects(Player player, Rectangle hitbox) {
 			if (Main.rand.NextBool(10)) {
-				Dust.NewDust(new Vector2(hitbox.X, hitbox.Y), hitbox.Width, hitbox.Height, DustType<Sparkle>());
+				Dust.NewDust(new Vector2(hitbox.X, hitbox.Y), hitbox.Width, hitbox.Height, ModContent.DustType<Sparkle>());
 			}
 		}
 

--- a/ExampleMod/Content/Items/Weapons/ExampleCloneWeapon.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleCloneWeapon.cs
@@ -2,7 +2,6 @@ using ExampleMod.Content.Projectiles;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Items.Weapons
 {
@@ -29,7 +28,7 @@ namespace ExampleMod.Content.Items.Weapons
 			//After CloneDefaults has been called, we can now modify the stats to our wishes, or keep them as they are.
 			//For the sake of example, let's swap the vanilla Meowmere projectile shot from our item for our own projectile by changing item.shoot:
 			
-			item.shoot = ProjectileType<ExampleCloneProjectile>(); //Remember that we must use ProjectileType<>() since it is a modded projectile!
+			item.shoot = ModContent.ProjectileType<ExampleCloneProjectile>(); //Remember that we must use ProjectileType<>() since it is a modded projectile!
 			//Check out ExampleCloneProjectile to see how this projectile is different from the Vanilla Meowmere projectile.
 			
 			//While we're at it, let's make our weapon's stats a bit stronger than the Meowmere, which can be done

--- a/ExampleMod/Content/Items/Weapons/ExampleSword.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleSword.cs
@@ -4,7 +4,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent; //This lets us access methods (like ItemType) from ModContent without having to type its name.
 
 namespace ExampleMod.Content.Items.Weapons
 {
@@ -30,14 +29,14 @@ namespace ExampleMod.Content.Items.Weapons
 			item.crit = 6; //The critical strike chance the weapon has. The player, by default, has a 4% critical strike chance.
 
 			item.value = Item.buyPrice(gold: 1); //The value of the weapon in copper coins.
-			item.rare = RarityType<ExampleModRarity>(); // Give this item our custom rarity.
+			item.rare = ModContent.RarityType<ExampleModRarity>(); // Give this item our custom rarity.
 			item.UseSound = SoundID.Item1; //The sound when the weapon is being used.
 		}
 
 		public override void MeleeEffects(Player player, Rectangle hitbox) {
 			if (Main.rand.NextBool(3)) {
 				// Emit dusts when the sword is swung
-				Dust.NewDust(new Vector2(hitbox.X, hitbox.Y), hitbox.Width, hitbox.Height, DustType<Dusts.Sparkle>());
+				Dust.NewDust(new Vector2(hitbox.X, hitbox.Y), hitbox.Width, hitbox.Height, ModContent.DustType<Dusts.Sparkle>());
 			}
 		}
 

--- a/ExampleMod/Content/NPCs/ExamplePerson.cs
+++ b/ExampleMod/Content/NPCs/ExamplePerson.cs
@@ -13,7 +13,6 @@ using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.Utilities;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.NPCs
 {
@@ -53,7 +52,7 @@ namespace ExampleMod.Content.NPCs
 		public override void HitEffect(int hitDirection, double damage) {
 			int num = npc.life > 0 ? 1 : 5;
 			for (int k = 0; k < num; k++) {
-				Dust.NewDust(npc.position, npc.width, npc.height, DustType<Sparkle>());
+				Dust.NewDust(npc.position, npc.width, npc.height, ModContent.DustType<Sparkle>());
 			}
 		}
 
@@ -65,7 +64,7 @@ namespace ExampleMod.Content.NPCs
 				}
 
 				// Player has to have either an ExampleItem or an ExampleBlock in order for the NPC to spawn
-				if (player.inventory.Any(item => item.type == ItemType<ExampleItem>() || item.type == ItemType<Items.Placeable.ExampleBlock>())) {
+				if (player.inventory.Any(item => item.type == ModContent.ItemType<ExampleItem>() || item.type == ModContent.ItemType<Items.Placeable.ExampleBlock>())) {
 					return true;
 				}
 			}
@@ -79,11 +78,11 @@ namespace ExampleMod.Content.NPCs
 			for (int x = left; x <= right; x++) {
 				for (int y = top; y <= bottom; y++) {
 					int type = Main.tile[x, y].type;
-					if (type == TileType<ExampleBlock>() || type == TileType<ExampleChair>() || type == TileType<ExampleWorkbench>() || type == TileType<ExampleBed>() || type == TileType<ExampleDoorOpen>() || type == TileType<ExampleDoorClosed>()) {
+					if (type == ModContent.TileType<ExampleBlock>() || type == ModContent.TileType<ExampleChair>() || type == ModContent.TileType<ExampleWorkbench>() || type == ModContent.TileType<ExampleBed>() || type == ModContent.TileType<ExampleDoorOpen>() || type == ModContent.TileType<ExampleDoorClosed>()) {
 						score++;
 					}
 
-					if (Main.tile[x, y].wall == WallType<ExampleWall>()) {
+					if (Main.tile[x, y].wall == ModContent.WallType<ExampleWall>()) {
 						score++;
 					}
 				}
@@ -148,12 +147,12 @@ namespace ExampleMod.Content.NPCs
 				if (Main.LocalPlayer.HasItem(ItemID.HiveBackpack)) {
 					SoundEngine.PlaySound(SoundID.Item37); // Reforge/Anvil sound
 
-					Main.npcChatText = $"I upgraded your {Lang.GetItemNameValue(ItemID.HiveBackpack)} to a {Lang.GetItemNameValue(ItemType<WaspNest>())}";
+					Main.npcChatText = $"I upgraded your {Lang.GetItemNameValue(ItemID.HiveBackpack)} to a {Lang.GetItemNameValue(ModContent.ItemType<WaspNest>())}";
 
 					int hiveBackpackItemIndex = Main.LocalPlayer.FindItem(ItemID.HiveBackpack);
 
 					Main.LocalPlayer.inventory[hiveBackpackItemIndex].TurnToAir();
-					Main.LocalPlayer.QuickSpawnItem(ItemType<WaspNest>());
+					Main.LocalPlayer.QuickSpawnItem(ModContent.ItemType<WaspNest>());
 
 					return;
 				}
@@ -248,7 +247,7 @@ namespace ExampleMod.Content.NPCs
 					position.Y = Math.Sign(position.Y) * 20;
 				}
 
-				Dust.NewDustPerfect(npc.Center + position, DustType<Sparkle>(), Vector2.Zero).noGravity = true;
+				Dust.NewDustPerfect(npc.Center + position, ModContent.DustType<Sparkle>(), Vector2.Zero).noGravity = true;
 			}
 		}
 

--- a/ExampleMod/Content/Pets/ExampleLightPet/ExampleLightPetBuff.cs
+++ b/ExampleMod/Content/Pets/ExampleLightPet/ExampleLightPetBuff.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Pets.ExampleLightPet
 {
@@ -18,7 +17,7 @@ namespace ExampleMod.Content.Pets.ExampleLightPet
 		public override void Update(Player player, ref int buffIndex) {
 			player.buffTime[buffIndex] = 18000;
 
-			int projType = ProjectileType<ExampleLightPetProjectile>();
+			int projType = ModContent.ProjectileType<ExampleLightPetProjectile>();
 
 			//If the player is local, and there hasn't been a pet projectile spawned yet - spawn it.
 			if (player.whoAmI == Main.myPlayer && player.ownedProjectileCounts[projType] <= 0) {

--- a/ExampleMod/Content/Pets/ExampleLightPet/ExampleLightPetItem.cs
+++ b/ExampleMod/Content/Pets/ExampleLightPet/ExampleLightPetItem.cs
@@ -3,7 +3,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Pets.ExampleLightPet
 {
@@ -18,7 +17,7 @@ namespace ExampleMod.Content.Pets.ExampleLightPet
 		public override void SetDefaults() {
 			item.damage = 0;
 			item.useStyle = ItemUseStyleID.Swing;
-			item.shoot = ProjectileType<ExampleLightPetProjectile>();
+			item.shoot = ModContent.ProjectileType<ExampleLightPetProjectile>();
 			item.width = 16;
 			item.height = 30;
 			item.UseSound = SoundID.Item2;
@@ -27,7 +26,7 @@ namespace ExampleMod.Content.Pets.ExampleLightPet
 			item.rare = ItemRarityID.Yellow;
 			item.noMelee = true;
 			item.value = Item.sellPrice(0, 5, 50);
-			item.buffType = BuffType<ExampleLightPetBuff>();
+			item.buffType = ModContent.BuffType<ExampleLightPetBuff>();
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Content/Pets/ExamplePet/ExamplePetBuff.cs
+++ b/ExampleMod/Content/Pets/ExamplePet/ExamplePetBuff.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Pets.ExamplePet
 {
@@ -18,7 +17,7 @@ namespace ExampleMod.Content.Pets.ExamplePet
 		public override void Update(Player player, ref int buffIndex) { // This method gets called every frame your buff is active on your player.
 			player.buffTime[buffIndex] = 18000;
 
-			int projType = ProjectileType<ExamplePetProjectile>();
+			int projType = ModContent.ProjectileType<ExamplePetProjectile>();
 
 			//If the player is local, and there hasn't been a pet projectile spawned yet - spawn it.
 			if (player.whoAmI == Main.myPlayer && player.ownedProjectileCounts[projType] <= 0) {

--- a/ExampleMod/Content/Pets/ExamplePet/ExamplePetItem.cs
+++ b/ExampleMod/Content/Pets/ExamplePet/ExamplePetItem.cs
@@ -3,7 +3,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Pets.ExamplePet
 {
@@ -18,8 +17,8 @@ namespace ExampleMod.Content.Pets.ExamplePet
 		public override void SetDefaults() {
 			item.CloneDefaults(ItemID.ZephyrFish); // Copy the Defaults of the Zephyr Fish item.
 
-			item.shoot = ProjectileType<ExamplePetProjectile>(); // "Shoot" your pet projectile.
-			item.buffType = BuffType<ExamplePetBuff>(); // Apply buff upon usage of the item.
+			item.shoot = ModContent.ProjectileType<ExamplePetProjectile>(); // "Shoot" your pet projectile.
+			item.buffType = ModContent.BuffType<ExamplePetBuff>(); // Apply buff upon usage of the item.
 		}
 
 		public override void UseStyle(Player player) {

--- a/ExampleMod/Content/Tiles/ExampleBar.cs
+++ b/ExampleMod/Content/Tiles/ExampleBar.cs
@@ -3,7 +3,6 @@ using Terraria;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Tiles
 {
@@ -28,7 +27,7 @@ namespace ExampleMod.Content.Tiles
 			int style = t.frameX / 18;
 			if (style == 0) // It can be useful to share a single tile with multiple styles. This code will let you drop the appropriate bar if you had multiple.
 			{
-				Item.NewItem(i * 16, j * 16, 16, 16, ItemType<Items.Placeable.ExampleBar>());
+				Item.NewItem(i * 16, j * 16, 16, 16, ModContent.ItemType<Items.Placeable.ExampleBar>());
 			}
 
 			return base.Drop(i, j);

--- a/ExampleMod/Content/Tiles/ExampleBlock.cs
+++ b/ExampleMod/Content/Tiles/ExampleBlock.cs
@@ -2,7 +2,6 @@ using ExampleMod.Content.Dusts;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Tiles
 {
@@ -13,8 +12,8 @@ namespace ExampleMod.Content.Tiles
 			Main.tileMergeDirt[Type] = true;
 			Main.tileBlockLight[Type] = true;
 			Main.tileLighted[Type] = true;
-			dustType = DustType<Sparkle>();
-			drop = ItemType<Items.Placeable.ExampleBlock>();
+			dustType = ModContent.DustType<Sparkle>();
+			drop = ModContent.ItemType<Items.Placeable.ExampleBlock>();
 			AddMapEntry(new Color(200, 200, 200));
 
 			// todo: implement

--- a/ExampleMod/Content/Tiles/ExampleLamp.cs
+++ b/ExampleMod/Content/Tiles/ExampleLamp.cs
@@ -7,7 +7,6 @@ using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Tiles
 {
@@ -38,12 +37,12 @@ namespace ExampleMod.Content.Tiles
 
 			// Assets
 			if (!Main.dedServ) {
-				flameTexture = GetTexture("ExampleMod/Content/Tiles/ExampleLamp_Flame"); // We could also reuse Main.FlameTexture[] textures, but using our own texture is nice.
+				flameTexture = ModContent.GetTexture("ExampleMod/Content/Tiles/ExampleLamp_Flame"); // We could also reuse Main.FlameTexture[] textures, but using our own texture is nice.
 			}
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 16, 48, ItemType<Items.Placeable.ExampleLamp>());
+			Item.NewItem(i * 16, j * 16, 16, 48, ModContent.ItemType<Items.Placeable.ExampleLamp>());
 		}
 
 		public override void HitWire(int i, int j) {

--- a/ExampleMod/Content/Tiles/ExampleOre.cs
+++ b/ExampleMod/Content/Tiles/ExampleOre.cs
@@ -5,7 +5,6 @@ using Terraria.ID;
 using Terraria.IO;
 using Terraria.ModLoader;
 using Terraria.WorldBuilding;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Tiles
 {
@@ -26,7 +25,7 @@ namespace ExampleMod.Content.Tiles
 			AddMapEntry(new Color(152, 171, 198), name);
 
 			dustType = 84;
-			drop = ItemType<Items.Placeable.ExampleOre>();
+			drop = ModContent.ItemType<Items.Placeable.ExampleOre>();
 			soundType = SoundID.Tink;
 			soundStyle = 1;
 			//mineResist = 4f;
@@ -73,7 +72,7 @@ namespace ExampleMod.Content.Tiles
 
 				// Then, we call WorldGen.TileRunner with random "strength" and random "steps", as well as the Tile we wish to place.
 				// Feel free to experiment with strength and step to see the shape they generate.
-				WorldGen.TileRunner(x, y, WorldGen.genRand.Next(3, 6), WorldGen.genRand.Next(2, 6), TileType<ExampleOre>());
+				WorldGen.TileRunner(x, y, WorldGen.genRand.Next(3, 6), WorldGen.genRand.Next(2, 6), ModContent.TileType<ExampleOre>());
 
 				// Alternately, we could check the tile already present in the coordinate we are interested.
 				// Wrapping WorldGen.TileRunner in the following condition would make the ore only generate in Snow.

--- a/ExampleMod/Content/Tiles/ExampleTorch.cs
+++ b/ExampleMod/Content/Tiles/ExampleTorch.cs
@@ -8,7 +8,6 @@ using Terraria.Enums;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Tiles
 {
@@ -28,8 +27,8 @@ namespace ExampleMod.Content.Tiles
 			TileID.Sets.DisableSmartCursor[Type] = true;
 			TileID.Sets.Torch[Type] = true;
 
-			drop = ItemType<Items.Placeable.ExampleTorch>();
-			dustType = DustType<Sparkle>();
+			drop = ModContent.ItemType<Items.Placeable.ExampleTorch>();
+			dustType = ModContent.DustType<Sparkle>();
 			adjTiles = new int[] { TileID.Torches };
 
 			AddToArray(ref TileID.Sets.RoomNeeds.CountsAsTorch);
@@ -59,7 +58,7 @@ namespace ExampleMod.Content.Tiles
 
 			// Assets
 			if (!Main.dedServ) {
-				flameTexture = GetTexture("ExampleMod/Content/Tiles/ExampleTorch_Flame");
+				flameTexture = ModContent.GetTexture("ExampleMod/Content/Tiles/ExampleTorch_Flame");
 			}
 		}
 

--- a/ExampleMod/Content/Tiles/Furniture/ExampleBed.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleBed.cs
@@ -5,7 +5,6 @@ using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Tiles.Furniture
 {
@@ -20,7 +19,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 			TileID.Sets.IsValidSpawnPoint[Type] = true;
 			TileID.Sets.DisableSmartCursor[Type] = true;
 
-			dustType = DustType<Sparkle>();
+			dustType = ModContent.DustType<Sparkle>();
 			adjTiles = new int[] { TileID.Beds };
 
 			// Placement
@@ -38,7 +37,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 		public override void NumDust(int i, int j, bool fail, ref int num) => num = 1;
 
-		public override void KillMultiTile(int i, int j, int frameX, int frameY) => Item.NewItem(i * 16, j * 16, 64, 32, ItemType<Items.Placeable.Furniture.ExampleBed>());
+		public override void KillMultiTile(int i, int j, int frameX, int frameY) => Item.NewItem(i * 16, j * 16, 64, 32, ModContent.ItemType<Items.Placeable.Furniture.ExampleBed>());
 
 		public override bool RightClick(int i, int j) {
 			Player player = Main.LocalPlayer;
@@ -84,7 +83,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 			else {
 				player.noThrow = 2;
 				player.cursorItemIconEnabled = true;
-				player.cursorItemIconID = ItemType<Items.Placeable.Furniture.ExampleBed>();
+				player.cursorItemIconID = ModContent.ItemType<Items.Placeable.Furniture.ExampleBed>();
 			}
 		}
 	}

--- a/ExampleMod/Content/Tiles/Furniture/ExampleChair.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleChair.cs
@@ -5,7 +5,6 @@ using Terraria.Enums;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Tiles.Furniture
 {
@@ -20,7 +19,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 			AddToArray(ref TileID.Sets.RoomNeeds.CountsAsChair);
 
-			dustType = DustType<Sparkle>();
+			dustType = ModContent.DustType<Sparkle>();
 			adjTiles = new int[] { TileID.Chairs };
 
 			// Names
@@ -43,6 +42,6 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 		public override void NumDust(int i, int j, bool fail, ref int num) => num = fail ? 1 : 3;
 
-		public override void KillMultiTile(int i, int j, int frameX, int frameY) => Item.NewItem(i * 16, j * 16, 16, 32, ItemType<Items.Placeable.Furniture.ExampleChair>());
+		public override void KillMultiTile(int i, int j, int frameX, int frameY) => Item.NewItem(i * 16, j * 16, 16, 32, ModContent.ItemType<Items.Placeable.Furniture.ExampleChair>());
 	}
 }

--- a/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
@@ -9,7 +9,6 @@ using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Tiles.Furniture
 {
@@ -28,9 +27,9 @@ namespace ExampleMod.Content.Tiles.Furniture
 			TileID.Sets.BasicChest[Type] = true;
 			TileID.Sets.DisableSmartCursor[Type] = true;
 
-			dustType = DustType<Sparkle>();
+			dustType = ModContent.DustType<Sparkle>();
 			adjTiles = new int[] { TileID.Containers };
-			chestDrop = ItemType<Items.Placeable.Furniture.ExampleChest>();
+			chestDrop = ModContent.ItemType<Items.Placeable.Furniture.ExampleChest>();
 
 			// Names
 			ContainerName.SetDefault("Example Chest");
@@ -148,7 +147,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 			}
 			else {
 				if (isLocked) {
-					int key = ItemType<ExampleChestKey>();
+					int key = ModContent.ItemType<ExampleChestKey>();
 					if (player.ConsumeItem(key) && Chest.Unlock(left, top)) {
 						if (Main.netMode == NetmodeID.MultiplayerClient) {
 							NetMessage.SendData(MessageID.Unlock, -1, -1, null, player.whoAmI, 1f, left, top);
@@ -200,9 +199,9 @@ namespace ExampleMod.Content.Tiles.Furniture
 			else {
 				player.cursorItemIconText = Main.chest[chest].name.Length > 0 ? Main.chest[chest].name : "Example Chest";
 				if (player.cursorItemIconText == "Example Chest") {
-					player.cursorItemIconID = ItemType<Items.Placeable.Furniture.ExampleChest>();
+					player.cursorItemIconID = ModContent.ItemType<Items.Placeable.Furniture.ExampleChest>();
 					if (Main.tile[left, top].frameX / 36 == 1) {
-						player.cursorItemIconID = ItemType<ExampleChestKey>();
+						player.cursorItemIconID = ModContent.ItemType<ExampleChestKey>();
 					}
 
 					player.cursorItemIconText = "";

--- a/ExampleMod/Content/Tiles/Furniture/ExampleClock.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleClock.cs
@@ -4,7 +4,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Tiles.Furniture
 {
@@ -17,7 +16,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 			Main.tileLavaDeath[Type] = true;
 			TileID.Sets.Clock[Type] = true;
 
-			dustType = DustType<Sparkle>();
+			dustType = ModContent.DustType<Sparkle>();
 			adjTiles = new int[] { TileID.GrandfatherClocks };
 
 			// Placement
@@ -81,6 +80,6 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 		public override void NumDust(int i, int j, bool fail, ref int num) => num = fail ? 1 : 3;
 
-		public override void KillMultiTile(int i, int j, int frameX, int frameY) => Item.NewItem(i * 16, j * 16, 48, 32, ItemType<Items.Placeable.Furniture.ExampleClock>());
+		public override void KillMultiTile(int i, int j, int frameX, int frameY) => Item.NewItem(i * 16, j * 16, 48, 32, ModContent.ItemType<Items.Placeable.Furniture.ExampleClock>());
 	}
 }

--- a/ExampleMod/Content/Tiles/Furniture/ExampleDoorClosed.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleDoorClosed.cs
@@ -7,7 +7,6 @@ using Terraria.Enums;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Tiles.Furniture
 {
@@ -28,9 +27,9 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 			AddToArray(ref TileID.Sets.RoomNeeds.CountsAsDoor);
 
-			dustType = DustType<Sparkle>();
+			dustType = ModContent.DustType<Sparkle>();
 			adjTiles = new int[] { TileID.ClosedDoor };
-			openDoorID = TileType<ExampleDoorOpen>();
+			openDoorID = ModContent.TileType<ExampleDoorOpen>();
 
 			// Names
 			ModTranslation name = CreateMapEntryName();
@@ -61,13 +60,13 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 		public override void NumDust(int i, int j, bool fail, ref int num) => num = 1;
 
-		public override void KillMultiTile(int i, int j, int frameX, int frameY) => Item.NewItem(i * 16, j * 16, 16, 48, ItemType<ExampleDoor>());
+		public override void KillMultiTile(int i, int j, int frameX, int frameY) => Item.NewItem(i * 16, j * 16, 16, 48, ModContent.ItemType<ExampleDoor>());
 
 		public override void MouseOver(int i, int j) {
 			Player player = Main.LocalPlayer;
 			player.noThrow = 2;
 			player.cursorItemIconEnabled = true;
-			player.cursorItemIconID = ItemType<ExampleDoor>();
+			player.cursorItemIconID = ModContent.ItemType<ExampleDoor>();
 		}
 	}
 }

--- a/ExampleMod/Content/Tiles/Furniture/ExampleDoorOpen.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleDoorOpen.cs
@@ -7,7 +7,6 @@ using Terraria.Enums;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Tiles.Furniture
 {
@@ -25,9 +24,9 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 			AddToArray(ref TileID.Sets.RoomNeeds.CountsAsDoor);
 
-			dustType = DustType<Sparkle>();
+			dustType = ModContent.DustType<Sparkle>();
 			adjTiles = new int[] { TileID.OpenDoor };
-			closeDoorID = TileType<ExampleDoorClosed>();
+			closeDoorID = ModContent.TileType<ExampleDoorClosed>();
 
 			// Names
 			ModTranslation name = CreateMapEntryName();
@@ -80,13 +79,13 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 		public override void NumDust(int i, int j, bool fail, ref int num) => num = 1;
 
-		public override void KillMultiTile(int i, int j, int frameX, int frameY) => Item.NewItem(i * 16, j * 16, 32, 48, ItemType<ExampleDoor>());
+		public override void KillMultiTile(int i, int j, int frameX, int frameY) => Item.NewItem(i * 16, j * 16, 32, 48, ModContent.ItemType<ExampleDoor>());
 
 		public override void MouseOver(int i, int j) {
 			Player player = Main.LocalPlayer;
 			player.noThrow = 2;
 			player.cursorItemIconEnabled = true;
-			player.cursorItemIconID = ItemType<ExampleDoor>();
+			player.cursorItemIconID = ModContent.ItemType<ExampleDoor>();
 		}
 	}
 }

--- a/ExampleMod/Content/Tiles/Furniture/ExamplePlatform.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExamplePlatform.cs
@@ -4,7 +4,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Tiles.Furniture
 {
@@ -25,8 +24,8 @@ namespace ExampleMod.Content.Tiles.Furniture
 			AddToArray(ref TileID.Sets.RoomNeeds.CountsAsDoor);
 			AddMapEntry(new Color(200, 200, 200));
 
-			dustType = DustType<Sparkle>();
-			drop = ItemType<Items.Placeable.Furniture.ExamplePlatform>();
+			dustType = ModContent.DustType<Sparkle>();
+			drop = ModContent.ItemType<Items.Placeable.Furniture.ExamplePlatform>();
 			adjTiles = new int[] { TileID.Platforms };
 
 			// Placement

--- a/ExampleMod/Content/Tiles/Furniture/ExampleWorkbench.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleWorkbench.cs
@@ -3,7 +3,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent; //This lets us access methods (like ItemType) from ModContent without having to type its name.
 
 namespace ExampleMod.Content.Tiles.Furniture
 {
@@ -18,7 +17,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 			Main.tileFrameImportant[Type] = true;
 			TileID.Sets.DisableSmartCursor[Type] = true;
 
-			dustType = DustType<Dusts.Sparkle>();
+			dustType = ModContent.DustType<Dusts.Sparkle>();
 			adjTiles = new int[] { TileID.WorkBenches };
 
 			// Placement
@@ -37,7 +36,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 		public override void NumDust(int x, int y, bool fail, ref int num) => num = fail ? 1 : 3;
 
 		public override void KillMultiTile(int x, int y, int frameX, int frameY) {
-			Item.NewItem(x * 16, y * 16, 32, 16, ItemType<Items.Placeable.Furniture.ExampleWorkbench>());
+			Item.NewItem(x * 16, y * 16, 32, 16, ModContent.ItemType<Items.Placeable.Furniture.ExampleWorkbench>());
 		}
 	}
 }

--- a/ExampleMod/Content/Walls/ExampleWall.cs
+++ b/ExampleMod/Content/Walls/ExampleWall.cs
@@ -2,7 +2,6 @@ using ExampleMod.Content.Dusts;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Content.Walls
 {
@@ -10,8 +9,8 @@ namespace ExampleMod.Content.Walls
 	{
 		public override void SetDefaults() {
 			Main.wallHouse[Type] = true;
-			dustType = DustType<Sparkle>();
-			drop = ItemType<Items.Placeable.ExampleWall>();
+			dustType = ModContent.DustType<Sparkle>();
+			drop = ModContent.ItemType<Items.Placeable.ExampleWall>();
 			AddMapEntry(new Color(150, 150, 150));
 		}
 


### PR DESCRIPTION
### What are the changes to ExampleMod?
Removed `using static` from ExampleMod code, so that people don't get confused when `ItemType<>()` isn't working.

### Do these changes need additional documentation?
No

