### PR TITLE
Adding natural mana regen hooks to tmodloader

### DIFF
--- a/ExampleMod/Common/Players/ExampleInventoryPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleInventoryPlayer.cs
@@ -1,5 +1,6 @@
 ﻿using ExampleMod.Content.Items;
 using System.Collections.Generic;
+using System.Globalization;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -38,6 +39,10 @@ namespace ExampleMod.Common.Players
 		// Terraria's entry is always named just "Terraria"
 		public override void ModifyStartingInventory(IReadOnlyDictionary<string, List<Item>> itemsByMod, bool mediumCoreDeath) {
 			itemsByMod["Terraria"].RemoveAll(item => item.type == ItemID.IronAxe);
+		}
+
+		public override void NaturalManaRegen(ref float regen) {
+			regen = -500;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -171,6 +171,13 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to modify the power of the player's natural mana regeneration. This can be done by multiplying the regen parameter by any number. For example, walking multiplies it by 0.5.
+		/// </summary>
+		/// <param name="regen"></param>
+		public virtual void NaturalManaRegen(ref float regen) {
+		}
+
+		/// <summary>
 		/// Allows you to give the player a negative life regeneration based on its state (for example, the "On Fire!" debuff makes the player take damage-over-time). This is typically done by setting player.lifeRegen to 0 if it is positive, setting player.lifeRegenTime to 0, and subtracting a number from player.lifeRegen. The player will take damage at a rate of half the number you subtract per second.
 		/// </summary>
 		public virtual void UpdateBadLifeRegen() {

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -171,10 +171,10 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to modify the power of the player's natural mana regeneration. This can be done by multiplying the regen parameter by any number. For example, walking multiplies it by 0.5.
+		/// Allows you to modify the power of the player's natural mana regeneration. This can be done by multiplying the regen parameter by any number.
 		/// </summary>
 		/// <param name="regen"></param>
-		public virtual void NaturalManaRegen(ref float regen) {
+		public virtual void NaturalManaRegen(ref float flatRegen, ref float multiRegen) {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/PlayerHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerHooks.cs
@@ -243,12 +243,12 @@ namespace Terraria.ModLoader
 			return texture;
 		}
 
-		private delegate void DelegateNaturalManaRegen(ref float regen);
+		private delegate void DelegateNaturalManaRegen(ref float flatRegen, ref float multiRegen);
 		private static HookList HookNaturalManaRegen = AddHook<DelegateNaturalManaRegen>(p => p.NaturalManaRegen);
 
-		public static void NaturalManaRegen(Player player, ref float regen) {
+		public static void NaturalManaRegen(Player player, ref float flatRegen, ref float multiRegen) {
 			foreach (int index in HookNaturalManaRegen.arr) {
-				player.modPlayers[index].NaturalManaRegen(ref regen);
+				player.modPlayers[index].NaturalManaRegen(ref flatRegen, ref multiRegen);
 			}
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/PlayerHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerHooks.cs
@@ -243,6 +243,15 @@ namespace Terraria.ModLoader
 			return texture;
 		}
 
+		private delegate void DelegateNaturalManaRegen(ref float regen);
+		private static HookList HookNaturalManaRegen = AddHook<DelegateNaturalManaRegen>(p => p.NaturalManaRegen);
+
+		public static void NaturalManaRegen(Player player, ref float regen) {
+			foreach (int index in HookNaturalManaRegen.arr) {
+				player.modPlayers[index].NaturalManaRegen(ref regen);
+			}
+		}
+
 		private static HookList HookUpdateBadLifeRegen = AddHook<Action>(p => p.UpdateBadLifeRegen);
 
 		public static void UpdateBadLifeRegen(Player player) {

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1505,15 +1505,30 @@
  			float num4 = (float)statLifeMax2 / 400f * 0.85f + 0.15f;
  			num2 *= num4;
  			lifeRegen += (int)Math.Round(num2);
-@@ -13071,6 +_,8 @@
+@@ -13069,8 +_,9 @@
+ 				manaRegen = statManaMax2 / 7 + 1 + manaRegenBonus;
+ 				if ((velocity.X == 0f && velocity.Y == 0f) || grappling[0] >= 0 || manaRegenBuff)
  					manaRegen += statManaMax2 / 2;
- 
+-
++				
  				float num2 = (float)statMana / (float)statManaMax2 * 0.8f + 0.2f;
-+				PlayerHooks.NaturalManaRegen(this, ref num2);
 +
  				if (manaRegenBuff)
  					num2 = 1f;
  
+@@ -13080,7 +_,11 @@
+ 				manaRegen = 0;
+ 			}
+ 
+-			manaRegenCount += manaRegen;
++			float flatManaRegenNum = 0;
++			float multiManaRegenNum = 1;
++			PlayerHooks.NaturalManaRegen(this, ref flatManaRegenNum, ref multiManaRegenNum);
++
++			manaRegenCount += (int) ((manaRegen + flatManaRegenNum) * multiManaRegenNum);
+ 			while (manaRegenCount >= 120) {
+ 				bool flag = false;
+ 				manaRegenCount -= 120;
 @@ -13108,8 +_,8 @@
  
  		public void UpdateJumpHeight() {

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1505,6 +1505,15 @@
  			float num4 = (float)statLifeMax2 / 400f * 0.85f + 0.15f;
  			num2 *= num4;
  			lifeRegen += (int)Math.Round(num2);
+@@ -13071,6 +_,8 @@
+ 					manaRegen += statManaMax2 / 2;
+ 
+ 				float num2 = (float)statMana / (float)statManaMax2 * 0.8f + 0.2f;
++				PlayerHooks.NaturalManaRegen(this, ref num2);
++
+ 				if (manaRegenBuff)
+ 					num2 = 1f;
+ 
 @@ -13108,8 +_,8 @@
  
  		public void UpdateJumpHeight() {


### PR DESCRIPTION
### What is the new feature?
referencing this feature request https://github.com/tModLoader/tModLoader/issues/1105

Adding a player hook for natural mana regen, just like natural life regen.

### Why should this be part of tModLoader?

Give modders a more intricate way of messing around with mana.

### Are there alternative designs?

ATM player.manaRegenBonus exists although it is not as in depth as this hook would provide 

### Sample usage for the new feature

```cs
public class ExamplePlayer: ModPlayer {
                // for example this would double natural player regen 
		public override void NaturalManaRegen(ref float flatRegen, ref float multiRegen) {
			multiRegen *= 2;
                        flatRegen = 0; // doesn't change mana rate at all as value defaults to 0 in Player.cs
		}
}
```