### PR TITLE
Removed "using static" from ExampleMod (1.3)

### DIFF
--- a/ExampleMod/Buffs/Blocky.cs
+++ b/ExampleMod/Buffs/Blocky.cs
@@ -1,7 +1,6 @@
 using ExampleMod.Items.Placeable;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Buffs
 {
@@ -23,7 +22,7 @@ namespace ExampleMod.Buffs
 			if (player.townNPCs >= 1 && p.blockyAccessoryPrevious) {
 				p.blockyPower = true;
 				if (Main.myPlayer == player.whoAmI && Main.time % 1000 == 0) {
-					player.QuickSpawnItem(ItemType<ExampleBlock>());
+					player.QuickSpawnItem(ModContent.ItemType<ExampleBlock>());
 				}
 				player.jumpSpeedBoost += 4.8f;
 				player.extraFall += 45;

--- a/ExampleMod/Buffs/CarMount.cs
+++ b/ExampleMod/Buffs/CarMount.cs
@@ -1,6 +1,5 @@
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Buffs
 {
@@ -14,7 +13,7 @@ namespace ExampleMod.Buffs
 		}
 
 		public override void Update(Player player, ref int buffIndex) {
-			player.mount.SetMount(MountType<Mounts.Car>(), player);
+			player.mount.SetMount(ModContent.MountType<Mounts.Car>(), player);
 			player.buffTime[buffIndex] = 10;
 		}
 	}

--- a/ExampleMod/Buffs/ExampleLightPet.cs
+++ b/ExampleMod/Buffs/ExampleLightPet.cs
@@ -1,7 +1,6 @@
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Buffs
 {
@@ -17,14 +16,14 @@ namespace ExampleMod.Buffs
 		public override void Update(Player player, ref int buffIndex) {
 			player.GetModPlayer<ExamplePlayer>().exampleLightPet = true;
 			player.buffTime[buffIndex] = 18000;
-			bool petProjectileNotSpawned = player.ownedProjectileCounts[ProjectileType<Projectiles.Pets.ExampleLightPet>()] <= 0;
+			bool petProjectileNotSpawned = player.ownedProjectileCounts[ModContent.ProjectileType<Projectiles.Pets.ExampleLightPet>()] <= 0;
 			if (petProjectileNotSpawned && player.whoAmI == Main.myPlayer) {
-				Projectile.NewProjectile(player.position.X + (float)(player.width / 2), player.position.Y + (float)(player.height / 2), 0f, 0f, ProjectileType<Projectiles.Pets.ExampleLightPet>(), 0, 0f, player.whoAmI, 0f, 0f);
+				Projectile.NewProjectile(player.position.X + (float)(player.width / 2), player.position.Y + (float)(player.height / 2), 0f, 0f, ModContent.ProjectileType<Projectiles.Pets.ExampleLightPet>(), 0, 0f, player.whoAmI, 0f, 0f);
 			}
 			if (player.controlDown && player.releaseDown) {
 				if (player.doubleTapCardinalTimer[0] > 0 && player.doubleTapCardinalTimer[0] != 15) {
 					for (int j = 0; j < 1000; j++) {
-						if (Main.projectile[j].active && Main.projectile[j].type == ProjectileType<Projectiles.Pets.ExampleLightPet>() && Main.projectile[j].owner == player.whoAmI) {
+						if (Main.projectile[j].active && Main.projectile[j].type == ModContent.ProjectileType<Projectiles.Pets.ExampleLightPet>() && Main.projectile[j].owner == player.whoAmI) {
 							Projectile lightpet = Main.projectile[j];
 							Vector2 vectorToMouse = Main.MouseWorld - lightpet.Center;
 							lightpet.velocity += 5f * Vector2.Normalize(vectorToMouse);

--- a/ExampleMod/Buffs/ExamplePet.cs
+++ b/ExampleMod/Buffs/ExamplePet.cs
@@ -1,6 +1,5 @@
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Buffs
 {
@@ -17,9 +16,9 @@ namespace ExampleMod.Buffs
 		public override void Update(Player player, ref int buffIndex) {
 			player.buffTime[buffIndex] = 18000;
 			player.GetModPlayer<ExamplePlayer>().examplePet = true;
-			bool petProjectileNotSpawned = player.ownedProjectileCounts[ProjectileType<Projectiles.Pets.ExamplePet>()] <= 0;
+			bool petProjectileNotSpawned = player.ownedProjectileCounts[ModContent.ProjectileType<Projectiles.Pets.ExamplePet>()] <= 0;
 			if (petProjectileNotSpawned && player.whoAmI == Main.myPlayer) {
-				Projectile.NewProjectile(player.position.X + (float)(player.width / 2), player.position.Y + (float)(player.height / 2), 0f, 0f, ProjectileType<Projectiles.Pets.ExamplePet>(), 0, 0f, player.whoAmI, 0f, 0f);
+				Projectile.NewProjectile(player.position.X + (float)(player.width / 2), player.position.Y + (float)(player.height / 2), 0f, 0f, ModContent.ProjectileType<Projectiles.Pets.ExamplePet>(), 0, 0f, player.whoAmI, 0f, 0f);
 			}
 		}
 	}

--- a/ExampleMod/Buffs/PurityWisp.cs
+++ b/ExampleMod/Buffs/PurityWisp.cs
@@ -1,6 +1,5 @@
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Buffs
 {
@@ -15,7 +14,7 @@ namespace ExampleMod.Buffs
 
 		public override void Update(Player player, ref int buffIndex) {
 			ExamplePlayer modPlayer = player.GetModPlayer<ExamplePlayer>();
-			if (player.ownedProjectileCounts[ProjectileType<Projectiles.Minions.PurityWisp>()] > 0) {
+			if (player.ownedProjectileCounts[ModContent.ProjectileType<Projectiles.Minions.PurityWisp>()] > 0) {
 				modPlayer.purityMinion = true;
 			}
 			if (!modPlayer.purityMinion) {

--- a/ExampleMod/Commands/VolcanoCommand.cs
+++ b/ExampleMod/Commands/VolcanoCommand.cs
@@ -2,7 +2,6 @@
 using Terraria;
 using Terraria.Localization;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Commands
 {
@@ -21,7 +20,7 @@ namespace ExampleMod.Commands
 			const string key = "Mods.ExampleMod.VolcanoWarning";
 			Color messageColor = Color.Orange;
 			NetMessage.BroadcastChatMessage(NetworkText.FromKey(key), messageColor);
-			ExampleWorld exampleWorld = GetInstance<ExampleWorld>();
+			ExampleWorld exampleWorld = ModContent.GetInstance<ExampleWorld>();
 			exampleWorld.VolcanoCountdown = ExampleWorld.DefaultVolcanoCountdown;
 			exampleWorld.VolcanoCooldown = ExampleWorld.DefaultVolcanoCooldown;
 		}

--- a/ExampleMod/ExampleMod.cs
+++ b/ExampleMod/ExampleMod.cs
@@ -17,7 +17,6 @@ using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.UI;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod
 {
@@ -393,7 +392,7 @@ namespace ExampleMod
 				// This message sent by the server to initialize the Volcano Tremor on clients
 				case ExampleModMessageType.SetTremorTime:
 					int tremorTime = reader.ReadInt32();
-					ExampleWorld world = GetInstance<ExampleWorld>();
+					ExampleWorld world = ModContent.GetInstance<ExampleWorld>();
 					world.VolcanoTremorTime = tremorTime;
 					break;
 				// This message sent by the server to initialize the Volcano Rubble.

--- a/ExampleMod/ExamplePlayer.cs
+++ b/ExampleMod/ExamplePlayer.cs
@@ -17,7 +17,6 @@ using Terraria.GameInput;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod
 {
@@ -91,7 +90,7 @@ namespace ExampleMod
 
 		public override void OnEnterWorld(Player player) {
 			// We can refresh UI using OnEnterWorld. OnEnterWorld happens after Load, so nonStopParty is the correct value.
-			GetInstance<ExampleMod>().ExampleUI.ExampleButton.HoverText = "SendClientChanges Example: Non-Stop Party " + (nonStopParty ? "On" : "Off");
+			ModContent.GetInstance<ExampleMod>().ExampleUI.ExampleButton.HoverText = "SendClientChanges Example: Non-Stop Party " + (nonStopParty ? "On" : "Off");
 		}
 
 		// In MP, other clients need accurate information about your player or else bugs happen.
@@ -166,7 +165,7 @@ namespace ExampleMod
 
 		public override void SetupStartInventory(IList<Item> items, bool mediumcoreDeath) {
 			Item item = new Item();
-			item.SetDefaults(ItemType<ExampleItem>());
+			item.SetDefaults(ModContent.ItemType<ExampleItem>());
 			item.stack = 5;
 			items.Add(item);
 		}
@@ -204,7 +203,7 @@ namespace ExampleMod
 		}
 
 		public override void UpdateBiomeVisuals() {
-			bool usePurity = NPC.AnyNPCs(NPCType<PuritySpirit>());
+			bool usePurity = NPC.AnyNPCs(ModContent.NPCType<PuritySpirit>());
 			player.ManageSpecialBiomeVisuals("ExampleMod:PuritySpirit", usePurity);
 			bool useVoidMonolith = voidMonolith && !usePurity && !NPC.AnyNPCs(NPCID.MoonLordCore);
 			player.ManageSpecialBiomeVisuals("ExampleMod:MonolithVoid", useVoidMonolith, player.Center);
@@ -248,7 +247,7 @@ namespace ExampleMod
 				bool flag = false;
 				for (int k = 0; k < 200; k++) {
 					NPC npc = Main.npc[k];
-					if (npc.active && npc.type == NPCType<PuritySpirit>()) {
+					if (npc.active && npc.type == ModContent.NPCType<PuritySpirit>()) {
 						flag = true;
 						PuritySpiritTeleport(npc);
 						break;
@@ -258,13 +257,13 @@ namespace ExampleMod
 					heroLives = 0;
 				}
 				if (heroLives == 1) {
-					player.AddBuff(BuffType<Buffs.HeroOne>(), 2);
+					player.AddBuff(ModContent.BuffType<Buffs.HeroOne>(), 2);
 				}
 				else if (heroLives == 2) {
-					player.AddBuff(BuffType<Buffs.HeroTwo>(), 2);
+					player.AddBuff(ModContent.BuffType<Buffs.HeroTwo>(), 2);
 				}
 				else if (heroLives == 3) {
-					player.AddBuff(BuffType<Buffs.HeroThree>(), 3);
+					player.AddBuff(ModContent.BuffType<Buffs.HeroThree>(), 3);
 				}
 			}
 			if (purityDebuffCooldown > 0) {
@@ -343,10 +342,10 @@ namespace ExampleMod
 				}
 			}
 			if (flag || Main.expertMode || Main.rand.NextBool()) {
-				player.AddBuff(BuffType<Buffs.Undead>(), 1800, false);
+				player.AddBuff(ModContent.BuffType<Buffs.Undead>(), 1800, false);
 			}
 			for (int k = 0; k < 25; k++) {
-				Dust.NewDust(player.position, player.width, player.height, DustType<Dusts.Negative>(), 0f, -1f, 0, default(Color), 2f);
+				Dust.NewDust(player.position, player.width, player.height, ModContent.DustType<Dusts.Negative>(), 0f, -1f, 0, default(Color), 2f);
 			}
 		}
 
@@ -359,7 +358,7 @@ namespace ExampleMod
 		public override void UpdateVanityAccessories() {
 			for (int n = 13; n < 18 + player.extraAccessorySlots; n++) {
 				Item item = player.armor[n];
-				if (item.type == ItemType<Items.Armor.ExampleCostume>()) {
+				if (item.type == ModContent.ItemType<Items.Armor.ExampleCostume>()) {
 					blockyHideVanity = false;
 					blockyForceVanity = true;
 				}
@@ -369,7 +368,7 @@ namespace ExampleMod
 		public override void UpdateEquips(ref bool wallSpeedBuff, ref bool tileSpeedBuff, ref bool tileRangeBuff) {
 			// Make sure this condition is the same as the condition in the Buff to remove itself. We do this here instead of in ModItem.UpdateAccessory in case we want future upgraded items to set blockyAccessory
 			if (player.townNPCs >= 1 && blockyAccessory) {
-				player.AddBuff(BuffType<Buffs.Blocky>(), 60, true);
+				player.AddBuff(ModContent.BuffType<Buffs.Blocky>(), 60, true);
 			}
 		}
 
@@ -463,13 +462,13 @@ namespace ExampleMod
 					int k;
 					bool flag = false;
 					for (k = 3; k < 8 + player.extraAccessorySlots; k++) {
-						if (player.armor[k].type == ItemType<SixColorShield>()) {
+						if (player.armor[k].type == ModContent.ItemType<SixColorShield>()) {
 							flag = true;
 							break;
 						}
 					}
 					if (flag) {
-						Projectile.NewProjectile(player.Center.X, player.Center.Y, 0f, 0f, ProjectileType<ElementShield>(), player.GetWeaponDamage(player.armor[k]), player.GetWeaponKnockback(player.armor[k], 2f), player.whoAmI, elementShields++);
+						Projectile.NewProjectile(player.Center.X, player.Center.Y, 0f, 0f, ModContent.ProjectileType<ElementShield>(), player.GetWeaponDamage(player.armor[k]), player.GetWeaponKnockback(player.armor[k], 2f), player.whoAmI, elementShields++);
 					}
 				}
 				elementShieldTimer = 600;
@@ -477,7 +476,7 @@ namespace ExampleMod
 			if (heroLives > 0) {
 				for (int k = 0; k < 200; k++) {
 					NPC npc = Main.npc[k];
-					if (npc.active && npc.type == NPCType<PuritySpirit>()) {
+					if (npc.active && npc.type == ModContent.NPCType<PuritySpirit>()) {
 						PuritySpirit modNPC = (PuritySpirit)npc.modNPC;
 						if (modNPC.attack >= 0) {
 							double proportion = damage / player.statLifeMax2;
@@ -579,15 +578,15 @@ namespace ExampleMod
 				return;
 			}
 			if (player.FindBuffIndex(BuffID.TwinEyesMinion) > -1 && liquidType == 0 && Main.rand.NextBool(3)) {
-				caughtType = ItemType<SparklingSphere>();
+				caughtType = ModContent.ItemType<SparklingSphere>();
 			}
-			if (player.gravDir == -1f && questFish == ItemType<ExampleQuestFish>() && Main.rand.NextBool()) {
-				caughtType = ItemType<ExampleQuestFish>();
+			if (player.gravDir == -1f && questFish == ModContent.ItemType<ExampleQuestFish>() && Main.rand.NextBool()) {
+				caughtType = ModContent.ItemType<ExampleQuestFish>();
 			}
 		}
 
 		public override void GetFishingLevel(Item fishingRod, Item bait, ref int fishingLevel) {
-			if (player.FindBuffIndex(BuffType<CarMount>()) > -1) {
+			if (player.FindBuffIndex(ModContent.BuffType<CarMount>()) > -1) {
 				fishingLevel = (int)(fishingLevel * 1.1f);
 			}
 		}
@@ -612,7 +611,7 @@ namespace ExampleMod
 		public override void DrawEffects(PlayerDrawInfo drawInfo, ref float r, ref float g, ref float b, ref float a, ref bool fullBright) {
 			if (eFlames) {
 				if (Main.rand.NextBool(4) && drawInfo.shadow == 0f) {
-					int dust = Dust.NewDust(drawInfo.position - new Vector2(2f, 2f), player.width + 4, player.height + 4, DustType<EtherealFlame>(), player.velocity.X * 0.4f, player.velocity.Y * 0.4f, 100, default(Color), 3f);
+					int dust = Dust.NewDust(drawInfo.position - new Vector2(2f, 2f), player.width + 4, player.height + 4, ModContent.DustType<EtherealFlame>(), player.velocity.X * 0.4f, player.velocity.Y * 0.4f, 100, default(Color), 3f);
 					Main.dust[dust].noGravity = true;
 					Main.dust[dust].velocity *= 1.8f;
 					Main.dust[dust].velocity.Y -= 0.5f;
@@ -678,7 +677,7 @@ namespace ExampleMod
 				DrawData data = new DrawData(texture, new Vector2(drawX, drawY), null, Lighting.GetColor((int)((drawInfo.position.X + drawPlayer.width / 2f) / 16f), (int)((drawInfo.position.Y - 4f - texture.Height / 2f) / 16f)), 0f, new Vector2(texture.Width / 2f, texture.Height), 1f, SpriteEffects.None, 0);
 				Main.playerDrawData.Add(data);
 				for (int k = 0; k < 2; k++) {
-					int dust = Dust.NewDust(new Vector2(drawInfo.position.X + drawPlayer.width / 2f - texture.Width / 2f, drawInfo.position.Y - 4f - texture.Height), texture.Width, texture.Height, DustType<Smoke>(), 0f, 0f, 0, Color.Black);
+					int dust = Dust.NewDust(new Vector2(drawInfo.position.X + drawPlayer.width / 2f - texture.Width / 2f, drawInfo.position.Y - 4f - texture.Height), texture.Width, texture.Height, ModContent.DustType<Smoke>(), 0f, 0f, 0, Color.Black);
 					Main.dust[dust].velocity += drawPlayer.velocity * 0.25f;
 					Main.playerDrawDust.Add(dust);
 				}
@@ -705,7 +704,7 @@ namespace ExampleMod
 		public override void PostBuyItem(NPC vendor, Item[] shop, Item item)
 		{
 			// Here we use PostBuyItem to limit the player to only buying 1 item from the ExamplePersonFreeGiftList by removing items from the shop.
-			if (vendor.type == NPCType<ExamplePerson>() && item.GetGlobalItem<ExampleInstancedGlobalItem>().examplePersonFreeGift)
+			if (vendor.type == ModContent.NPCType<ExamplePerson>() && item.GetGlobalItem<ExampleInstancedGlobalItem>().examplePersonFreeGift)
 			{
 				examplePersonGiftReceived = true;
 				foreach (var shopItem in shop)
@@ -721,7 +720,7 @@ namespace ExampleMod
 		public override void PostSellItem(NPC vendor, Item[] shopInventory, Item item)
 		{
 			// Here we use PostSellItem to let the player buy a different item from the ExamplePersonFreeGiftList when the player sells the item back.
-			if (vendor.type == NPCType<ExamplePerson>() && (GetInstance<ExampleConfigServer>().ExamplePersonFreeGiftList?.Any(x => x.Type == item.type) ?? false))
+			if (vendor.type == ModContent.NPCType<ExamplePerson>() && (ModContent.GetInstance<ExampleConfigServer>().ExamplePersonFreeGiftList?.Any(x => x.Type == item.type) ?? false))
 			{
 				examplePersonGiftReceived = false;
 				item.TurnToAir();

--- a/ExampleMod/ExampleWorld.cs
+++ b/ExampleMod/ExampleWorld.cs
@@ -13,7 +13,6 @@ using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 using Terraria.World.Generation;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod
 {
@@ -168,7 +167,7 @@ namespace ExampleMod
 				int y = WorldGen.genRand.Next((int)WorldGen.worldSurfaceLow, Main.maxTilesY); // WorldGen.worldSurfaceLow is actually the highest surface tile. In practice you might want to use WorldGen.rockLayer or other WorldGen values.
 
 				// Then, we call WorldGen.TileRunner with random "strength" and random "steps", as well as the Tile we wish to place. Feel free to experiment with strength and step to see the shape they generate.
-				WorldGen.TileRunner(x, y, WorldGen.genRand.Next(3, 6), WorldGen.genRand.Next(2, 6), TileType<ExampleOre>());
+				WorldGen.TileRunner(x, y, WorldGen.genRand.Next(3, 6), WorldGen.genRand.Next(2, 6), ModContent.TileType<ExampleOre>());
 
 				// Alternately, we could check the tile already present in the coordinate we are interested. Wrapping WorldGen.TileRunner in the following condition would make the ore only generate in Snow.
 				// Tile tile = Framing.GetTileSafely(x, y);
@@ -188,7 +187,7 @@ namespace ExampleMod
 			for (int k = 0; k < (int)((double)(Main.maxTilesX * Main.maxTilesY) * 6E-05); k++) {
 				bool placeSuccessful = false;
 				Tile tile;
-				int tileToPlace = TileType<ExampleCutTileTile>();
+				int tileToPlace = ModContent.TileType<ExampleCutTileTile>();
 				while (!placeSuccessful) {
 					int x = WorldGen.genRand.Next(0, Main.maxTilesX);
 					int y = WorldGen.genRand.Next(0, Main.maxTilesY);
@@ -372,14 +371,14 @@ namespace ExampleMod
 			//}
 
 			// Here we spawn Example Person just like the Guide.
-			int num = NPC.NewNPC((Main.spawnTileX + 5) * 16, Main.spawnTileY * 16, NPCType<ExamplePerson>(), 0, 0f, 0f, 0f, 0f, 255);
+			int num = NPC.NewNPC((Main.spawnTileX + 5) * 16, Main.spawnTileY * 16, ModContent.NPCType<ExamplePerson>(), 0, 0f, 0f, 0f, 0f, 255);
 			Main.npc[num].homeTileX = Main.spawnTileX + 5;
 			Main.npc[num].homeTileY = Main.spawnTileY;
 			Main.npc[num].direction = 1;
 			Main.npc[num].homeless = true;
 
 			// Place some items in Ice Chests
-			int[] itemsToPlaceInIceChests = { ItemType<CarKey>(), ItemType<ExampleLightPet>(), ItemID.PinkJellyfishJar };
+			int[] itemsToPlaceInIceChests = { ModContent.ItemType<CarKey>(), ModContent.ItemType<ExampleLightPet>(), ItemID.PinkJellyfishJar };
 			int itemsToPlaceInIceChestsChoice = 0;
 			for (int chestIndex = 0; chestIndex < 1000; chestIndex++) {
 				Chest chest = Main.chest[chestIndex];
@@ -405,10 +404,10 @@ namespace ExampleMod
 
 		public override void TileCountsAvailable(int[] tileCounts) {
 			// Here we count various tiles towards ZoneExample
-			exampleTiles = tileCounts[TileType<ExampleBlock>()] + tileCounts[TileType<ExampleSand>()];
+			exampleTiles = tileCounts[ModContent.TileType<ExampleBlock>()] + tileCounts[ModContent.TileType<ExampleSand>()];
 
 			// We can also add to vanilla biome counts if appropriate. Here we are adding to the ZoneDesert since we have a sand tile in the mod.
-			Main.sandTiles += tileCounts[TileType<ExampleSand>()];
+			Main.sandTiles += tileCounts[ModContent.TileType<ExampleSand>()];
 		}
 
 		public override void PreUpdate() {
@@ -421,7 +420,7 @@ namespace ExampleMod
 				if (VolcanoCooldown > 0) {
 					VolcanoCooldown--;
 				}
-				if (VolcanoCooldown <= 0 && Main.rand.NextBool(VolcanoChance) && !GetInstance<ExampleConfigServer>().DisableVolcanoes) {
+				if (VolcanoCooldown <= 0 && Main.rand.NextBool(VolcanoChance) && !ModContent.GetInstance<ExampleConfigServer>().DisableVolcanoes) {
 					string key = "Mods.ExampleMod.VolcanoWarning";
 					Color messageColor = Color.Orange;
 					if (Main.netMode == NetmodeID.Server) // Server
@@ -489,7 +488,7 @@ namespace ExampleMod
 			Main.spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, Main.DefaultSamplerState, DepthStencilState.None, Main.instance.Rasterizer, null, Main.GameViewMatrix.TransformationMatrix);
 			var screenRect = new Rectangle((int)Main.screenPosition.X, (int)Main.screenPosition.Y, Main.screenWidth, Main.screenHeight);
 			screenRect.Inflate(TEScoreBoard.drawBorderWidth, TEScoreBoard.drawBorderWidth);
-			int scoreBoardType = TileEntityType<TEScoreBoard>();
+			int scoreBoardType = ModContent.TileEntityType<TEScoreBoard>();
 			foreach (var item in TileEntity.ByID) {
 				if (item.Value.type == scoreBoardType) {
 					var scoreBoard = item.Value as TEScoreBoard;

--- a/ExampleMod/Items/Abomination/AbominationBag.cs
+++ b/ExampleMod/Items/Abomination/AbominationBag.cs
@@ -2,7 +2,6 @@ using ExampleMod.Items.Armor;
 using ExampleMod.Items.Weapons;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Abomination
@@ -30,14 +29,14 @@ namespace ExampleMod.Items.Abomination
 		public override void OpenBossBag(Player player) {
 			player.TryGettingDevArmor();
 			if (Main.rand.NextBool(7)) {
-				player.QuickSpawnItem(ItemType<AbominationMask>());
+				player.QuickSpawnItem(ModContent.ItemType<AbominationMask>());
 			}
-			player.QuickSpawnItem(ItemType<MoltenDrill>());
-			player.QuickSpawnItem(ItemType<ElementResidue>());
-			player.QuickSpawnItem(ItemType<PurityTotem>());
-			player.QuickSpawnItem(ItemType<SixColorShield>());
+			player.QuickSpawnItem(ModContent.ItemType<MoltenDrill>());
+			player.QuickSpawnItem(ModContent.ItemType<ElementResidue>());
+			player.QuickSpawnItem(ModContent.ItemType<PurityTotem>());
+			player.QuickSpawnItem(ModContent.ItemType<SixColorShield>());
 		}
 
-		public override int BossBagNPC => NPCType<NPCs.Abomination.Abomination>();
+		public override int BossBagNPC => ModContent.NPCType<NPCs.Abomination.Abomination>();
 	}
 }

--- a/ExampleMod/Items/Abomination/FoulOrb.cs
+++ b/ExampleMod/Items/Abomination/FoulOrb.cs
@@ -3,7 +3,6 @@ using ExampleMod.Tiles;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Abomination
 {
@@ -30,11 +29,11 @@ namespace ExampleMod.Items.Abomination
 		// We use the CanUseItem hook to prevent a player from using this item while the boss is present in the world.
 		public override bool CanUseItem(Player player) {
 			// "player.ZoneUnderworldHeight" could also be written as "player.position.Y / 16f > Main.maxTilesY - 200"
-			return NPC.downedPlantBoss && player.ZoneUnderworldHeight && !NPC.AnyNPCs(NPCType<NPCs.Abomination.Abomination>()) && !NPC.AnyNPCs(NPCType<CaptiveElement>()) && !NPC.AnyNPCs(NPCType<CaptiveElement2>());
+			return NPC.downedPlantBoss && player.ZoneUnderworldHeight && !NPC.AnyNPCs(ModContent.NPCType<NPCs.Abomination.Abomination>()) && !NPC.AnyNPCs(ModContent.NPCType<CaptiveElement>()) && !NPC.AnyNPCs(ModContent.NPCType<CaptiveElement2>());
 		}
 
 		public override bool UseItem(Player player) {
-			NPC.SpawnOnPlayer(player.whoAmI, NPCType<NPCs.Abomination.Abomination>());
+			NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<NPCs.Abomination.Abomination>());
 			Main.PlaySound(SoundID.Roar, player.position, 0);
 			return true;
 		}
@@ -42,16 +41,16 @@ namespace ExampleMod.Items.Abomination
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.BeetleHusk);
-			recipe.AddIngredient(ItemType<ScytheBlade>());
-			recipe.AddIngredient(ItemType<Icicle>());
-			recipe.AddIngredient(ItemType<Bubble>());
+			recipe.AddIngredient(ModContent.ItemType<ScytheBlade>());
+			recipe.AddIngredient(ModContent.ItemType<Icicle>());
+			recipe.AddIngredient(ModContent.ItemType<Bubble>());
 			recipe.AddIngredient(ItemID.Ectoplasm, 5);
 			recipe.AddTile(TileID.MythrilAnvil);
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 			recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<BossItem>(), 10);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<BossItem>(), 10);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this, 20);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Abomination/MoltenDrill.cs
+++ b/ExampleMod/Items/Abomination/MoltenDrill.cs
@@ -1,7 +1,6 @@
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Abomination
 {
@@ -30,7 +29,7 @@ namespace ExampleMod.Items.Abomination
 			item.rare = ItemRarityID.Cyan;
 			item.UseSound = SoundID.Item23;
 			item.autoReuse = true;
-			item.shoot = ProjectileType<Projectiles.MoltenDrill>();
+			item.shoot = ModContent.ProjectileType<Projectiles.MoltenDrill>();
 			item.shootSpeed = 40f;
 		}
 	}

--- a/ExampleMod/Items/Abomination/SixColorShield.cs
+++ b/ExampleMod/Items/Abomination/SixColorShield.cs
@@ -3,7 +3,6 @@ using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Abomination
 {
@@ -61,7 +60,7 @@ namespace ExampleMod.Items.Abomination
 					int maxAccessoryIndex = 5 + player.extraAccessorySlots;
 					for (int i = 3; i < 3 + maxAccessoryIndex; i++) {
 						// We need "slot != i" because we don't care what is currently in the slot we will be replacing.
-						if (slot != i && player.armor[i].type == ItemType<SixColorShield>()) {
+						if (slot != i && player.armor[i].type == ModContent.ItemType<SixColorShield>()) {
 							return false;
 						}
 					}

--- a/ExampleMod/Items/Accessories/WaspNest.cs
+++ b/ExampleMod/Items/Accessories/WaspNest.cs
@@ -3,9 +3,7 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-
-// This shortens `c.Emit(OpCodes.Ldarg_0);` to simply `c.Emit(Ldarg_0);`
-using static Mono.Cecil.Cil.OpCodes;
+using Mono.Cecil.Cil;
 
 namespace ExampleMod.Items.Accessories
 {
@@ -34,7 +32,7 @@ namespace ExampleMod.Items.Accessories
 				// Move the cursor after 566 and onto the ret op.
 				c.Index++;
 				// Push the Player instance onto the stack
-				c.Emit(Ldarg_0);
+				c.Emit(OpCodes.Ldarg_0);
 				// Call a delegate using the int and Player from the stack.
 				c.EmitDelegate<Func<int, Player, int>>((returnValue, player) =>
 				{
@@ -49,14 +47,14 @@ namespace ExampleMod.Items.Accessories
 				// Make a label to use later
 				var label = c.DefineLabel();
 				// Push the Player instance onto the stack
-				c.Emit(Ldarg_0);
+				c.Emit(OpCodes.Ldarg_0);
 				// Call a delegate popping the Player from the stack and pushing a bool
 				c.EmitDelegate<Func<Player, bool>>(player => player.GetModPlayer<ExamplePlayer>().strongBeesUpgrade && Main.rand.NextBool(10) && Main.ProjectileUpdateLoopIndex == -1);
 				// if the bool on the stack is false, jump to label
-				c.Emit(Brfalse, label);
+				c.Emit(OpCodes.Brfalse, label);
 				// Otherwise, push ProjectileID.Beenade and return
-				c.Emit(Ldc_I4, ProjectileID.Beenade);
-				c.Emit(Ret);
+				c.Emit(OpCodes.Ldc_I4, ProjectileID.Beenade);
+				c.Emit(OpCodes.Ret);
 				// Set the label to the current cursor, which is still the instruction pushing 566 (which is followed by Ret)
 				c.MarkLabel(label);
 			}
@@ -65,24 +63,24 @@ namespace ExampleMod.Items.Accessories
 				var label = c.DefineLabel();
 
 				// Here we simply adapt the dnSpy output. This approach is tedious but easier if you don't understand IL instructions.
-				c.Emit(Ldarg_0);
+				c.Emit(OpCodes.Ldarg_0);
 				// We need to make sure to pass in FieldInfo or MethodInfo into Call instructions.
 				// Here we show how to retrieve a generic version of a MethodInfo
-				c.Emit(Call, typeof(Player).GetMethod("GetModPlayer", new Type[] { }).MakeGenericMethod(typeof(ExamplePlayer)));
+				c.Emit(OpCodes.Call, typeof(Player).GetMethod("GetModPlayer", new Type[] { }).MakeGenericMethod(typeof(ExamplePlayer)));
 				// nameof helps avoid spelling mistakes
-				c.Emit(Ldfld, typeof(ExamplePlayer).GetField(nameof(ExamplePlayer.strongBeesUpgrade)));
-				c.Emit(Brfalse_S, label);
-				c.Emit(Ldsfld, typeof(Main).GetField(nameof(Main.rand)));
+				c.Emit(OpCodes.Ldfld, typeof(ExamplePlayer).GetField(nameof(ExamplePlayer.strongBeesUpgrade)));
+				c.Emit(OpCodes.Brfalse_S, label);
+				c.Emit(OpCodes.Ldsfld, typeof(Main).GetField(nameof(Main.rand)));
 				// Ldc_I4_S expects an int8, aka an sbyte. Failure to cast correctly will crash the game
-				c.Emit(Ldc_I4_S, (sbyte)10);
-				c.Emit(Call, typeof(Utils).GetMethod("NextBool", new Type[] { typeof(Terraria.Utilities.UnifiedRandom), typeof(int) }));
-				c.Emit(Brfalse_S, label);
+				c.Emit(OpCodes.Ldc_I4_S, (sbyte)10);
+				c.Emit(OpCodes.Call, typeof(Utils).GetMethod("NextBool", new Type[] { typeof(Terraria.Utilities.UnifiedRandom), typeof(int) }));
+				c.Emit(OpCodes.Brfalse_S, label);
 				// You may be tempted to write c.Emit(Ldsfld, Main.ProjectileUpdateLoopIndex);, this won't work and will simply use the value of the field at patch time. That will crash.
-				c.Emit(Ldsfld, typeof(Main).GetField(nameof(Main.ProjectileUpdateLoopIndex)));
-				c.Emit(Ldc_I4_M1);
-				c.Emit(Bne_Un_S, label);
-				c.Emit(Ldc_I4, ProjectileID.Beenade);
-				c.Emit(Ret);
+				c.Emit(OpCodes.Ldsfld, typeof(Main).GetField(nameof(Main.ProjectileUpdateLoopIndex)));
+				c.Emit(OpCodes.Ldc_I4_M1);
+				c.Emit(OpCodes.Bne_Un_S, label);
+				c.Emit(OpCodes.Ldc_I4, ProjectileID.Beenade);
+				c.Emit(OpCodes.Ret);
 				// As Emit has been inserting and advancing the cursor index, we are still pointing at the 566 instruction. 
 				// All the branches in the dnspy output jumped to this instruction, so we set the label to this instruction.
 				c.MarkLabel(label);

--- a/ExampleMod/Items/Armor/ExampleBreastplate.cs
+++ b/ExampleMod/Items/Armor/ExampleBreastplate.cs
@@ -2,7 +2,6 @@ using ExampleMod.Tiles;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Armor
 {
@@ -33,8 +32,8 @@ namespace ExampleMod.Items.Armor
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<EquipMaterial>(), 60);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<EquipMaterial>(), 60);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Armor/ExampleCostume.cs
+++ b/ExampleMod/Items/Armor/ExampleCostume.cs
@@ -1,7 +1,6 @@
 using ExampleMod.Dusts;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Armor
@@ -53,7 +52,7 @@ namespace ExampleMod.Items.Armor
 
 		public override void UpdateVanity(Player player, EquipType type) {
 			if (Main.rand.NextBool(20)) {
-				Dust.NewDust(player.position, player.width, player.height, DustType<Sparkle>());
+				Dust.NewDust(player.position, player.width, player.height, ModContent.DustType<Sparkle>());
 			}
 		}
 	}

--- a/ExampleMod/Items/Armor/ExampleHelmet.cs
+++ b/ExampleMod/Items/Armor/ExampleHelmet.cs
@@ -1,7 +1,6 @@
 using ExampleMod.Tiles;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Armor
@@ -22,7 +21,7 @@ namespace ExampleMod.Items.Armor
 		}
 
 		public override bool IsArmorSet(Item head, Item body, Item legs) {
-			return body.type == ItemType<ExampleBreastplate>() && legs.type == ItemType<ExampleLeggings>();
+			return body.type == ModContent.ItemType<ExampleBreastplate>() && legs.type == ModContent.ItemType<ExampleLeggings>();
 		}
 
 		public override void UpdateArmorSet(Player player) {
@@ -39,8 +38,8 @@ namespace ExampleMod.Items.Armor
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<EquipMaterial>(), 30);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<EquipMaterial>(), 30);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Armor/ExampleHood.cs
+++ b/ExampleMod/Items/Armor/ExampleHood.cs
@@ -2,7 +2,6 @@ using ExampleMod.Tiles;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Armor
 {
@@ -22,7 +21,7 @@ namespace ExampleMod.Items.Armor
 		}
 
 		public override bool IsArmorSet(Item head, Item body, Item legs) {
-			return body.type == ItemType<ExampleBreastplate>() && legs.type == ItemType<ExampleLeggings>();
+			return body.type == ModContent.ItemType<ExampleBreastplate>() && legs.type == ModContent.ItemType<ExampleLeggings>();
 		}
 
 		public override void UpdateArmorSet(Player player) {
@@ -33,8 +32,8 @@ namespace ExampleMod.Items.Armor
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<EquipMaterial>(), 30);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<EquipMaterial>(), 30);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Armor/ExampleLeggings.cs
+++ b/ExampleMod/Items/Armor/ExampleLeggings.cs
@@ -1,7 +1,6 @@
 using ExampleMod.Tiles;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Armor
@@ -28,8 +27,8 @@ namespace ExampleMod.Items.Armor
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<EquipMaterial>(), 45);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<EquipMaterial>(), 45);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Banners/OctopusBanner.cs
+++ b/ExampleMod/Items/Banners/OctopusBanner.cs
@@ -1,7 +1,6 @@
 using ExampleMod.Tiles;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Banners
@@ -21,7 +20,7 @@ namespace ExampleMod.Items.Banners
 			item.consumable = true;
 			item.rare = ItemRarityID.Blue;
 			item.value = Item.buyPrice(0, 0, 10, 0);
-			item.createTile = TileType<MonsterBanner>();
+			item.createTile = ModContent.TileType<MonsterBanner>();
 			item.placeStyle = 1;        //Place style means which frame(Horizontally, starting from 0) of the tile should be placed
 		}
 	}

--- a/ExampleMod/Items/Banners/SarcophagusBanner.cs
+++ b/ExampleMod/Items/Banners/SarcophagusBanner.cs
@@ -1,7 +1,6 @@
 using ExampleMod.Tiles;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Banners
@@ -21,7 +20,7 @@ namespace ExampleMod.Items.Banners
 			item.consumable = true;
 			item.rare = ItemRarityID.Blue;
 			item.value = Item.buyPrice(0, 0, 10, 0);
-			item.createTile = TileType<MonsterBanner>();
+			item.createTile = ModContent.TileType<MonsterBanner>();
 			item.placeStyle = 0;
 		}
 	}

--- a/ExampleMod/Items/BossBags.cs
+++ b/ExampleMod/Items/BossBags.cs
@@ -2,7 +2,6 @@ using ExampleMod.Items.Abomination;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -12,7 +11,7 @@ namespace ExampleMod.Items
 			// This method shows adding items to Fishrons boss bag. 
 			// Typically you'll also want to also add an item to the non-expert boss drops, that code can be found in ExampleGlobalNPC.NPCLoot. Use this and that to add drops to bosses.
 			if (context == "bossBag" && arg == ItemID.FishronBossBag) {
-				player.QuickSpawnItem(ItemType<Bubble>(), Main.rand.Next(8, 13));
+				player.QuickSpawnItem(ModContent.ItemType<Bubble>(), Main.rand.Next(8, 13));
 			}
 		}
 	}

--- a/ExampleMod/Items/BossItem.cs
+++ b/ExampleMod/Items/BossItem.cs
@@ -1,5 +1,4 @@
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -11,7 +10,7 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/CarKey.cs
+++ b/ExampleMod/Items/CarKey.cs
@@ -2,7 +2,6 @@ using ExampleMod.Mounts;
 using ExampleMod.Tiles;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -22,13 +21,13 @@ namespace ExampleMod.Items
 			item.rare = ItemRarityID.Green;
 			item.UseSound = SoundID.Item79;
 			item.noMelee = true;
-			item.mountType = MountType<Car>();
+			item.mountType = ModContent.MountType<Car>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/EquipMaterial.cs
+++ b/ExampleMod/Items/EquipMaterial.cs
@@ -1,5 +1,4 @@
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -12,7 +11,7 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/ExampleBuffPotion.cs
+++ b/ExampleMod/Items/ExampleBuffPotion.cs
@@ -1,7 +1,6 @@
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -25,7 +24,7 @@ namespace ExampleMod.Items
             item.consumable = true;
             item.rare = ItemRarityID.Orange;
             item.value = Item.buyPrice(gold: 1);
-            item.buffType = BuffType<Buffs.ExampleDefenseBuff>(); //Specify an existing buff to be applied when used.
+            item.buffType = ModContent.BuffType<Buffs.ExampleDefenseBuff>(); //Specify an existing buff to be applied when used.
             item.buffTime = 5400; //The amount of time the buff declared in item.buffType will last in ticks. 5400 / 60 is 90, so this buff will last 90 seconds.
         }
     }

--- a/ExampleMod/Items/ExampleDamageClass/ExampleResourceStaff.cs
+++ b/ExampleMod/Items/ExampleDamageClass/ExampleResourceStaff.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.ExampleDamageClass
 {

--- a/ExampleMod/Items/ExampleDamageClass/Mundane.cs
+++ b/ExampleMod/Items/ExampleDamageClass/Mundane.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
-using static Terraria.ModLoader.ModContent;
+using Terraria.ModLoader;
 
 namespace ExampleMod.Items.ExampleDamageClass
 {
@@ -23,7 +23,7 @@ namespace ExampleMod.Items.ExampleDamageClass
 
 		private static float PlayerOnGetWeaponKnockback(On.Terraria.Player.orig_GetWeaponKnockback orig, Player self, Item sitem, float knockback)
 		{
-			bool isMundane = sitem.type == ItemType<Mundane>();
+			bool isMundane = sitem.type == ModContent.ItemType<Mundane>();
 			if (isMundane)sitem.ranged = true;
 
 			float kb = orig(self, sitem, knockback);
@@ -33,7 +33,7 @@ namespace ExampleMod.Items.ExampleDamageClass
 
 		private static int PlayerOnGetWeaponDamage(On.Terraria.Player.orig_GetWeaponDamage orig, Player self, Item sitem)
 		{
-			bool isMundane = sitem.type == ItemType<Mundane>();
+			bool isMundane = sitem.type == ModContent.ItemType<Mundane>();
 			if (isMundane) sitem.ranged = true;
 			
 			int dmg = orig(self, sitem);

--- a/ExampleMod/Items/ExampleDashAccessory.cs
+++ b/ExampleMod/Items/ExampleDashAccessory.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -78,8 +77,8 @@ namespace ExampleMod.Items
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}
@@ -124,7 +123,7 @@ namespace ExampleMod.Items
 
 				//Set the flag for the ExampleDashAccessory being equipped if we have it equipped OR immediately return if any of the accessories are
 				// one of the higher-priority ones
-				if(item.type == ItemType<ExampleDashAccessory>())
+				if(item.type == ModContent.ItemType<ExampleDashAccessory>())
 					dashAccessoryEquipped = true;
 				else if(item.type == ItemID.EoCShield || item.type == ItemID.MasterNinjaGear || item.type == ItemID.Tabi)
 					return;

--- a/ExampleMod/Items/ExampleDrawTooltips.cs
+++ b/ExampleMod/Items/ExampleDrawTooltips.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Terraria;
 using Terraria.ModLoader;
 using Terraria.UI.Chat;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items
@@ -101,7 +100,7 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/ExampleFishingRod.cs
+++ b/ExampleMod/Items/ExampleFishingRod.cs
@@ -4,7 +4,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -39,7 +38,7 @@ namespace ExampleMod.Items
 			item.shootSpeed = 12f;
 
 			//The Bobber projectile
-			item.shoot = ProjectileType<ExampleBobber>();
+			item.shoot = ModContent.ProjectileType<ExampleBobber>();
 
 			// Change the item's draw color so that it is visually distinct from the vanilla Wooden Fishing Rod.
 			item.color = OverrideColor;
@@ -66,8 +65,8 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/ExampleHamaxe.cs
+++ b/ExampleMod/Items/ExampleHamaxe.cs
@@ -4,7 +4,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -33,15 +32,15 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}
 
 		public override void MeleeEffects(Player player, Rectangle hitbox) {
 			if (Main.rand.NextBool(10)) {
-				int dust = Dust.NewDust(new Vector2(hitbox.X, hitbox.Y), hitbox.Width, hitbox.Height, DustType<Sparkle>());
+				int dust = Dust.NewDust(new Vector2(hitbox.X, hitbox.Y), hitbox.Width, hitbox.Height, ModContent.DustType<Sparkle>());
 			}
 		}
 	}

--- a/ExampleMod/Items/ExampleHook.cs
+++ b/ExampleMod/Items/ExampleHook.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -34,7 +33,7 @@ namespace ExampleMod.Items
 			// Instead of copying these values, we can clone and modify the ones we want to copy
 			item.CloneDefaults(ItemID.AmethystHook);
 			item.shootSpeed = 18f; // how quickly the hook is shot.
-			item.shoot = ProjectileType<ExampleHookProjectile>();
+			item.shoot = ModContent.ProjectileType<ExampleHookProjectile>();
 		}
 	}
 

--- a/ExampleMod/Items/ExampleInstancedGlobalItem.cs
+++ b/ExampleMod/Items/ExampleInstancedGlobalItem.cs
@@ -5,7 +5,6 @@ using Terraria;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 using Terraria.Utilities;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -66,7 +65,7 @@ namespace ExampleMod.Items
 					overrideColor = Color.Magenta
 				});
 			}
-			if (GetInstance<ExampleConfigClient>().ShowModOriginTooltip)
+			if (ModContent.GetInstance<ExampleConfigClient>().ShowModOriginTooltip)
 			{
 				foreach (TooltipLine line3 in tooltips)
 				{

--- a/ExampleMod/Items/ExampleLifeFruit.cs
+++ b/ExampleMod/Items/ExampleLifeFruit.cs
@@ -2,7 +2,6 @@
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -46,7 +45,7 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>());
 			recipe.SetResult(this, 11);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/ExampleLightPet.cs
+++ b/ExampleMod/Items/ExampleLightPet.cs
@@ -1,7 +1,6 @@
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -15,7 +14,7 @@ namespace ExampleMod.Items
 		public override void SetDefaults() {
 			item.damage = 0;
 			item.useStyle = ItemUseStyleID.SwingThrow;
-			item.shoot = ProjectileType<Projectiles.Pets.ExampleLightPet>();
+			item.shoot = ModContent.ProjectileType<Projectiles.Pets.ExampleLightPet>();
 			item.width = 16;
 			item.height = 30;
 			item.UseSound = SoundID.Item2;
@@ -24,7 +23,7 @@ namespace ExampleMod.Items
 			item.rare = ItemRarityID.Yellow;
 			item.noMelee = true;
 			item.value = Item.sellPrice(0, 5, 50, 0);
-			item.buffType = BuffType<Buffs.ExampleLightPet>();
+			item.buffType = ModContent.BuffType<Buffs.ExampleLightPet>();
 		}
 
 		public override void AddRecipes() {

--- a/ExampleMod/Items/ExampleMagicMirror.cs
+++ b/ExampleMod/Items/ExampleMagicMirror.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -72,7 +71,7 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/ExamplePet.cs
+++ b/ExampleMod/Items/ExamplePet.cs
@@ -2,7 +2,6 @@ using ExampleMod.Tiles;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -16,14 +15,14 @@ namespace ExampleMod.Items
 
 		public override void SetDefaults() {
 			item.CloneDefaults(ItemID.ZephyrFish);
-			item.shoot = ProjectileType<Projectiles.Pets.ExamplePet>();
-			item.buffType = BuffType<Buffs.ExamplePet>();
+			item.shoot = ModContent.ProjectileType<Projectiles.Pets.ExamplePet>();
+			item.buffType = ModContent.BuffType<Buffs.ExamplePet>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/ExamplePickaxe.cs
+++ b/ExampleMod/Items/ExamplePickaxe.cs
@@ -4,7 +4,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -32,15 +31,15 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}
 
 		public override void MeleeEffects(Player player, Rectangle hitbox) {
 			if (Main.rand.NextBool(10)) {
-				int dust = Dust.NewDust(new Vector2(hitbox.X, hitbox.Y), hitbox.Width, hitbox.Height, DustType<Sparkle>());
+				int dust = Dust.NewDust(new Vector2(hitbox.X, hitbox.Y), hitbox.Width, hitbox.Height, ModContent.DustType<Sparkle>());
 			}
 		}
 	}

--- a/ExampleMod/Items/ExampleShield.cs
+++ b/ExampleMod/Items/ExampleShield.cs
@@ -2,7 +2,6 @@ using ExampleMod.Tiles;
 using Terraria;
 using Terraria.Localization;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items
@@ -48,8 +47,8 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<EquipMaterial>(), 60);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<EquipMaterial>(), 60);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/ExampleSolution.cs
+++ b/ExampleMod/Items/ExampleSolution.cs
@@ -1,7 +1,6 @@
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -14,7 +13,7 @@ namespace ExampleMod.Items
 		}
 
 		public override void SetDefaults() {
-			item.shoot = ProjectileType<Projectiles.ExampleSolution>() - ProjectileID.PureSpray;
+			item.shoot = ModContent.ProjectileType<Projectiles.ExampleSolution>() - ProjectileID.PureSpray;
 			item.ammo = AmmoID.Solution;
 			item.width = 10;
 			item.height = 12;
@@ -26,7 +25,7 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
 			recipe.SetResult(this, 999);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/ExampleSoul.cs
+++ b/ExampleMod/Items/ExampleSoul.cs
@@ -3,7 +3,6 @@ using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -52,7 +51,7 @@ namespace ExampleMod.Items
 	{
 		public override void NPCLoot(NPC npc) {
 			if (Main.player[(int)Player.FindClosest(npc.position, npc.width, npc.height)].GetModPlayer<ExamplePlayer>().ZoneExample) {
-				Item.NewItem(npc.getRect(), ItemType<ExampleSoul>(), 1);
+				Item.NewItem(npc.getRect(), ModContent.ItemType<ExampleSoul>(), 1);
 			}
 		}
 	}

--- a/ExampleMod/Items/ExampleWings.cs
+++ b/ExampleMod/Items/ExampleWings.cs
@@ -1,7 +1,6 @@
 using ExampleMod.Tiles;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items
@@ -11,7 +10,7 @@ namespace ExampleMod.Items
 	{
 		public override bool Autoload(ref string name)
 		{
-			return !GetInstance<ExampleConfigServer>().DisableExampleWings;
+			return !ModContent.GetInstance<ExampleConfigServer>().DisableExampleWings;
 		}
 
 		public override void SetStaticDefaults() {
@@ -46,8 +45,8 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<EquipMaterial>(), 60);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<EquipMaterial>(), 60);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/ExplorerBag.cs
+++ b/ExampleMod/Items/ExplorerBag.cs
@@ -1,7 +1,6 @@
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -35,7 +34,7 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Face.cs
+++ b/ExampleMod/Items/Face.cs
@@ -5,7 +5,6 @@ using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -14,7 +13,7 @@ namespace ExampleMod.Items
 		public override void SetStaticDefaults() {
 			// See here for help on using Tags: http://terraria.gamepedia.com/Chat#Tags
 			Tooltip.SetDefault("How are you feeling today?"
-				+ $"\n[c/FF0000:Colors ][c/00FF00:are ][c/0000FF:fun ]and so are items: [i:{item.type}][i:{ItemType<CarKey>()}][i/s123:{ItemID.Ectoplasm}]");
+				+ $"\n[c/FF0000:Colors ][c/00FF00:are ][c/0000FF:fun ]and so are items: [i:{item.type}][i:{ModContent.ItemType<CarKey>()}][i/s123:{ItemID.Ectoplasm}]");
 
 			Main.RegisterItemAnimation(item.type, new DrawAnimationVertical(30, 4));
 			ItemID.Sets.ItemNoGravity[item.type] = true;
@@ -59,7 +58,7 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Fertilizer.cs
+++ b/ExampleMod/Items/Fertilizer.cs
@@ -2,7 +2,6 @@ using ExampleMod.Tiles;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -41,8 +40,8 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this, 5);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/GlobalPotion.cs
+++ b/ExampleMod/Items/GlobalPotion.cs
@@ -1,7 +1,6 @@
 using ExampleMod.Buffs;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -16,7 +15,7 @@ namespace ExampleMod.Items
 						heal = damage;
 					}
 					if (heal > 0) {
-						player.AddBuff(BuffType<Undead2>(), 2 * heal, false);
+						player.AddBuff(ModContent.BuffType<Undead2>(), 2 * heal, false);
 					}
 				}
 			}

--- a/ExampleMod/Items/Placeable/AbominationTrophy.cs
+++ b/ExampleMod/Items/Placeable/AbominationTrophy.cs
@@ -1,6 +1,5 @@
 using ExampleMod.Tiles;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Placeable
@@ -19,7 +18,7 @@ namespace ExampleMod.Items.Placeable
 			item.consumable = true;
 			item.value = 50000;
 			item.rare = ItemRarityID.Blue;
-			item.createTile = TileType<BossTrophy>();
+			item.createTile = ModContent.TileType<BossTrophy>();
 			item.placeStyle = 0;
 		}
 	}

--- a/ExampleMod/Items/Placeable/BunnyTrophy.cs
+++ b/ExampleMod/Items/Placeable/BunnyTrophy.cs
@@ -1,6 +1,5 @@
 using ExampleMod.Tiles;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Placeable
@@ -19,7 +18,7 @@ namespace ExampleMod.Items.Placeable
 			item.consumable = true;
 			item.value = 50000;
 			item.rare = ItemRarityID.Blue;
-			item.createTile = TileType<BossTrophy>();
+			item.createTile = ModContent.TileType<BossTrophy>();
 			item.placeStyle = 2;
 		}
 	}

--- a/ExampleMod/Items/Placeable/ElementalPurge.cs
+++ b/ExampleMod/Items/Placeable/ElementalPurge.cs
@@ -2,7 +2,6 @@ using ExampleMod.Items.Abomination;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -20,7 +19,7 @@ namespace ExampleMod.Items.Placeable
 			item.consumable = true;
 			item.rare = ItemRarityID.Red;
 			item.value = Item.buyPrice(0, 20, 0, 0);
-			item.createTile = TileType<Tiles.ElementalPurge>();
+			item.createTile = ModContent.TileType<Tiles.ElementalPurge>();
 		}
 
 		public override void AddRecipes() {

--- a/ExampleMod/Items/Placeable/ElementalPurge.cs
+++ b/ExampleMod/Items/Placeable/ElementalPurge.cs
@@ -24,8 +24,8 @@ namespace ExampleMod.Items.Placeable
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<VoidMonolith>());
-			recipe.AddIngredient(ItemType<ElementResidue>());
+			recipe.AddIngredient(ModContent.ItemType<VoidMonolith>());
+			recipe.AddIngredient(ModContent.ItemType<ElementResidue>());
 			recipe.AddTile(TileID.CrystalBall);
 			recipe.SetResult(this);
 			recipe.AddRecipe();

--- a/ExampleMod/Items/Placeable/ExampleBar.cs
+++ b/ExampleMod/Items/Placeable/ExampleBar.cs
@@ -1,6 +1,5 @@
 ﻿using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -23,14 +22,14 @@ namespace ExampleMod.Items.Placeable
 			item.useTime = 10;
 			item.autoReuse = true;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.ExampleBar>();
+			item.createTile = ModContent.TileType<Tiles.ExampleBar>();
 			item.placeStyle = 0;
 		}
 
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleOre>(), 4);
+			recipe.AddIngredient(ModContent.ItemType<ExampleOre>(), 4);
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Placeable/ExampleBed.cs
+++ b/ExampleMod/Items/Placeable/ExampleBed.cs
@@ -1,6 +1,5 @@
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -21,14 +20,14 @@ namespace ExampleMod.Items.Placeable
 			item.useStyle = ItemUseStyleID.SwingThrow;
 			item.consumable = true;
 			item.value = 2000;
-			item.createTile = TileType<Tiles.ExampleBed>();
+			item.createTile = ModContent.TileType<Tiles.ExampleBed>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.Bed);
-			recipe.AddIngredient(ItemType<ExampleBlock>(), 10);
-			recipe.AddTile(TileType<Tiles.ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleBlock>(), 10);
+			recipe.AddTile(ModContent.TileType<Tiles.ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Placeable/ExampleBlock.cs
+++ b/ExampleMod/Items/Placeable/ExampleBlock.cs
@@ -4,7 +4,6 @@ using Terraria.ID;
 // If you are using c# 6, you can use: "using static Terraria.Localization.GameCulture;" which would mean you could just write "DisplayName.AddTranslation(German, "");"
 using Terraria.Localization;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -43,28 +42,28 @@ namespace ExampleMod.Items.Placeable
 			item.useTime = 10;
 			item.useStyle = ItemUseStyleID.SwingThrow;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.ExampleBlock>();
+			item.createTile = ModContent.TileType<Tiles.ExampleBlock>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>());
 			recipe.SetResult(this, 10);
 			recipe.AddRecipe();
 			recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleWall>(), 4);
+			recipe.AddIngredient(ModContent.ItemType<ExampleWall>(), 4);
 			recipe.SetResult(this);
-			recipe.AddTile(TileType<Tiles.ExampleWorkbench>());
+			recipe.AddTile(ModContent.TileType<Tiles.ExampleWorkbench>());
 			recipe.AddRecipe();
 			recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExamplePlatform>(), 2);
+			recipe.AddIngredient(ModContent.ItemType<ExamplePlatform>(), 2);
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}
 
 		public override void ExtractinatorUse(ref int resultType, ref int resultStack) {
 			if (Main.rand.NextBool(30)) {
-				resultType = ItemType<FoulOrb>();
+				resultType = ModContent.ItemType<FoulOrb>();
 				if (Main.rand.NextBool(5)) {
 					resultStack += Main.rand.Next(2);
 				}

--- a/ExampleMod/Items/Placeable/ExampleChair.cs
+++ b/ExampleMod/Items/Placeable/ExampleChair.cs
@@ -1,6 +1,5 @@
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -21,14 +20,14 @@ namespace ExampleMod.Items.Placeable
 			item.useStyle = ItemUseStyleID.SwingThrow;
 			item.consumable = true;
 			item.value = 150;
-			item.createTile = TileType<Tiles.ExampleChair>();
+			item.createTile = ModContent.TileType<Tiles.ExampleChair>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.WoodenChair);
-			recipe.AddIngredient(ItemType<ExampleBlock>(), 10);
-			recipe.AddTile(TileType<Tiles.ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleBlock>(), 10);
+			recipe.AddTile(ModContent.TileType<Tiles.ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Placeable/ExampleChest.cs
+++ b/ExampleMod/Items/Placeable/ExampleChest.cs
@@ -1,6 +1,5 @@
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -21,13 +20,13 @@ namespace ExampleMod.Items.Placeable
 			item.useStyle = ItemUseStyleID.SwingThrow;
 			item.consumable = true;
 			item.value = 500;
-			item.createTile = TileType<Tiles.ExampleChest>();
+			item.createTile = ModContent.TileType<Tiles.ExampleChest>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.Chest);
-			recipe.AddIngredient(ItemType<ExampleBlock>(), 10);
+			recipe.AddIngredient(ModContent.ItemType<ExampleBlock>(), 10);
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Placeable/ExampleClock.cs
+++ b/ExampleMod/Items/Placeable/ExampleClock.cs
@@ -1,6 +1,5 @@
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -21,13 +20,13 @@ namespace ExampleMod.Items.Placeable
 			item.useStyle = ItemUseStyleID.SwingThrow;
 			item.consumable = true;
 			item.value = 500;
-			item.createTile = TileType<Tiles.ExampleClock>();
+			item.createTile = ModContent.TileType<Tiles.ExampleClock>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.GrandfatherClock);
-			recipe.AddIngredient(ItemType<ExampleBlock>(), 10);
+			recipe.AddIngredient(ModContent.ItemType<ExampleBlock>(), 10);
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Placeable/ExampleDoor.cs
+++ b/ExampleMod/Items/Placeable/ExampleDoor.cs
@@ -1,6 +1,5 @@
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -21,14 +20,14 @@ namespace ExampleMod.Items.Placeable
 			item.useStyle = ItemUseStyleID.SwingThrow;
 			item.consumable = true;
 			item.value = 150;
-			item.createTile = TileType<Tiles.ExampleDoorClosed>();
+			item.createTile = ModContent.TileType<Tiles.ExampleDoorClosed>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.WoodenDoor);
-			recipe.AddIngredient(ItemType<ExampleBlock>(), 10);
-			recipe.AddTile(TileType<Tiles.ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleBlock>(), 10);
+			recipe.AddTile(ModContent.TileType<Tiles.ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Placeable/ExampleDresser.cs
+++ b/ExampleMod/Items/Placeable/ExampleDresser.cs
@@ -1,6 +1,5 @@
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -21,13 +20,13 @@ namespace ExampleMod.Items.Placeable
 			item.useStyle = ItemUseStyleID.SwingThrow;
 			item.consumable = true;
 			item.value = 500;
-			item.createTile = TileType<Tiles.ExampleDresser>();
+			item.createTile = ModContent.TileType<Tiles.ExampleDresser>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.Dresser);
-			recipe.AddIngredient(ItemType<ExampleBlock>(), 10);
+			recipe.AddIngredient(ModContent.ItemType<ExampleBlock>(), 10);
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Placeable/ExampleHerbSeeds.cs
+++ b/ExampleMod/Items/Placeable/ExampleHerbSeeds.cs
@@ -1,5 +1,4 @@
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Placeable
@@ -18,12 +17,12 @@ namespace ExampleMod.Items.Placeable
 			item.width = 12;
 			item.height = 14;
 			item.value = 80;
-			item.createTile = TileType<Tiles.ExampleHerb>();
+			item.createTile = ModContent.TileType<Tiles.ExampleHerb>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleBlock>(), 1);
+			recipe.AddIngredient(ModContent.ItemType<ExampleBlock>(), 1);
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Placeable/ExampleLamp.cs
+++ b/ExampleMod/Items/Placeable/ExampleLamp.cs
@@ -1,6 +1,5 @@
 ﻿using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -14,7 +13,7 @@ namespace ExampleMod.Items.Placeable
 			item.autoReuse = true;
 			item.maxStack = 99;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.ExampleLamp>();
+			item.createTile = ModContent.TileType<Tiles.ExampleLamp>();
 			item.width = 10;
 			item.height = 24;
 			item.value = 500;
@@ -23,8 +22,8 @@ namespace ExampleMod.Items.Placeable
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.WoodenChair);
-			recipe.AddIngredient(ItemType<ExampleBlock>(), 10);
-			recipe.AddTile(TileType<Tiles.ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleBlock>(), 10);
+			recipe.AddTile(ModContent.TileType<Tiles.ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Placeable/ExampleMusicBox.cs
+++ b/ExampleMod/Items/Placeable/ExampleMusicBox.cs
@@ -1,5 +1,4 @@
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Placeable
@@ -17,7 +16,7 @@ namespace ExampleMod.Items.Placeable
 			item.useTime = 10;
 			item.autoReuse = true;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.ExampleMusicBox>();
+			item.createTile = ModContent.TileType<Tiles.ExampleMusicBox>();
 			item.width = 24;
 			item.height = 24;
 			item.rare = ItemRarityID.LightRed;

--- a/ExampleMod/Items/Placeable/ExampleOre.cs
+++ b/ExampleMod/Items/Placeable/ExampleOre.cs
@@ -1,6 +1,5 @@
 ﻿using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -20,7 +19,7 @@ namespace ExampleMod.Items.Placeable
 			item.autoReuse = true;
 			item.maxStack = 999;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.ExampleOre>();
+			item.createTile = ModContent.TileType<Tiles.ExampleOre>();
 			item.width = 12;
 			item.height = 12;
 			item.value = 3000;

--- a/ExampleMod/Items/Placeable/ExamplePlatform.cs
+++ b/ExampleMod/Items/Placeable/ExamplePlatform.cs
@@ -1,5 +1,4 @@
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Placeable
@@ -20,14 +19,14 @@ namespace ExampleMod.Items.Placeable
 			item.useTime = 10;
 			item.useStyle = ItemUseStyleID.SwingThrow;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.ExamplePlatform>();
+			item.createTile = ModContent.TileType<Tiles.ExamplePlatform>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleBlock>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleBlock>());
 			recipe.SetResult(this, 2);
-			recipe.AddTile(TileType<Tiles.ExampleWorkbench>());
+			recipe.AddTile(ModContent.TileType<Tiles.ExampleWorkbench>());
 			recipe.AddRecipe();
 		}
 	}

--- a/ExampleMod/Items/Placeable/ExampleTorch.cs
+++ b/ExampleMod/Items/Placeable/ExampleTorch.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -25,14 +24,14 @@ namespace ExampleMod.Items.Placeable
 			item.useTime = 10;
 			item.useStyle = ItemUseStyleID.SwingThrow;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.ExampleTorch>();
+			item.createTile = ModContent.TileType<Tiles.ExampleTorch>();
 			item.flame = true;
 			item.value = 50;
 		}
 
 		public override void HoldItem(Player player) {
 			if (Main.rand.Next(player.itemAnimation > 0 ? 40 : 80) == 0) {
-				Dust.NewDust(new Vector2(player.itemLocation.X + 16f * player.direction, player.itemLocation.Y - 14f * player.gravDir), 4, 4, DustType<Sparkle>());
+				Dust.NewDust(new Vector2(player.itemLocation.X + 16f * player.direction, player.itemLocation.Y - 14f * player.gravDir), 4, 4, ModContent.DustType<Sparkle>());
 			}
 			Vector2 position = player.RotatedRelativePoint(new Vector2(player.itemLocation.X + 12f * player.direction + player.velocity.X, player.itemLocation.Y - 14f + player.velocity.Y), true);
 			Lighting.AddLight(position, 1f, 1f, 1f);
@@ -51,7 +50,7 @@ namespace ExampleMod.Items.Placeable
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.Torch, 3);
-			recipe.AddIngredient(ItemType<ExampleBlock>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleBlock>());
 			recipe.SetResult(this, 3);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Placeable/ExampleTrap.cs
+++ b/ExampleMod/Items/Placeable/ExampleTrap.cs
@@ -1,6 +1,5 @@
 ﻿using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -52,7 +51,7 @@ namespace ExampleMod.Items.Placeable
 			item.autoReuse = true;
 			item.maxStack = 999;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.ExampleTrap>();
+			item.createTile = ModContent.TileType<Tiles.ExampleTrap>();
 			// With all the setup above, placeStyle will be either 0 or 1 for the 2 ExampleTrap instances we've loaded.
 			item.placeStyle = placeStyle;
 			item.width = 12;

--- a/ExampleMod/Items/Placeable/ExampleWall.cs
+++ b/ExampleMod/Items/Placeable/ExampleWall.cs
@@ -1,5 +1,4 @@
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Placeable
@@ -20,12 +19,12 @@ namespace ExampleMod.Items.Placeable
 			item.useTime = 7;
 			item.useStyle = ItemUseStyleID.SwingThrow;
 			item.consumable = true;
-			item.createWall = WallType<Walls.ExampleWall>();
+			item.createWall = ModContent.WallType<Walls.ExampleWall>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleBlock>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleBlock>());
 			recipe.SetResult(this, 4);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Placeable/ExampleWorkbench.cs
+++ b/ExampleMod/Items/Placeable/ExampleWorkbench.cs
@@ -1,6 +1,5 @@
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -21,13 +20,13 @@ namespace ExampleMod.Items.Placeable
 			item.useStyle = ItemUseStyleID.SwingThrow;
 			item.consumable = true;
 			item.value = 150;
-			item.createTile = TileType<Tiles.ExampleWorkbench>();
+			item.createTile = ModContent.TileType<Tiles.ExampleWorkbench>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.WorkBench);
-			recipe.AddIngredient(ItemType<ExampleBlock>(), 10);
+			recipe.AddIngredient(ModContent.ItemType<ExampleBlock>(), 10);
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Placeable/PuritySpiritTrophy.cs
+++ b/ExampleMod/Items/Placeable/PuritySpiritTrophy.cs
@@ -1,5 +1,4 @@
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Placeable
@@ -22,7 +21,7 @@ namespace ExampleMod.Items.Placeable
 			item.consumable = true;
 			item.value = 50000;
 			item.rare = ItemRarityID.Blue;
-			item.createTile = TileType<Tiles.BossTrophy>();
+			item.createTile = ModContent.TileType<Tiles.BossTrophy>();
 			item.placeStyle = 1;
 		}
 	}

--- a/ExampleMod/Items/Placeable/ScoreBoard.cs
+++ b/ExampleMod/Items/Placeable/ScoreBoard.cs
@@ -1,5 +1,4 @@
 ﻿using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Placeable
@@ -19,7 +18,7 @@ namespace ExampleMod.Items.Placeable
 			item.autoReuse = true;
 			item.maxStack = 999;
 			item.consumable = true;
-			item.createTile = TileType<Tiles.ScoreBoard>();
+			item.createTile = ModContent.TileType<Tiles.ScoreBoard>();
 			item.width = 28;
 			item.height = 28;
 		}

--- a/ExampleMod/Items/Placeable/TreeTrophy.cs
+++ b/ExampleMod/Items/Placeable/TreeTrophy.cs
@@ -1,5 +1,4 @@
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items.Placeable
@@ -18,7 +17,7 @@ namespace ExampleMod.Items.Placeable
 			item.consumable = true;
 			item.value = 50000;
 			item.rare = ItemRarityID.Blue;
-			item.createTile = TileType<Tiles.BossTrophy>();
+			item.createTile = ModContent.TileType<Tiles.BossTrophy>();
 			item.placeStyle = 3;
 		}
 	}

--- a/ExampleMod/Items/Placeable/VoidMonolith.cs
+++ b/ExampleMod/Items/Placeable/VoidMonolith.cs
@@ -1,7 +1,6 @@
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Placeable
 {
@@ -19,7 +18,7 @@ namespace ExampleMod.Items.Placeable
 			item.consumable = true;
 			item.rare = ItemRarityID.Red;
 			item.value = Item.buyPrice(0, 10, 0, 0);
-			item.createTile = TileType<Tiles.VoidMonolith>();
+			item.createTile = ModContent.TileType<Tiles.VoidMonolith>();
 		}
 
 		public override void AddRecipes() {

--- a/ExampleMod/Items/PlanteraItem.cs
+++ b/ExampleMod/Items/PlanteraItem.cs
@@ -1,7 +1,6 @@
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -37,8 +36,8 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<BossItem>(), 10);
-			recipe.AddTile(TileType<Tiles.ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<BossItem>(), 10);
+			recipe.AddTile(ModContent.TileType<Tiles.ExampleWorkbench>());
 			recipe.SetResult(this, 20);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/PuritySpiritBag.cs
+++ b/ExampleMod/Items/PuritySpiritBag.cs
@@ -3,7 +3,6 @@ using ExampleMod.NPCs.PuritySpirit;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items
 {
@@ -32,17 +31,17 @@ namespace ExampleMod.Items
 			player.TryGettingDevArmor();
 			int choice = Main.rand.Next(7);
 			if (choice == 0) {
-				player.QuickSpawnItem(ItemType<PuritySpiritMask>());
+				player.QuickSpawnItem(ModContent.ItemType<PuritySpiritMask>());
 			}
 			else if (choice == 1) {
-				player.QuickSpawnItem(ItemType<BunnyMask>());
+				player.QuickSpawnItem(ModContent.ItemType<BunnyMask>());
 			}
 			if (choice != 1) {
 				player.QuickSpawnItem(ItemID.Bunny);
 			}
-			player.QuickSpawnItem(ItemType<PurityShield>());
+			player.QuickSpawnItem(ModContent.ItemType<PurityShield>());
 		}
 
-		public override int BossBagNPC => NPCType<PuritySpirit>();
+		public override int BossBagNPC => ModContent.NPCType<PuritySpirit>();
 	}
 }

--- a/ExampleMod/Items/SparklingSphere.cs
+++ b/ExampleMod/Items/SparklingSphere.cs
@@ -2,7 +2,6 @@ using ExampleMod.Dusts;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Items
@@ -48,10 +47,10 @@ namespace ExampleMod.Items
 		public override void HoldItem(Player player) {
 			Vector2 position = GetLightPosition(player) - new Vector2(20f, 20f);
 			if (Main.rand.NextBool(10)) {
-				Dust.NewDust(player.position, player.width, player.height, DustType<Sparkle>());
+				Dust.NewDust(player.position, player.width, player.height, ModContent.DustType<Sparkle>());
 			}
 			if (Main.rand.NextBool(3)) {
-				Dust.NewDust(position, 40, 40, DustType<Sparkle>());
+				Dust.NewDust(position, 40, 40, ModContent.DustType<Sparkle>());
 			}
 		}
 
@@ -64,7 +63,7 @@ namespace ExampleMod.Items
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Weapons/ExampleBullet.cs
+++ b/ExampleMod/Items/Weapons/ExampleBullet.cs
@@ -2,7 +2,6 @@ using ExampleMod.Tiles;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -22,7 +21,7 @@ namespace ExampleMod.Items.Weapons
 			item.knockBack = 1.5f;
 			item.value = 10;
 			item.rare = ItemRarityID.Green;
-			item.shoot = ProjectileType<Projectiles.ExampleBullet>();   //The projectile shoot when your weapon using this ammo
+			item.shoot = ModContent.ProjectileType<Projectiles.ExampleBullet>();   //The projectile shoot when your weapon using this ammo
 			item.shootSpeed = 16f;                  //The speed of the projectile
 			item.ammo = AmmoID.Bullet;              //The ammo class this ammo belongs to.
 		}
@@ -37,8 +36,8 @@ namespace ExampleMod.Items.Weapons
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.MusketBall, 50);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 1);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 1);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this, 50);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Weapons/ExampleCloneItem.cs
+++ b/ExampleMod/Items/Weapons/ExampleCloneItem.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -20,7 +19,7 @@ namespace ExampleMod.Items.Weapons
 		}
 
 		public override bool Shoot(Player player, ref Vector2 position, ref float speedX, ref float speedY, ref int type, ref int damage, ref float knockBack) {
-			type = ProjectileType<ExampleCloneProjectile>();
+			type = ModContent.ProjectileType<ExampleCloneProjectile>();
 			return base.Shoot(player, ref position, ref speedX, ref speedY, ref type, ref damage, ref knockBack);
 		}
 

--- a/ExampleMod/Items/Weapons/ExampleDualUseWeapon.cs
+++ b/ExampleMod/Items/Weapons/ExampleDualUseWeapon.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -32,8 +31,8 @@ namespace ExampleMod.Items.Weapons
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Weapons/ExampleExplosive.cs
+++ b/ExampleMod/Items/Weapons/ExampleExplosive.cs
@@ -1,7 +1,6 @@
 ﻿using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -18,7 +17,7 @@ namespace ExampleMod.Items.Weapons
 		{
 			item.useStyle = ItemUseStyleID.SwingThrow;
 			item.shootSpeed = 12f;
-			item.shoot = ProjectileType<Projectiles.ExampleExplosive>();
+			item.shoot = ModContent.ProjectileType<Projectiles.ExampleExplosive>();
 			item.width = 8;
 			item.height = 28;
 			item.maxStack = 30;
@@ -35,7 +34,7 @@ namespace ExampleMod.Items.Weapons
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>());
 			recipe.AddIngredient(ItemID.Dynamite);
 			recipe.AddTile(TileID.WorkBenches);
 			recipe.SetResult(this);

--- a/ExampleMod/Items/Weapons/ExampleGun.cs
+++ b/ExampleMod/Items/Weapons/ExampleGun.cs
@@ -1,7 +1,6 @@
 using ExampleMod.Tiles;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -32,8 +31,8 @@ namespace ExampleMod.Items.Weapons
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Weapons/ExampleJavelin.cs
+++ b/ExampleMod/Items/Weapons/ExampleJavelin.cs
@@ -2,7 +2,6 @@
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -31,7 +30,7 @@ namespace ExampleMod.Items.Weapons
 			item.value = Item.sellPrice(silver: 5);
 			// Look at the javelin projectile for a lot of custom code
 			// If you are in an editor like Visual Studio, you can hold CTRL and Click ExampleJavelinProjectile
-			item.shoot = ProjectileType<ExampleJavelinProjectile>();
+			item.shoot = ModContent.ProjectileType<ExampleJavelinProjectile>();
 		}
 	}
 }

--- a/ExampleMod/Items/Weapons/ExampleLaserWeapon.cs
+++ b/ExampleMod/Items/Weapons/ExampleLaserWeapon.cs
@@ -2,7 +2,6 @@
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -26,7 +25,7 @@ namespace ExampleMod.Items.Weapons
 			item.useStyle = ItemUseStyleID.HoldingOut;
 			item.shootSpeed = 14f;
 			item.useAnimation = 20;
-			item.shoot = ProjectileType<ExampleLaser>();
+			item.shoot = ModContent.ProjectileType<ExampleLaser>();
 			item.value = Item.sellPrice(silver: 3);
 		}
 

--- a/ExampleMod/Items/Weapons/ExampleLastPrism.cs
+++ b/ExampleMod/Items/Weapons/ExampleLastPrism.cs
@@ -4,7 +4,6 @@ using Terraria;
 using Microsoft.Xna.Framework;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -28,7 +27,7 @@ Ignores NPC immunity frames and fires 10 beams at once instead of 6.");
 			item.CloneDefaults(ItemID.LastPrism);
 			item.mana = 4;
 			item.damage = 42;
-			item.shoot = ProjectileType<ExampleLastPrismHoldout>();
+			item.shoot = ModContent.ProjectileType<ExampleLastPrismHoldout>();
 			item.shootSpeed = 30f;
 
 			// Change the item's draw color so that it is visually distinct from the vanilla Last Prism.
@@ -38,13 +37,13 @@ Ignores NPC immunity frames and fires 10 beams at once instead of 6.");
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}
 
 		// Because this weapon fires a holdout projectile, it needs to block usage if its projectile already exists.
-		public override bool CanUseItem(Player player) => player.ownedProjectileCounts[ProjectileType<ExampleLastPrismHoldout>()] <= 0;
+		public override bool CanUseItem(Player player) => player.ownedProjectileCounts[ModContent.ProjectileType<ExampleLastPrismHoldout>()] <= 0;
 	}
 }

--- a/ExampleMod/Items/Weapons/ExampleMagicMissile.cs
+++ b/ExampleMod/Items/Weapons/ExampleMagicMissile.cs
@@ -3,7 +3,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -29,7 +28,7 @@ namespace ExampleMod.Items.Weapons
 			item.value = Item.sellPrice(silver : 50);
 			item.rare = ItemRarityID.Orange;
 			item.UseSound = SoundID.Item9;
-			item.shoot = ProjectileType<Projectiles.MagicMissile>();
+			item.shoot = ModContent.ProjectileType<Projectiles.MagicMissile>();
 			item.shootSpeed = 10f;
 		}
 
@@ -51,8 +50,8 @@ namespace ExampleMod.Items.Weapons
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 20);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 20);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Weapons/ExampleSpear.cs
+++ b/ExampleMod/Items/Weapons/ExampleSpear.cs
@@ -2,7 +2,6 @@
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -31,7 +30,7 @@ namespace ExampleMod.Items.Weapons
 			item.autoReuse = true; // Most spears don't autoReuse, but it's possible when used in conjunction with CanUseItem()
 
 			item.UseSound = SoundID.Item1;
-			item.shoot = ProjectileType<ExampleSpearProjectile>();
+			item.shoot = ModContent.ProjectileType<ExampleSpearProjectile>();
 		}
 
 		public override bool CanUseItem(Player player) {

--- a/ExampleMod/Items/Weapons/ExampleStaff.cs
+++ b/ExampleMod/Items/Weapons/ExampleStaff.cs
@@ -3,7 +3,6 @@ using ExampleMod.Tiles;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -29,14 +28,14 @@ namespace ExampleMod.Items.Weapons
 			item.rare = ItemRarityID.Green;
 			item.UseSound = SoundID.Item20;
 			item.autoReuse = true;
-			item.shoot = ProjectileType<SparklingBall>();
+			item.shoot = ModContent.ProjectileType<SparklingBall>();
 			item.shootSpeed = 16f;
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Items/Weapons/ExampleSword.cs
+++ b/ExampleMod/Items/Weapons/ExampleSword.cs
@@ -4,7 +4,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -40,9 +39,9 @@ namespace ExampleMod.Items.Weapons
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			// ItemType<ExampleItem>() is how to get the ExampleItem item, 10 is the amount of that item you need to craft the recipe
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
 			// You can use recipe.AddIngredient(ItemID.TheItemYouWantToUse, the amount of items needed); for a vanilla item.
-			recipe.AddTile(TileType<ExampleWorkbench>()); // Set the crafting tile to ExampleWorkbench
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>()); // Set the crafting tile to ExampleWorkbench
 			recipe.SetResult(this); // Set the result to this item (ExampleSword)
 			recipe.AddRecipe(); // When your done, add the recipe
 		}
@@ -50,7 +49,7 @@ namespace ExampleMod.Items.Weapons
 		public override void MeleeEffects(Player player, Rectangle hitbox) {
 			if (Main.rand.NextBool(3)) {
 				//Emit dusts when the sword is swung
-				Dust.NewDust(new Vector2(hitbox.X, hitbox.Y), hitbox.Width, hitbox.Height, DustType<Sparkle>());
+				Dust.NewDust(new Vector2(hitbox.X, hitbox.Y), hitbox.Width, hitbox.Height, ModContent.DustType<Sparkle>());
 			}
 		}
 

--- a/ExampleMod/Items/Weapons/ExampleYoyo.cs
+++ b/ExampleMod/Items/Weapons/ExampleYoyo.cs
@@ -3,7 +3,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -36,7 +35,7 @@ namespace ExampleMod.Items.Weapons
 
 			item.UseSound = SoundID.Item1;
 			item.value = Item.sellPrice(silver: 1);
-			item.shoot = ProjectileType<ExampleYoyoProjectile>();
+			item.shoot = ModContent.ProjectileType<ExampleYoyoProjectile>();
 		}
 
 		// Make sure that your item can even receive these prefixes (check the vanilla wiki on prefixes)
@@ -61,7 +60,7 @@ namespace ExampleMod.Items.Weapons
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
 			recipe.AddIngredient(ItemID.WoodYoyo);
 			recipe.SetResult(this);
 			recipe.AddRecipe();

--- a/ExampleMod/Items/Weapons/PurityTotem.cs
+++ b/ExampleMod/Items/Weapons/PurityTotem.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -29,8 +28,8 @@ namespace ExampleMod.Items.Weapons
 			item.value = Item.buyPrice(0, 30, 0, 0);
 			item.rare = ItemRarityID.Cyan;
 			item.UseSound = SoundID.Item44;
-			item.shoot = ProjectileType<PurityWisp>();
-			item.buffType = BuffType<Buffs.PurityWisp>(); //The buff added to player after used the item
+			item.shoot = ModContent.ProjectileType<PurityWisp>();
+			item.buffType = ModContent.BuffType<Buffs.PurityWisp>(); //The buff added to player after used the item
 		}
 
 		public override bool Shoot(Player player, ref Vector2 position, ref float speedX, ref float speedY, ref int type, ref int damage, ref float knockBack) {

--- a/ExampleMod/Items/Weapons/SpectreGun.cs
+++ b/ExampleMod/Items/Weapons/SpectreGun.cs
@@ -2,7 +2,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -26,14 +25,14 @@ namespace ExampleMod.Items.Weapons
 			item.rare = ItemRarityID.Yellow;
 			item.UseSound = mod.GetLegacySoundSlot(SoundType.Item, "Sounds/Item/Wooo");
 			item.autoReuse = true;
-			item.shoot = ProjectileType<Projectiles.Wisp>();
+			item.shoot = ModContent.ProjectileType<Projectiles.Wisp>();
 			item.shootSpeed = 6f;
-			item.useAmmo = ItemType<Wisp>();        //Restrict the type of ammo the weapon can use, so that the weapon cannot use other ammos
+			item.useAmmo = ModContent.ItemType<Wisp>();        //Restrict the type of ammo the weapon can use, so that the weapon cannot use other ammos
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 10);
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 10);
 			recipe.AddTile(TileID.WorkBenches);
 			recipe.SetResult(this);
 			recipe.AddRecipe();

--- a/ExampleMod/Items/Weapons/Wisp.cs
+++ b/ExampleMod/Items/Weapons/Wisp.cs
@@ -2,7 +2,6 @@ using ExampleMod.Tiles;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Items.Weapons
 {
@@ -22,7 +21,7 @@ namespace ExampleMod.Items.Weapons
 			item.knockBack = 1f;
 			item.value = Item.sellPrice(0, 0, 1, 0);
 			item.rare = ItemRarityID.Yellow;
-			item.shoot = ProjectileType<Projectiles.Wisp>();
+			item.shoot = ModContent.ProjectileType<Projectiles.Wisp>();
 			item.ammo = item.type; // The first item in an ammo class sets the AmmoID to it's type
 		}
 
@@ -41,11 +40,11 @@ namespace ExampleMod.Items.Weapons
 		}
 
 		public override bool RecipeAvailable() {
-			return Main.LocalPlayer.HasItem(ItemType<SpectreGun>());
+			return Main.LocalPlayer.HasItem(ModContent.ItemType<SpectreGun>());
 		}
 
 		public override int ConsumeItem(int type, int numRequired) {
-			if (type == ItemID.Ectoplasm && Main.LocalPlayer.adjTile[TileType<ExampleWorkbench>()]) {
+			if (type == ItemID.Ectoplasm && Main.LocalPlayer.adjTile[ModContent.TileType<ExampleWorkbench>()]) {
 				Main.PlaySound(SoundID.Item, -1, -1, mod.GetSoundSlot(SoundType.Item, "Sounds/Item/Wooo"));
 				return Main.rand.NextBool() ? 0 : 1; //You have half chance to not consume your materials
 			}

--- a/ExampleMod/Mounts/Car.cs
+++ b/ExampleMod/Mounts/Car.cs
@@ -9,15 +9,14 @@ using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Mounts
 {
 	public class Car : ModMountData
 	{
 		public override void SetDefaults() {
-			mountData.spawnDust = DustType<Smoke>();
-			mountData.buff = BuffType<CarMount>();
+			mountData.spawnDust = ModContent.DustType<Smoke>();
+			mountData.buff = ModContent.BuffType<CarMount>();
 			mountData.heightBoost = 20;
 			mountData.fallDamage = 0.5f;
 			mountData.runSpeed = 11f;
@@ -82,7 +81,7 @@ namespace ExampleMod.Mounts
 				return;
 			}
 			Rectangle rect = player.getRect();
-			Dust.NewDust(new Vector2(rect.X, rect.Y), rect.Width, rect.Height, DustType<Smoke>());
+			Dust.NewDust(new Vector2(rect.X, rect.Y), rect.Width, rect.Height, ModContent.DustType<Smoke>());
 		}
 
 		// Since only a single instance of ModMountData ever exists, we can use player.mount._mountSpecificData to store additional data related to a specific mount.

--- a/ExampleMod/NPCs/Abomination/Abomination.cs
+++ b/ExampleMod/NPCs/Abomination/Abomination.cs
@@ -7,7 +7,6 @@ using System.IO;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs.Abomination
 {
@@ -80,7 +79,7 @@ namespace ExampleMod.NPCs.Abomination
 		public override void AI() {
 			if (Main.netMode != NetmodeID.MultiplayerClient && npc.localAI[0] == 0f) {
 				for (int k = 0; k < 5; k++) {
-					int captive = NPC.NewNPC((int)npc.position.X, (int)npc.position.Y, NPCType<CaptiveElement>());
+					int captive = NPC.NewNPC((int)npc.position.X, (int)npc.position.Y, ModContent.NPCType<CaptiveElement>());
 					Main.npc[captive].ai[0] = npc.whoAmI;
 					Main.npc[captive].ai[1] = k;
 					Main.npc[captive].ai[2] = 50 * (k + 1);
@@ -169,7 +168,7 @@ namespace ExampleMod.NPCs.Abomination
 				if (Main.expertMode) {
 					damage = (int)(damage / Main.expertDamage);
 				}
-				Projectile.NewProjectile(npc.Center.X, npc.Center.Y, delta.X, delta.Y, ProjectileType<ElementBall>(), damage, 3f, Main.myPlayer, BuffID.OnFire, 600f);
+				Projectile.NewProjectile(npc.Center.X, npc.Center.Y, delta.X, delta.Y, ModContent.ProjectileType<ElementBall>(), damage, 3f, Main.myPlayer, BuffID.OnFire, 600f);
 				npc.netUpdate = true;
 			}
 			if (Main.expertMode) {
@@ -178,7 +177,7 @@ namespace ExampleMod.NPCs.Abomination
 			if (Main.rand.NextBool()) {
 				float radius = (float)Math.Sqrt(Main.rand.Next(sphereRadius * sphereRadius));
 				double angle = Main.rand.NextDouble() * 2.0 * Math.PI;
-				Dust.NewDust(new Vector2(npc.Center.X + radius * (float)Math.Cos(angle), npc.Center.Y + radius * (float)Math.Sin(angle)), 0, 0, DustType<Sparkle>(), 0f, 0f, 0, default(Color), 1.5f);
+				Dust.NewDust(new Vector2(npc.Center.X + radius * (float)Math.Cos(angle), npc.Center.Y + radius * (float)Math.Sin(angle)), 0, 0, ModContent.DustType<Sparkle>(), 0f, 0f, 0, default(Color), 1.5f);
 			}
 		}
 
@@ -193,7 +192,7 @@ namespace ExampleMod.NPCs.Abomination
 					}
 					else {
 						for (laser1Index = 0; laser1Index < 200; laser1Index++) {
-							if (Main.npc[laser1Index].type == NPCType<CaptiveElement>() && laser1 == Main.npc[laser1Index].ai[1]) {
+							if (Main.npc[laser1Index].type == ModContent.NPCType<CaptiveElement>() && laser1 == Main.npc[laser1Index].ai[1]) {
 								break;
 							}
 						}
@@ -203,7 +202,7 @@ namespace ExampleMod.NPCs.Abomination
 					}
 					else {
 						for (laser2Index = 0; laser2Index < 200; laser2Index++) {
-							if (Main.npc[laser2Index].type == NPCType<CaptiveElement>() && laser2 == Main.npc[laser2Index].ai[1]) {
+							if (Main.npc[laser2Index].type == ModContent.NPCType<CaptiveElement>() && laser2 == Main.npc[laser2Index].ai[1]) {
 								break;
 							}
 						}
@@ -213,7 +212,7 @@ namespace ExampleMod.NPCs.Abomination
 					if (Main.expertMode) {
 						damage = (int)(damage / Main.expertDamage);
 					}
-					Projectile.NewProjectile(pos.X, pos.Y, 0f, 0f, ProjectileType<ElementLaser>(), damage, 0f, Main.myPlayer, laser1Index, laser2Index);
+					Projectile.NewProjectile(pos.X, pos.Y, 0f, 0f, ModContent.ProjectileType<ElementLaser>(), damage, 0f, Main.myPlayer, laser1Index, laser2Index);
 				}
 				else {
 					npc.localAI[0] = 2f;
@@ -263,7 +262,7 @@ namespace ExampleMod.NPCs.Abomination
 			}
 			if (Main.netMode != NetmodeID.MultiplayerClient && npc.life <= 0) {
 				Vector2 spawnAt = npc.Center + new Vector2(0f, (float)npc.height / 2f);
-				NPC.NewNPC((int)spawnAt.X, (int)spawnAt.Y, NPCType<AbominationRun>());
+				NPC.NewNPC((int)spawnAt.X, (int)spawnAt.Y, ModContent.NPCType<AbominationRun>());
 			}
 		}
 

--- a/ExampleMod/NPCs/Abomination/CaptiveElement.cs
+++ b/ExampleMod/NPCs/Abomination/CaptiveElement.cs
@@ -6,7 +6,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs.Abomination
 {
@@ -76,8 +75,8 @@ namespace ExampleMod.NPCs.Abomination
 
 		public override void AI() {
 			NPC abomination = Main.npc[center];
-			if (!abomination.active || abomination.type != NPCType<Abomination>()) {
-				if (change > 0 || NPC.AnyNPCs(NPCType<AbominationRun>())) {
+			if (!abomination.active || abomination.type != ModContent.NPCType<Abomination>()) {
+				if (change > 0 || NPC.AnyNPCs(ModContent.NPCType<AbominationRun>())) {
 					if (change == 0) {
 						npc.netUpdate = true;
 					}
@@ -93,13 +92,13 @@ namespace ExampleMod.NPCs.Abomination
 				Color? color = GetColor();
 				if (color.HasValue) {
 					for (int x = 0; x < 5; x++) {
-						int dust = Dust.NewDust(npc.position, npc.width, npc.height, DustType<Pixel>(), 0f, 0f, 0, color.Value);
+						int dust = Dust.NewDust(npc.position, npc.width, npc.height, ModContent.DustType<Pixel>(), 0f, 0f, 0, color.Value);
 						double angle = Main.rand.NextDouble() * 2.0 * Math.PI;
 						Main.dust[dust].velocity = 3f * new Vector2((float)Math.Cos(angle), (float)Math.Sin(angle));
 					}
 				}
 				if (Main.netMode != NetmodeID.MultiplayerClient && change >= 100f) {
-					int next = NPC.NewNPC((int)npc.Center.X, (int)npc.position.Y + npc.height, NPCType<CaptiveElement2>());
+					int next = NPC.NewNPC((int)npc.Center.X, (int)npc.position.Y + npc.height, ModContent.NPCType<CaptiveElement2>());
 					Main.npc[next].ai[0] = captiveType;
 					if (captiveType != 4) {
 						Main.npc[next].ai[1] = 300f + (float)Main.rand.Next(100);
@@ -140,7 +139,7 @@ namespace ExampleMod.NPCs.Abomination
 				if (Main.expertMode) {
 					damage = (int)(damage / Main.expertDamage);
 				}
-				Projectile.NewProjectile(npc.Center.X, npc.Center.Y, delta.X, delta.Y, ProjectileType<ElementBall>(), damage, 3f, Main.myPlayer, GetDebuff(), GetDebuffTime());
+				Projectile.NewProjectile(npc.Center.X, npc.Center.Y, delta.X, delta.Y, ModContent.ProjectileType<ElementBall>(), damage, 3f, Main.myPlayer, GetDebuff(), GetDebuffTime());
 				npc.netUpdate = true;
 			}
 		}
@@ -185,7 +184,7 @@ namespace ExampleMod.NPCs.Abomination
 				case 0:
 					return BuffID.Frostburn;
 				case 1:
-					return BuffType<Buffs.EtherealFlames>();
+					return ModContent.BuffType<Buffs.EtherealFlames>();
 				case 3:
 					return BuffID.Venom;
 				case 4:

--- a/ExampleMod/NPCs/Abomination/CaptiveElement2.cs
+++ b/ExampleMod/NPCs/Abomination/CaptiveElement2.cs
@@ -10,7 +10,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs.Abomination
 {
@@ -72,7 +71,7 @@ namespace ExampleMod.NPCs.Abomination
 			npc.HitSound = SoundID.NPCHit5;
 			npc.DeathSound = SoundID.NPCDeath7;
 			music = MusicID.Boss2;
-			bossBag = ItemType<AbominationBag>();
+			bossBag = ModContent.ItemType<AbominationBag>();
 		}
 
 		public override void ScaleExpertStats(int numPlayers, float bossLifeScale) {
@@ -120,7 +119,7 @@ namespace ExampleMod.NPCs.Abomination
 				bool flag = true;
 				if (run == 1) {
 					for (int k = 0; k < 200; k++) {
-						if (Main.npc[k].active && Main.npc[k].type == NPCType<CaptiveElement2>() && Main.npc[k].ai[2] == 0f) {
+						if (Main.npc[k].active && Main.npc[k].type == ModContent.NPCType<CaptiveElement2>() && Main.npc[k].ai[2] == 0f) {
 							flag = false;
 							break;
 						}
@@ -144,7 +143,7 @@ namespace ExampleMod.NPCs.Abomination
 			//move
 			int count = 0;
 			for (int k = 0; k < 200; k++) {
-				if (Main.npc[k].active && Main.npc[k].type == NPCType<CaptiveElement2>()) {
+				if (Main.npc[k].active && Main.npc[k].type == ModContent.NPCType<CaptiveElement2>()) {
 					count++;
 				}
 			}
@@ -235,7 +234,7 @@ namespace ExampleMod.NPCs.Abomination
 						if (captiveType != 1) {
 							speed = Main.expertMode ? 9f : 7f;
 						}
-						Projectile.NewProjectile(npc.Center.X, npc.Center.Y, 5f * (float)Math.Cos(npc.rotation), speed * (float)Math.Sin(npc.rotation), ProjectileType<PixelBall>(), damage, 3f, Main.myPlayer, GetDebuff(), GetDebuffTime());
+						Projectile.NewProjectile(npc.Center.X, npc.Center.Y, 5f * (float)Math.Cos(npc.rotation), speed * (float)Math.Sin(npc.rotation), ModContent.ProjectileType<PixelBall>(), damage, 3f, Main.myPlayer, GetDebuff(), GetDebuffTime());
 					}
 					npc.TargetClosest(false);
 					npc.netUpdate = true;
@@ -266,7 +265,7 @@ namespace ExampleMod.NPCs.Abomination
 				Vector2 unit = new Vector2((float)Math.Cos(npc.rotation), (float)Math.Sin(npc.rotation));
 				Vector2 center = npc.Center;
 				for (int k = 0; k < 4; k++) {
-					int dust = Dust.NewDust(npc.position, npc.width, npc.height, DustType<Pixel>(), 0f, 0f, 0, color.Value);
+					int dust = Dust.NewDust(npc.position, npc.width, npc.height, ModContent.DustType<Pixel>(), 0f, 0f, 0, color.Value);
 					Vector2 offset = Main.dust[dust].position - center;
 					offset.X = (offset.X - (float)npc.width / 2f) / 2f;
 					Main.dust[dust].position = center + new Vector2(unit.X * offset.X - unit.Y * offset.Y, unit.Y * offset.X + unit.X * offset.Y);
@@ -303,7 +302,7 @@ namespace ExampleMod.NPCs.Abomination
 		public override void HitEffect(int hitDirection, double damage) {
 			if (npc.life <= 0) {
 				if (Main.expertMode) {
-					int next = NPC.NewNPC((int)npc.Center.X, (int)npc.position.Y + npc.height * 3 / 4, NPCType<FreedElement>());
+					int next = NPC.NewNPC((int)npc.Center.X, (int)npc.position.Y + npc.height * 3 / 4, ModContent.NPCType<FreedElement>());
 					Main.npc[next].ai[0] = captiveType;
 					Main.npc[next].netUpdate = true;
 				}
@@ -311,7 +310,7 @@ namespace ExampleMod.NPCs.Abomination
 					Color? color = GetColor();
 					if (color.HasValue) {
 						for (int k = 0; k < 75; k++) {
-							Dust.NewDust(npc.position, npc.width, npc.height, DustType<PixelHurt>(), 0f, 0f, 0, color.Value);
+							Dust.NewDust(npc.position, npc.width, npc.height, ModContent.DustType<PixelHurt>(), 0f, 0f, 0, color.Value);
 						}
 					}
 				}
@@ -324,7 +323,7 @@ namespace ExampleMod.NPCs.Abomination
 					return false;
 				}
 			}
-			NPCLoader.blockLoot.Add(ItemType<ExampleItem>());
+			NPCLoader.blockLoot.Add(ModContent.ItemType<ExampleItem>());
 			return true;
 		}
 
@@ -351,18 +350,18 @@ namespace ExampleMod.NPCs.Abomination
 				}
 			}
 			if (Main.rand.NextBool(10)) {
-				Item.NewItem(npc.getRect(), ItemType<AbominationTrophy>());
+				Item.NewItem(npc.getRect(), ModContent.ItemType<AbominationTrophy>());
 			}
 			if (Main.expertMode) {
 				npc.DropBossBags();
 			}
 			else {
 				if (Main.rand.NextBool(7)) {
-					Item.NewItem(npc.getRect(), ItemType<AbominationMask>());
+					Item.NewItem(npc.getRect(), ModContent.ItemType<AbominationMask>());
 				}
-				Item.NewItem(npc.getRect(), ItemType<Items.Abomination.MoltenDrill>());
-				Item.NewItem(npc.getRect(), ItemType<ElementResidue>());
-				Item.NewItem(npc.getRect(), ItemType<PurityTotem>());
+				Item.NewItem(npc.getRect(), ModContent.ItemType<Items.Abomination.MoltenDrill>());
+				Item.NewItem(npc.getRect(), ModContent.ItemType<ElementResidue>());
+				Item.NewItem(npc.getRect(), ModContent.ItemType<PurityTotem>());
 			}
 			if (!ExampleWorld.downedAbomination) {
 				ExampleWorld.downedAbomination = true;
@@ -398,7 +397,7 @@ namespace ExampleMod.NPCs.Abomination
 				case 0:
 					return BuffID.Frostburn;
 				case 1:
-					return BuffType<Buffs.EtherealFlames>();
+					return ModContent.BuffType<Buffs.EtherealFlames>();
 				case 3:
 					return BuffID.Venom;
 				case 4:

--- a/ExampleMod/NPCs/Abomination/FreedElement.cs
+++ b/ExampleMod/NPCs/Abomination/FreedElement.cs
@@ -4,7 +4,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs.Abomination
 {
@@ -73,7 +72,7 @@ namespace ExampleMod.NPCs.Abomination
 				}
 				npc.localAI[0] = 1f;
 			}
-			if (NPC.AnyNPCs(NPCType<CaptiveElement2>())) {
+			if (NPC.AnyNPCs(ModContent.NPCType<CaptiveElement2>())) {
 				if (npc.timeLeft < 750) {
 					npc.timeLeft = 750;
 				}
@@ -109,14 +108,14 @@ namespace ExampleMod.NPCs.Abomination
 			Color? color = GetColor();
 			if (color.HasValue) {
 				for (int k = 0; k < 5; k++) {
-					int dust = Dust.NewDust(npc.position, npc.width, npc.height, DustType<Pixel>(), 0f, 0f, 0, color.Value);
+					int dust = Dust.NewDust(npc.position, npc.width, npc.height, ModContent.DustType<Pixel>(), 0f, 0f, 0, color.Value);
 					double angle = Main.rand.NextDouble() * 2.0 * Math.PI;
 					Main.dust[dust].velocity = 3f * new Vector2((float)Math.Cos(angle), (float)Math.Sin(angle));
 				}
 			}
 			else {
 				for (int k = 0; k < 1; k++) {
-					int dust = Dust.NewDust(npc.position, npc.width, npc.height, DustType<Bubble>(), 0f, 0f, 0);
+					int dust = Dust.NewDust(npc.position, npc.width, npc.height, ModContent.DustType<Bubble>(), 0f, 0f, 0);
 					double angle = Main.rand.NextDouble() * 2.0 * Math.PI;
 					Main.dust[dust].velocity = 2f * new Vector2((float)Math.Cos(angle), (float)Math.Sin(angle));
 				}

--- a/ExampleMod/NPCs/ExampleChestSummon.cs
+++ b/ExampleMod/NPCs/ExampleChestSummon.cs
@@ -2,7 +2,6 @@
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs
 {
@@ -43,7 +42,7 @@ namespace ExampleMod.NPCs
 			if (TileID.Sets.BasicChest[tileType] && (tileStyle < 5 || tileStyle > 6)) {
 				for (int i = 0; i < 40; i++) {
 					if (Main.chest[num].item[i] != null && Main.chest[num].item[i].type > ItemID.None) {
-						if (Main.chest[num].item[i].type == ItemType<ExampleBlock>()) {
+						if (Main.chest[num].item[i].type == ModContent.ItemType<ExampleBlock>()) {
 							numberExampleBlocks += Main.chest[num].item[i].stack;
 						}
 						else {
@@ -75,7 +74,7 @@ namespace ExampleMod.NPCs
 					NetMessage.SendData(MessageID.ChestUpdates, -1, -1, null, 1, (float)x, (float)y, 0f, number, 0, 0);
 					NetMessage.SendTileSquare(-1, x, y, 3);
 				}
-				int npcToSpawn = NPCType<PartyZombie>();
+				int npcToSpawn = ModContent.NPCType<PartyZombie>();
 				int npcIndex = NPC.NewNPC(x * 16 + 16, y * 16 + 32, npcToSpawn, 0, 0f, 0f, 0f, 0f, 255);
 				Main.npc[npcIndex].whoAmI = npcIndex;
 				NetMessage.SendData(MessageID.SyncNPC, -1, -1, null, npcIndex, 0f, 0f, 0f, 0, 0, 0);

--- a/ExampleMod/NPCs/ExampleCritter.cs
+++ b/ExampleMod/NPCs/ExampleCritter.cs
@@ -4,7 +4,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs
 {
@@ -125,7 +124,7 @@ namespace ExampleMod.NPCs
 			//npc.catchItem = 2007;
 
 			npc.CloneDefaults(NPCID.GlowingSnail);
-			npc.catchItem = (short)ItemType<ExampleCritterItem>();
+			npc.catchItem = (short)ModContent.ItemType<ExampleCritterItem>();
 			npc.lavaImmune = true;
 			//npc.aiStyle = 0;
 			npc.friendly = true; // We have to add this and CanBeHitByItem/CanBeHitByProjectile because of reasons.
@@ -227,7 +226,7 @@ namespace ExampleMod.NPCs
 
 			item.CloneDefaults(ItemID.GlowingSnail);
 			item.bait = 17;
-			item.makeNPC = (short)NPCType<ExampleCritterNPC>();
+			item.makeNPC = (short)ModContent.NPCType<ExampleCritterNPC>();
 		}
 	}
 }

--- a/ExampleMod/NPCs/ExampleGlobalNPC.cs
+++ b/ExampleMod/NPCs/ExampleGlobalNPC.cs
@@ -5,7 +5,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs
 {
@@ -23,7 +22,7 @@ namespace ExampleMod.NPCs
 
 		public override void SetDefaults(NPC npc) {
 			// We want our ExampleJavelin buff to follow the same immunities as BoneJavelin
-			npc.buffImmune[BuffType<Buffs.ExampleJavelin>()] = npc.buffImmune[BuffID.BoneJavelin];
+			npc.buffImmune[ModContent.BuffType<Buffs.ExampleJavelin>()] = npc.buffImmune[BuffID.BoneJavelin];
 		}
 
 		public override void UpdateLifeRegen(NPC npc, ref int damage) {
@@ -34,7 +33,7 @@ namespace ExampleMod.NPCs
 				int exampleJavelinCount = 0;
 				for (int i = 0; i < 1000; i++) {
 					Projectile p = Main.projectile[i];
-					if (p.active && p.type == ProjectileType<Projectiles.ExampleJavelinProjectile>() && p.ai[0] == 1f && p.ai[1] == npc.whoAmI) {
+					if (p.active && p.type == ModContent.ProjectileType<Projectiles.ExampleJavelinProjectile>() && p.ai[0] == 1f && p.ai[1] == npc.whoAmI) {
 						exampleJavelinCount++;
 					}
 				}
@@ -56,9 +55,9 @@ namespace ExampleMod.NPCs
 
 		public override void NPCLoot(NPC npc) {
 			if (npc.lifeMax > 5 && npc.value > 0f) {
-				Item.NewItem(npc.getRect(), ItemType<ExampleItem>());
+				Item.NewItem(npc.getRect(), ModContent.ItemType<ExampleItem>());
 				if (Main.player[(int)Player.FindClosest(npc.position, npc.width, npc.height)].GetModPlayer<ExamplePlayer>().ZoneExample) {
-					Item.NewItem(npc.getRect(), ItemType<BossItem>());
+					Item.NewItem(npc.getRect(), ModContent.ItemType<BossItem>());
 				}
 			}
 			if ((npc.type == NPCID.Pumpking && Main.pumpkinMoon || npc.type == NPCID.IceQueen && Main.snowMoon) && NPC.waveNumber > 10) {
@@ -83,7 +82,7 @@ namespace ExampleMod.NPCs
 			}
 			// See BossBags.OpenVanillaBag to see how to handle adding items to the boss bags used in expert mode. You'll want to do both for most items added to boss drops.
 			if (npc.type == NPCID.DukeFishron && !Main.expertMode) {
-				Item.NewItem(npc.getRect(), ItemType<Items.Abomination.Bubble>(), Main.rand.Next(5, 8));
+				Item.NewItem(npc.getRect(), ModContent.ItemType<Items.Abomination.Bubble>(), Main.rand.Next(5, 8));
 			}
 			if (npc.type == NPCID.Bunny && npc.AnyInteractions()) {
 				int left = (int)(npc.position.X / 16f);
@@ -94,7 +93,7 @@ namespace ExampleMod.NPCs
 				for (int i = left; i <= right; i++) {
 					for (int j = top; j <= bottom; j++) {
 						Tile tile = Main.tile[i, j];
-						if (tile.active() && tile.type == TileType<ElementalPurge>() && !NPC.AnyNPCs(NPCType<PuritySpirit.PuritySpirit>())) {
+						if (tile.active() && tile.type == ModContent.TileType<ElementalPurge>() && !NPC.AnyNPCs(ModContent.NPCType<PuritySpirit.PuritySpirit>())) {
 							i -= Main.tile[i, j].frameX / 18;
 							j -= Main.tile[i, j].frameY / 18;
 							i = i * 16 + 16;
@@ -107,7 +106,7 @@ namespace ExampleMod.NPCs
 								}
 							}
 							if (flag) {
-								NPC.NewNPC(i, j, NPCType<PuritySpirit.PuritySpirit>());
+								NPC.NewNPC(i, j, ModContent.NPCType<PuritySpirit.PuritySpirit>());
 								break;
 							}
 						}
@@ -122,7 +121,7 @@ namespace ExampleMod.NPCs
 		public override void DrawEffects(NPC npc, ref Color drawColor) {
 			if (eFlames) {
 				if (Main.rand.Next(4) < 3) {
-					int dust = Dust.NewDust(npc.position - new Vector2(2f, 2f), npc.width + 4, npc.height + 4, DustType<EtherealFlame>(), npc.velocity.X * 0.4f, npc.velocity.Y * 0.4f, 100, default(Color), 3.5f);
+					int dust = Dust.NewDust(npc.position - new Vector2(2f, 2f), npc.width + 4, npc.height + 4, ModContent.DustType<EtherealFlame>(), npc.velocity.X * 0.4f, npc.velocity.Y * 0.4f, 100, default(Color), 3.5f);
 					Main.dust[dust].noGravity = true;
 					Main.dust[dust].velocity *= 1.8f;
 					Main.dust[dust].velocity.Y -= 0.5f;
@@ -144,27 +143,27 @@ namespace ExampleMod.NPCs
 
 		public override void SetupShop(int type, Chest shop, ref int nextSlot) {
 			if (type == NPCID.Dryad) {
-				shop.item[nextSlot].SetDefaults(ItemType<CarKey>());
+				shop.item[nextSlot].SetDefaults(ModContent.ItemType<CarKey>());
 				nextSlot++;
 
 				// We can use shopCustomPrice and shopSpecialCurrency to support custom prices and currency. Usually a shop sells an item for item.value. 
 				// Editing item.value in SetupShop is an incorrect approach.
-				shop.item[nextSlot].SetDefaults(ItemType<CarKey>());
+				shop.item[nextSlot].SetDefaults(ModContent.ItemType<CarKey>());
 				shop.item[nextSlot].shopCustomPrice = 2;
 				shop.item[nextSlot].shopSpecialCurrency = CustomCurrencyID.DefenderMedals; // omit this line if shopCustomPrice should be in regular coins. 
 				nextSlot++;
 
-				shop.item[nextSlot].SetDefaults(ItemType<CarKey>());
+				shop.item[nextSlot].SetDefaults(ModContent.ItemType<CarKey>());
 				shop.item[nextSlot].shopCustomPrice = 3;
 				shop.item[nextSlot].shopSpecialCurrency = ExampleMod.FaceCustomCurrencyId;
 				nextSlot++;
 			}
 			else if (type == NPCID.Wizard && Main.expertMode) {
-				shop.item[nextSlot].SetDefaults(ItemType<Infinity>());
+				shop.item[nextSlot].SetDefaults(ModContent.ItemType<Infinity>());
 				nextSlot++;
 			}
 			else if (type == NPCID.Stylist) {
-				shop.item[nextSlot].SetDefaults(ItemType<ExampleHairDye>());
+				shop.item[nextSlot].SetDefaults(ModContent.ItemType<ExampleHairDye>());
 				nextSlot++;
 			}
 		}

--- a/ExampleMod/NPCs/ExamplePerson.cs
+++ b/ExampleMod/NPCs/ExamplePerson.cs
@@ -10,7 +10,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs
 {
@@ -58,7 +57,7 @@ namespace ExampleMod.NPCs
 		public override void HitEffect(int hitDirection, double damage) {
 			int num = npc.life > 0 ? 1 : 5;
 			for (int k = 0; k < num; k++) {
-				Dust.NewDust(npc.position, npc.width, npc.height, DustType<Sparkle>());
+				Dust.NewDust(npc.position, npc.width, npc.height, ModContent.DustType<Sparkle>());
 			}
 		}
 
@@ -70,7 +69,7 @@ namespace ExampleMod.NPCs
 				}
 
 				foreach (Item item in player.inventory) {
-					if (item.type == ItemType<ExampleItem>() || item.type == ItemType<Items.Placeable.ExampleBlock>()) {
+					if (item.type == ModContent.ItemType<ExampleItem>() || item.type == ModContent.ItemType<Items.Placeable.ExampleBlock>()) {
 						return true;
 					}
 				}
@@ -84,10 +83,10 @@ namespace ExampleMod.NPCs
 			for (int x = left; x <= right; x++) {
 				for (int y = top; y <= bottom; y++) {
 					int type = Main.tile[x, y].type;
-					if (type == TileType<ExampleBlock>() || type == TileType<ExampleChair>() || type == TileType<ExampleWorkbench>() || type == TileType<ExampleBed>() || type == TileType<ExampleDoorOpen>() || type == TileType<ExampleDoorClosed>()) {
+					if (type == ModContent.TileType<ExampleBlock>() || type == ModContent.TileType<ExampleChair>() || type == ModContent.TileType<ExampleWorkbench>() || type == ModContent.TileType<ExampleBed>() || type == ModContent.TileType<ExampleDoorOpen>() || type == ModContent.TileType<ExampleDoorClosed>()) {
 						score++;
 					}
-					if (Main.tile[x, y].wall == WallType<ExampleWall>()) {
+					if (Main.tile[x, y].wall == ModContent.WallType<ExampleWall>()) {
 						score++;
 					}
 				}
@@ -175,10 +174,10 @@ namespace ExampleMod.NPCs
 				if (Main.LocalPlayer.HasItem(ItemID.HiveBackpack))
 				{
 					Main.PlaySound(SoundID.Item37); // Reforge/Anvil sound
-					Main.npcChatText = $"I upgraded your {Lang.GetItemNameValue(ItemID.HiveBackpack)} to a {Lang.GetItemNameValue(ItemType<Items.Accessories.WaspNest>())}";
+					Main.npcChatText = $"I upgraded your {Lang.GetItemNameValue(ItemID.HiveBackpack)} to a {Lang.GetItemNameValue(ModContent.ItemType<Items.Accessories.WaspNest>())}";
 					int hiveBackpackItemIndex = Main.LocalPlayer.FindItem(ItemID.HiveBackpack);
 					Main.LocalPlayer.inventory[hiveBackpackItemIndex].TurnToAir();
-					Main.LocalPlayer.QuickSpawnItem(ItemType<Items.Accessories.WaspNest>());
+					Main.LocalPlayer.QuickSpawnItem(ModContent.ItemType<Items.Accessories.WaspNest>());
 					return;
 				}
 				shop = true;
@@ -189,52 +188,52 @@ namespace ExampleMod.NPCs
 				// remove the chat window...
 				Main.npcChatText = "";
 				// and start an instance of our UIState.
-				GetInstance<ExampleMod>().ExamplePersonUserInterface.SetState(new UI.ExamplePersonUI());
+				ModContent.GetInstance<ExampleMod>().ExamplePersonUserInterface.SetState(new UI.ExamplePersonUI());
 				// Note that even though we remove the chat window, Main.LocalPlayer.talkNPC will still be set correctly and we are still technically chatting with the npc.
 			}
 		}
 
 		public override void SetupShop(Chest shop, ref int nextSlot) {
-			shop.item[nextSlot].SetDefaults(ItemType<ExampleItem>());
+			shop.item[nextSlot].SetDefaults(ModContent.ItemType<ExampleItem>());
 			nextSlot++;
-			shop.item[nextSlot].SetDefaults(ItemType<EquipMaterial>());
+			shop.item[nextSlot].SetDefaults(ModContent.ItemType<EquipMaterial>());
 			nextSlot++;
-			shop.item[nextSlot].SetDefaults(ItemType<BossItem>());
+			shop.item[nextSlot].SetDefaults(ModContent.ItemType<BossItem>());
 			nextSlot++;
-			shop.item[nextSlot].SetDefaults(ItemType<Items.Placeable.ExampleWorkbench>());
+			shop.item[nextSlot].SetDefaults(ModContent.ItemType<Items.Placeable.ExampleWorkbench>());
 			nextSlot++;
-			shop.item[nextSlot].SetDefaults(ItemType<Items.Placeable.ExampleChair>());
+			shop.item[nextSlot].SetDefaults(ModContent.ItemType<Items.Placeable.ExampleChair>());
 			nextSlot++;
-			shop.item[nextSlot].SetDefaults(ItemType<Items.Placeable.ExampleDoor>());
+			shop.item[nextSlot].SetDefaults(ModContent.ItemType<Items.Placeable.ExampleDoor>());
 			nextSlot++;
-			shop.item[nextSlot].SetDefaults(ItemType<Items.Placeable.ExampleBed>());
+			shop.item[nextSlot].SetDefaults(ModContent.ItemType<Items.Placeable.ExampleBed>());
 			nextSlot++;
-			shop.item[nextSlot].SetDefaults(ItemType<Items.Placeable.ExampleChest>());
+			shop.item[nextSlot].SetDefaults(ModContent.ItemType<Items.Placeable.ExampleChest>());
 			nextSlot++;
-			shop.item[nextSlot].SetDefaults(ItemType<ExamplePickaxe>());
+			shop.item[nextSlot].SetDefaults(ModContent.ItemType<ExamplePickaxe>());
 			nextSlot++;
-			shop.item[nextSlot].SetDefaults(ItemType<ExampleHamaxe>());
+			shop.item[nextSlot].SetDefaults(ModContent.ItemType<ExampleHamaxe>());
 			nextSlot++;
 			if (Main.LocalPlayer.HasBuff(BuffID.Lifeforce)) {
-				shop.item[nextSlot].SetDefaults(ItemType<ExampleHealingPotion>());
+				shop.item[nextSlot].SetDefaults(ModContent.ItemType<ExampleHealingPotion>());
 				nextSlot++;
 			}
-			if (Main.LocalPlayer.GetModPlayer<ExamplePlayer>().ZoneExample && !GetInstance<ExampleConfigServer>().DisableExampleWings) {
-				shop.item[nextSlot].SetDefaults(ItemType<ExampleWings>());
+			if (Main.LocalPlayer.GetModPlayer<ExamplePlayer>().ZoneExample && !ModContent.GetInstance<ExampleConfigServer>().DisableExampleWings) {
+				shop.item[nextSlot].SetDefaults(ModContent.ItemType<ExampleWings>());
 				nextSlot++;
 			}
 			if (Main.moonPhase < 2) {
-				shop.item[nextSlot].SetDefaults(ItemType<ExampleSword>());
+				shop.item[nextSlot].SetDefaults(ModContent.ItemType<ExampleSword>());
 				nextSlot++;
 			}
 			else if (Main.moonPhase < 4) {
-				shop.item[nextSlot].SetDefaults(ItemType<ExampleGun>());
+				shop.item[nextSlot].SetDefaults(ModContent.ItemType<ExampleGun>());
 				nextSlot++;
-				shop.item[nextSlot].SetDefaults(ItemType<Items.Weapons.ExampleBullet>());
+				shop.item[nextSlot].SetDefaults(ModContent.ItemType<Items.Weapons.ExampleBullet>());
 				nextSlot++;
 			}
 			else if (Main.moonPhase < 6) {
-				shop.item[nextSlot].SetDefaults(ItemType<ExampleStaff>());
+				shop.item[nextSlot].SetDefaults(ModContent.ItemType<ExampleStaff>());
 				nextSlot++;
 			}
 			else {
@@ -246,9 +245,9 @@ namespace ExampleMod.NPCs
 				nextSlot++;
 			}
 
-			if (!Main.LocalPlayer.GetModPlayer<ExamplePlayer>().examplePersonGiftReceived && GetInstance<ExampleConfigServer>().ExamplePersonFreeGiftList != null)
+			if (!Main.LocalPlayer.GetModPlayer<ExamplePlayer>().examplePersonGiftReceived && ModContent.GetInstance<ExampleConfigServer>().ExamplePersonFreeGiftList != null)
 			{
-				foreach (var item in GetInstance<ExampleConfigServer>().ExamplePersonFreeGiftList)
+				foreach (var item in ModContent.GetInstance<ExampleConfigServer>().ExamplePersonFreeGiftList)
 				{
 					if (item.IsUnloaded)
 						continue;
@@ -262,7 +261,7 @@ namespace ExampleMod.NPCs
 		}
 
 		public override void NPCLoot() {
-			Item.NewItem(npc.getRect(), ItemType<Items.Armor.ExampleCostume>());
+			Item.NewItem(npc.getRect(), ModContent.ItemType<Items.Armor.ExampleCostume>());
 		}
 
 		// Make this Town NPC teleport to the King and/or Queen statue when triggered.
@@ -293,7 +292,7 @@ namespace ExampleMod.NPCs
 				else {
 					position.Y = Math.Sign(position.Y) * 20;
 				}
-				Dust.NewDustPerfect(npc.Center + position, DustType<Pixel>(), Vector2.Zero).noGravity = true;
+				Dust.NewDustPerfect(npc.Center + position, ModContent.DustType<Pixel>(), Vector2.Zero).noGravity = true;
 			}
 		}
 
@@ -308,7 +307,7 @@ namespace ExampleMod.NPCs
 		}
 
 		public override void TownNPCAttackProj(ref int projType, ref int attackDelay) {
-			projType = ProjectileType<SparklingBall>();
+			projType = ModContent.ProjectileType<SparklingBall>();
 			attackDelay = 1;
 		}
 

--- a/ExampleMod/NPCs/ExampleTravelingMerchant.cs
+++ b/ExampleMod/NPCs/ExampleTravelingMerchant.cs
@@ -10,7 +10,6 @@ using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs
 {
@@ -30,7 +29,7 @@ namespace ExampleMod.NPCs
 		public static NPC FindNPC(int npcType) => Main.npc.FirstOrDefault(npc => npc.type == npcType && npc.active);
 
 		public static void UpdateTravelingMerchant() {
-			NPC traveler = FindNPC(NPCType<ExampleTravelingMerchant>()); // Find an Explorer if there's one spawned in the world
+			NPC traveler = FindNPC(ModContent.NPCType<ExampleTravelingMerchant>()); // Find an Explorer if there's one spawned in the world
 			if (traveler != null && (!Main.dayTime || Main.time >= despawnTime) && !IsNpcOnscreen(traveler.Center)) // If it's past the despawn time and the NPC isn't onscreen
 			{
 				// Here we despawn the NPC and send a message stating that the NPC has despawned
@@ -59,7 +58,7 @@ namespace ExampleMod.NPCs
 
 			// Spawn the traveler if the spawn conditions are met (time of day, no events, no sundial)
 			if (traveler == null && CanSpawnNow()) {
-				int newTraveler = NPC.NewNPC(Main.spawnTileX * 16, Main.spawnTileY * 16, NPCType<ExampleTravelingMerchant>(), 1); // Spawning at the world spawn
+				int newTraveler = NPC.NewNPC(Main.spawnTileX * 16, Main.spawnTileY * 16, ModContent.NPCType<ExampleTravelingMerchant>(), 1); // Spawning at the world spawn
 				traveler = Main.npc[newTraveler];
 				traveler.homeless = true;
 				traveler.direction = Main.spawnTileX >= WorldGen.bestX ? -1 : 1;
@@ -111,37 +110,37 @@ namespace ExampleMod.NPCs
 			// For each slot we add a switch case to determine what should go in that slot
 			switch (Main.rand.Next(2)) {
 				case 0:
-					itemIds.Add(ItemType<ExampleItem>());
+					itemIds.Add(ModContent.ItemType<ExampleItem>());
 					break;
 				default:
-					itemIds.Add(ItemType<EquipMaterial>());
+					itemIds.Add(ModContent.ItemType<EquipMaterial>());
 					break;
 			}
 
 			switch (Main.rand.Next(3)) {
 				case 0:
-					itemIds.Add(ItemType<BossItem>());
+					itemIds.Add(ModContent.ItemType<BossItem>());
 					break;
 				case 1:
-					itemIds.Add(ItemType<ExampleWorkbench>());
+					itemIds.Add(ModContent.ItemType<ExampleWorkbench>());
 					break;
 				default:
-					itemIds.Add(ItemType<ExampleChair>());
+					itemIds.Add(ModContent.ItemType<ExampleChair>());
 					break;
 			}
 
 			switch (Main.rand.Next(4)) {
 				case 0:
-					itemIds.Add(ItemType<ExampleDoor>());
+					itemIds.Add(ModContent.ItemType<ExampleDoor>());
 					break;
 				case 1:
-					itemIds.Add(ItemType<ExampleBed>());
+					itemIds.Add(ModContent.ItemType<ExampleBed>());
 					break;
 				case 2:
-					itemIds.Add(ItemType<ExampleChest>());
+					itemIds.Add(ModContent.ItemType<ExampleChest>());
 					break;
 				default:
-					itemIds.Add(ItemType<ExamplePickaxe>());
+					itemIds.Add(ModContent.ItemType<ExamplePickaxe>());
 					break;
 			}
 
@@ -197,7 +196,7 @@ namespace ExampleMod.NPCs
 		public override void HitEffect(int hitDirection, double damage) {
 			int num = npc.life > 0 ? 1 : 5;
 			for (int k = 0; k < num; k++) {
-				Dust.NewDust(npc.position, npc.width, npc.height, DustType<Sparkle>());
+				Dust.NewDust(npc.position, npc.width, npc.height, ModContent.DustType<Sparkle>());
 			}
 		}
 
@@ -264,7 +263,7 @@ namespace ExampleMod.NPCs
 		}
 
 		public override void NPCLoot() {
-			Item.NewItem(npc.getRect(), ItemType<Items.Armor.ExampleCostume>());
+			Item.NewItem(npc.getRect(), ModContent.ItemType<Items.Armor.ExampleCostume>());
 		}
 
 		public override void TownNPCAttackStrength(ref int damage, ref float knockback) {
@@ -278,7 +277,7 @@ namespace ExampleMod.NPCs
 		}
 
 		public override void TownNPCAttackProj(ref int projType, ref int attackDelay) {
-			projType = ProjectileType<SparklingBall>();
+			projType = ModContent.ProjectileType<SparklingBall>();
 			attackDelay = 1;
 		}
 

--- a/ExampleMod/NPCs/FallenSoul.cs
+++ b/ExampleMod/NPCs/FallenSoul.cs
@@ -3,7 +3,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs
 {
@@ -137,7 +136,7 @@ namespace ExampleMod.NPCs
 
 			for (int i = 0; i < Main.maxNPCs; i++) {
 				if (Main.npc[i].active && Main.npc[i].type == NPCID.Wraith && projectile.Hitbox.Intersects(Main.npc[i].Hitbox)) {
-					Main.npc[i].Transform(NPCType<FallenSoul>());
+					Main.npc[i].Transform(ModContent.NPCType<FallenSoul>());
 				}
 			}
 		}

--- a/ExampleMod/NPCs/Octopus.cs
+++ b/ExampleMod/NPCs/Octopus.cs
@@ -5,7 +5,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs
 {
@@ -39,7 +38,7 @@ namespace ExampleMod.NPCs
 			npc.value = Item.buyPrice(0, 0, 15, 0);
 			npc.hide = true;
 			banner = npc.type;
-			bannerItem = ItemType<OctopusBanner>();
+			bannerItem = ModContent.ItemType<OctopusBanner>();
 		}
 
 		public override void AI() {
@@ -49,7 +48,7 @@ namespace ExampleMod.NPCs
 					damage /= 2;
 				}
 				for (int k = 0; k < 6; k++) {
-					int proj = Projectile.NewProjectile(npc.Center.X, npc.Center.Y, 0f, 0f, ProjectileType<OctopusArm>(), damage, 0, Main.myPlayer);
+					int proj = Projectile.NewProjectile(npc.Center.X, npc.Center.Y, 0f, 0f, ModContent.ProjectileType<OctopusArm>(), damage, 0, Main.myPlayer);
 					if (proj == 1000) {
 						npc.active = false;
 						return;

--- a/ExampleMod/NPCs/PuritySpirit/PurityShield.cs
+++ b/ExampleMod/NPCs/PuritySpirit/PurityShield.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs.PuritySpirit
 {
@@ -40,7 +39,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 
 		public override void AI() {
 			NPC owner = Main.npc[(int)npc.ai[0]];
-			if (!owner.active || owner.type != NPCType<PuritySpirit>()) {
+			if (!owner.active || owner.type != ModContent.NPCType<PuritySpirit>()) {
 				npc.active = false;
 				return;
 			}

--- a/ExampleMod/NPCs/PuritySpirit/PuritySpirit.cs
+++ b/ExampleMod/NPCs/PuritySpirit/PuritySpirit.cs
@@ -12,7 +12,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs.PuritySpirit
 {
@@ -52,7 +51,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 			}
 			music = MusicID.Title;
 			musicPriority = MusicPriority.BossMedium; // By default, musicPriority is BossLow
-			bossBag = ItemType<PuritySpiritBag>();
+			bossBag = ModContent.ItemType<PuritySpiritBag>();
 		}
 
 		public override void ScaleExpertStats(int numPlayers, float bossLifeScale) {
@@ -141,7 +140,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 				return;
 			}
 			if (stage == 2 && difficulty > 0) {
-				Projectile.NewProjectile(npc.Center.X - arenaWidth / 2, npc.Center.Y, NegativeWall.speed, 0f, ProjectileType<NegativeWall>(), 0, 0f, Main.myPlayer, npc.whoAmI, arenaHeight);
+				Projectile.NewProjectile(npc.Center.X - arenaWidth / 2, npc.Center.Y, NegativeWall.speed, 0f, ModContent.ProjectileType<NegativeWall>(), 0, 0f, Main.myPlayer, npc.whoAmI, arenaHeight);
 				stage++;
 			}
 			if (stage == 3 && difficulty > 1) {
@@ -149,7 +148,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 				stage++;
 			}
 			if (stage == 4 && difficulty > 2) {
-				Projectile.NewProjectile(npc.Center.X, npc.Center.Y - arenaHeight / 2, 0f, NegativeWall.speed, ProjectileType<NegativeWall>(), 0, 0f, Main.myPlayer, npc.whoAmI, -arenaWidth);
+				Projectile.NewProjectile(npc.Center.X, npc.Center.Y - arenaHeight / 2, 0f, NegativeWall.speed, ModContent.ProjectileType<NegativeWall>(), 0, 0f, Main.myPlayer, npc.whoAmI, -arenaWidth);
 				stage++;
 			}
 			if (stage == 5 && difficulty > 3) {
@@ -323,7 +322,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 				if (Main.expertMode) {
 					damage = (int)(100 / Main.expertDamage);
 				}
-				int proj = Projectile.NewProjectile(pos.X, pos.Y, 0f, 0f, ProjectileType<PureCrystal>(), damage, 0f, Main.myPlayer, npc.whoAmI, angle);
+				int proj = Projectile.NewProjectile(pos.X, pos.Y, 0f, 0f, ModContent.ProjectileType<PureCrystal>(), damage, 0f, Main.myPlayer, npc.whoAmI, angle);
 				Main.projectile[proj].localAI[0] = radius;
 				Main.projectile[proj].localAI[1] = clockwise ? 1 : -1;
 				NetMessage.SendData(MessageID.SyncProjectile, -1, -1, null, proj);
@@ -335,7 +334,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 				PlaySound(15, 0);
 				if (Main.netMode != NetmodeID.MultiplayerClient) {
 					int damage = Main.expertMode ? 720 : 600;
-					Projectile.NewProjectile(npc.Center.X, npc.Center.Y, 0f, 0f, ProjectileType<VoidWorld>(), damage, 0f, Main.myPlayer, npc.whoAmI, Main.rand.Next());
+					Projectile.NewProjectile(npc.Center.X, npc.Center.Y, 0f, 0f, ModContent.ProjectileType<VoidWorld>(), damage, 0f, Main.myPlayer, npc.whoAmI, Main.rand.Next());
 				}
 			}
 			attackProgress++;
@@ -396,7 +395,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 				int damage = Main.expertMode ? 360 : 300;
 				for (int k = 0; k < targets.Count; k++) {
 					float x = Main.player[targets[k]].Center.X;
-					Projectile.NewProjectile(x, y, 0f, 0f, ProjectileType<PurityBeam>(), damage, 0f, Main.myPlayer, arenaHeight);
+					Projectile.NewProjectile(x, y, 0f, 0f, ModContent.ProjectileType<PurityBeam>(), damage, 0f, Main.myPlayer, arenaHeight);
 					for (int j = -1; j <= 1; j += 2) {
 						float spawnX = x + j * Main.rand.Next(200, 401);
 						if (spawnX > npc.Center.X + arenaWidth / 2) {
@@ -405,7 +404,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 						else if (spawnX < npc.Center.X - arenaWidth / 2) {
 							spawnX += arenaWidth;
 						}
-						Projectile.NewProjectile(spawnX, y, 0f, 0f, ProjectileType<PurityBeam>(), damage, 0f, Main.myPlayer, arenaHeight);
+						Projectile.NewProjectile(spawnX, y, 0f, 0f, ModContent.ProjectileType<PurityBeam>(), damage, 0f, Main.myPlayer, arenaHeight);
 					}
 				}
 				int numExtra = 2 * (difficulty + 1) - 2 * (targets.Count - 1);
@@ -416,7 +415,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 					numExtra--;
 				}
 				for (int k = 0; k < numExtra; k++) {
-					Projectile.NewProjectile(npc.Center.X + Main.rand.Next(-arenaWidth / 2 + 50, arenaWidth / 2 - 50 + 1), y, 0f, 0f, ProjectileType<PurityBeam>(), damage, 0f, Main.myPlayer, arenaHeight);
+					Projectile.NewProjectile(npc.Center.X + Main.rand.Next(-arenaWidth / 2 + 50, arenaWidth / 2 - 50 + 1), y, 0f, 0f, ModContent.ProjectileType<PurityBeam>(), damage, 0f, Main.myPlayer, arenaHeight);
 				}
 				attackProgress = (int)(PurityBeam.charge + 60f);
 			}
@@ -429,7 +428,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 		private void SnakeAttack() {
 			if (attackProgress == 0) {
 				int damage = Main.expertMode ? 60 : 80;
-				Projectile.NewProjectile(npc.Center.X, npc.Center.Y, 0f, 0f, ProjectileType<PuritySnake>(), damage, 0f, Main.myPlayer, npc.whoAmI, timeMultiplier);
+				Projectile.NewProjectile(npc.Center.X, npc.Center.Y, 0f, 0f, ModContent.ProjectileType<PuritySnake>(), damage, 0f, Main.myPlayer, npc.whoAmI, timeMultiplier);
 				attackProgress = 240;
 			}
 			attackProgress--;
@@ -445,7 +444,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 				float totalTime = numAttacks * timer + 120f;
 				int damage = Main.expertMode ? 55 : 80;
 				for (int k = 0; k < numAttacks; k++) {
-					int proj = Projectile.NewProjectile(npc.Center.X, npc.Center.Y, 0f, 0f, ProjectileType<NullLaser>(), damage, 0f, Main.myPlayer, npc.whoAmI, (int)(60f + k * timer));
+					int proj = Projectile.NewProjectile(npc.Center.X, npc.Center.Y, 0f, 0f, ModContent.ProjectileType<NullLaser>(), damage, 0f, Main.myPlayer, npc.whoAmI, (int)(60f + k * timer));
 					Main.projectile[proj].localAI[0] = (int)totalTime;
 					((NullLaser)Main.projectile[proj].modProjectile).warningTime = timer;
 					NetMessage.SendData(MessageID.SyncProjectile, -1, -1, null, proj);
@@ -455,7 +454,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 			if (attackProgress % 20 == 0) {
 				PlaySound(2, 15);
 			}
-			Dust.NewDust(npc.position, npc.width, npc.height, DustType<Sparkle>(), 0f, 0f, 0, new Color(0, 180, 0), 1.5f);
+			Dust.NewDust(npc.position, npc.width, npc.height, ModContent.DustType<Sparkle>(), 0f, 0f, 0, new Color(0, 180, 0), 1.5f);
 			attackProgress--;
 			if (attackProgress < 0) {
 				attackProgress = 0;
@@ -485,7 +484,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 					for (int k = 0; k < numSpheres; k++) {
 						Vector2 pos = center + radius * new Vector2((float)Math.Cos(angle), (float)Math.Sin(angle));
 						angle += 2f * (float)Math.PI / numSpheres;
-						int proj = Projectile.NewProjectile(pos.X, pos.Y, 0f, 0f, ProjectileType<PuritySphere>(), damage, 0f, Main.myPlayer, center.X, center.Y);
+						int proj = Projectile.NewProjectile(pos.X, pos.Y, 0f, 0f, ModContent.ProjectileType<PuritySphere>(), damage, 0f, Main.myPlayer, center.X, center.Y);
 						Main.projectile[proj].localAI[0] = target;
 						Main.projectile[proj].localAI[1] = rotationSpeed;
 						((PuritySphere)Main.projectile[proj].modProjectile).maxTimer = (int)time;
@@ -503,7 +502,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 		private void DoShield(int numShields) {
 			int count = 0;
 			for (int k = 0; k < 200; k++) {
-				if (Main.npc[k].active && Main.npc[k].type == NPCType<PurityShield>() && Main.npc[k].ai[0] == npc.whoAmI) {
+				if (Main.npc[k].active && Main.npc[k].type == ModContent.NPCType<PurityShield>() && Main.npc[k].ai[0] == npc.whoAmI) {
 					count++;
 				}
 			}
@@ -516,7 +515,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 			if (shieldTimer >= 300 + 300 * timeMult) {
 				float targetX = npc.Center.X + (Main.rand.Next(2) * 2 - 1) * arenaWidth / 4;
 				float targetY = npc.Center.Y + (Main.rand.Next(2) * 2 - 1) * arenaHeight / 4;
-				NPC.NewNPC((int)npc.Center.X, (int)npc.Center.Y + 40, NPCType<PurityShield>(), 0, npc.whoAmI, targetX, targetY);
+				NPC.NewNPC((int)npc.Center.X, (int)npc.Center.Y + 40, ModContent.NPCType<PurityShield>(), 0, npc.whoAmI, targetX, targetY);
 				shieldTimer = 0;
 			}
 		}
@@ -607,13 +606,13 @@ namespace ExampleMod.NPCs.PuritySpirit
 			int item = 0;
 			switch (choice) {
 				case 0:
-					item = ItemType<PuritySpiritTrophy>();
+					item = ModContent.ItemType<PuritySpiritTrophy>();
 					break;
 				case 1:
-					item = ItemType<BunnyTrophy>();
+					item = ModContent.ItemType<BunnyTrophy>();
 					break;
 				case 2:
-					item = ItemType<TreeTrophy>();
+					item = ModContent.ItemType<TreeTrophy>();
 					break;
 			}
 			if (item > 0) {
@@ -625,15 +624,15 @@ namespace ExampleMod.NPCs.PuritySpirit
 			else {
 				choice = Main.rand.Next(7);
 				if (choice == 0) {
-					Item.NewItem(npc.getRect(), ItemType<PuritySpiritMask>());
+					Item.NewItem(npc.getRect(), ModContent.ItemType<PuritySpiritMask>());
 				}
 				else if (choice == 1) {
-					Item.NewItem(npc.getRect(), ItemType<BunnyMask>());
+					Item.NewItem(npc.getRect(), ModContent.ItemType<BunnyMask>());
 				}
 				if (choice != 1) {
 					Item.NewItem(npc.getRect(), ItemID.Bunny);
 				}
-				Item.NewItem(npc.getRect(), ItemType<Items.PurityShield>());
+				Item.NewItem(npc.getRect(), ModContent.ItemType<Items.PurityShield>());
 			}
 			if (!ExampleWorld.downedPuritySpirit) {
 				ExampleWorld.downedPuritySpirit = true;
@@ -680,7 +679,7 @@ namespace ExampleMod.NPCs.PuritySpirit
 				return false;
 			}
 			for (int k = 0; k < 200; k++) {
-				if (Main.npc[k].active && Main.npc[k].type == NPCType<PurityShield>() && Main.npc[k].ai[0] == npc.whoAmI) {
+				if (Main.npc[k].active && Main.npc[k].type == ModContent.NPCType<PurityShield>() && Main.npc[k].ai[0] == npc.whoAmI) {
 					return false;
 				}
 			}

--- a/ExampleMod/NPCs/Sarcophagus.cs
+++ b/ExampleMod/NPCs/Sarcophagus.cs
@@ -7,7 +7,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs
 {
@@ -38,7 +37,7 @@ namespace ExampleMod.NPCs
 			npc.buffImmune[BuffID.Poisoned] = true;
 			npc.buffImmune[BuffID.Venom] = true;
 			banner = npc.type;
-			bannerItem = ItemType<SarcophagusBanner>();
+			bannerItem = ModContent.ItemType<SarcophagusBanner>();
 		}
 
 		public override void CustomBehavior(ref float ai) {
@@ -52,7 +51,7 @@ namespace ExampleMod.NPCs
 				else if (ai >= 180f) {
 					ai = -120f;
 					if (Main.netMode != NetmodeID.MultiplayerClient) {
-						int proj = Projectile.NewProjectile(npc.Center.X, npc.Center.Y, 0f, 0f, ProjectileType<ShadowArm>(), npc.damage / 2, 0f, Main.myPlayer, player.Center.X, player.Center.Y);
+						int proj = Projectile.NewProjectile(npc.Center.X, npc.Center.Y, 0f, 0f, ModContent.ProjectileType<ShadowArm>(), npc.damage / 2, 0f, Main.myPlayer, player.Center.X, player.Center.Y);
 					}
 					npc.netUpdate = true;
 				}
@@ -88,7 +87,7 @@ namespace ExampleMod.NPCs
 				}
 			}
 			for (int k = 0; k < 2; k++) {
-				int dust = Dust.NewDust(npc.position - new Vector2(8f, 8f), npc.width + 16, npc.height + 16, DustType<Smoke>(), 0f, 0f, 0, Color.Black);
+				int dust = Dust.NewDust(npc.position - new Vector2(8f, 8f), npc.width + 16, npc.height + 16, ModContent.DustType<Smoke>(), 0f, 0f, 0, Color.Black);
 				Main.dust[dust].velocity += npc.velocity * 0.25f;
 			}
 		}

--- a/ExampleMod/NPCs/Worm.cs
+++ b/ExampleMod/NPCs/Worm.cs
@@ -3,7 +3,6 @@ using System.IO;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.NPCs
 {
@@ -89,9 +88,9 @@ namespace ExampleMod.NPCs
 		public override void Init() {
 			minLength = 6;
 			maxLength = 12;
-			tailType = NPCType<ExampleWormTail>();
-			bodyType = NPCType<ExampleWormBody>();
-			headType = NPCType<ExampleWormHead>();
+			tailType = ModContent.NPCType<ExampleWormTail>();
+			bodyType = ModContent.NPCType<ExampleWormBody>();
+			headType = ModContent.NPCType<ExampleWormHead>();
 			speed = 5.5f;
 			turnSpeed = 0.045f;
 		}

--- a/ExampleMod/Projectiles/ElementBall.cs
+++ b/ExampleMod/Projectiles/ElementBall.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -50,7 +49,7 @@ namespace ExampleMod.Projectiles
 		public virtual void CreateDust() {
 			Color? color = GetColor();
 			if (color.HasValue) {
-				int dust = Dust.NewDust(projectile.position, projectile.width, projectile.height, DustType<Flame>(), 0f, 0f, 0, color.Value);
+				int dust = Dust.NewDust(projectile.position, projectile.width, projectile.height, ModContent.DustType<Flame>(), 0f, 0f, 0, color.Value);
 				Main.dust[dust].velocity *= 0.4f;
 				Main.dust[dust].velocity += projectile.velocity;
 			}
@@ -69,7 +68,7 @@ namespace ExampleMod.Projectiles
 			if (projectile.ai[0] == 44f) {
 				return "Frost Ball";
 			}
-			if (projectile.ai[0] == BuffType<Buffs.EtherealFlames>()) {
+			if (projectile.ai[0] == ModContent.BuffType<Buffs.EtherealFlames>()) {
 				return "Ethereal Fireball";
 			}
 			if (projectile.ai[0] == 70f) {
@@ -88,7 +87,7 @@ namespace ExampleMod.Projectiles
 			if (projectile.ai[0] == 44f) {
 				return new Color(0, 230, 230);
 			}
-			if (projectile.ai[0] == BuffType<Buffs.EtherealFlames>()) {
+			if (projectile.ai[0] == ModContent.BuffType<Buffs.EtherealFlames>()) {
 				return new Color(0, 153, 230);
 			}
 			if (projectile.ai[0] == 70f) {

--- a/ExampleMod/Projectiles/ElementLaser.cs
+++ b/ExampleMod/Projectiles/ElementLaser.cs
@@ -4,7 +4,6 @@ using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -28,7 +27,7 @@ namespace ExampleMod.Projectiles
 		public override void AI() {
 			NPC npc = Main.npc[(int)projectile.ai[0]];
 			if (projectile.localAI[0] == 0f) {
-				if (npc.type == NPCType<CaptiveElement>() && npc.ai[1] == 2f && Main.expertMode) {
+				if (npc.type == ModContent.NPCType<CaptiveElement>() && npc.ai[1] == 2f && Main.expertMode) {
 					cooldownSlot = 1;
 				}
 				projectile.Name = GetName();
@@ -61,7 +60,7 @@ namespace ExampleMod.Projectiles
 
 		public string GetName() {
 			NPC npc = Main.npc[(int)projectile.ai[0]];
-			if (npc.type == NPCType<Abomination>()) {
+			if (npc.type == ModContent.NPCType<Abomination>()) {
 				return "Fire Beam";
 			}
 			if (npc.ai[1] == 0f) {
@@ -84,7 +83,7 @@ namespace ExampleMod.Projectiles
 
 		public Color GetColor() {
 			NPC npc = Main.npc[(int)projectile.ai[0]];
-			if (npc.type == NPCType<Abomination>()) {
+			if (npc.type == ModContent.NPCType<Abomination>()) {
 				return new Color(250, 10, 0);
 			}
 			if (npc.ai[1] == 0f) {
@@ -104,14 +103,14 @@ namespace ExampleMod.Projectiles
 
 		public int GetDebuff() {
 			NPC npc = Main.npc[(int)projectile.ai[0]];
-			if (npc.type == NPCType<Abomination>()) {
+			if (npc.type == ModContent.NPCType<Abomination>()) {
 				return BuffID.OnFire;
 			}
 			if (npc.ai[1] == 0f) {
 				return BuffID.Frostburn;
 			}
 			if (npc.ai[1] == 1f) {
-				return BuffType<Buffs.EtherealFlames>();
+				return ModContent.BuffType<Buffs.EtherealFlames>();
 			}
 			if (npc.ai[1] == 3f) {
 				return BuffID.Venom;
@@ -124,7 +123,7 @@ namespace ExampleMod.Projectiles
 
 		public int GetDebuffTime() {
 			NPC npc = Main.npc[(int)projectile.ai[0]];
-			if (npc.type == NPCType<Abomination>()) {
+			if (npc.type == ModContent.NPCType<Abomination>()) {
 				return 600;
 			}
 			if (npc.ai[1] == 0f) {

--- a/ExampleMod/Projectiles/ElementShield.cs
+++ b/ExampleMod/Projectiles/ElementShield.cs
@@ -3,7 +3,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -149,7 +148,7 @@ namespace ExampleMod.Projectiles
 				case 1:
 					return BuffID.Frostburn;
 				case 2:
-					return BuffType<Buffs.EtherealFlames>();
+					return ModContent.BuffType<Buffs.EtherealFlames>();
 				case 3:
 					return 0;
 				case 4:

--- a/ExampleMod/Projectiles/ExampleAnimatedPierce.cs
+++ b/ExampleMod/Projectiles/ExampleAnimatedPierce.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -141,7 +140,7 @@ namespace ExampleMod.Projectiles
 			item.CloneDefaults(ItemID.NebulaBlaze);
 			item.mana = 3;
 			item.damage = 3;
-			item.shoot = ProjectileType<ExampleAnimatedPierce>();
+			item.shoot = ModContent.ProjectileType<ExampleAnimatedPierce>();
 		}
 	}
 }

--- a/ExampleMod/Projectiles/ExampleBehindTilesProjectile.cs
+++ b/ExampleMod/Projectiles/ExampleBehindTilesProjectile.cs
@@ -3,7 +3,6 @@ using ExampleMod.Tiles;
 using System.Collections.Generic;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -43,14 +42,14 @@ namespace ExampleMod.Projectiles
 
 		public override void SetDefaults() {
 			item.CloneDefaults(ItemID.Shuriken);
-			item.shoot = ProjectileType<ExampleBehindTilesProjectile>();
+			item.shoot = ModContent.ProjectileType<ExampleBehindTilesProjectile>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.Shuriken, 10);
-			recipe.AddIngredient(ItemType<ExampleItem>(), 1);
-			recipe.AddTile(TileType<ExampleWorkbench>());
+			recipe.AddIngredient(ModContent.ItemType<ExampleItem>(), 1);
+			recipe.AddTile(ModContent.TileType<ExampleWorkbench>());
 			recipe.SetResult(this, 10);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Projectiles/ExampleBobber.cs
+++ b/ExampleMod/Projectiles/ExampleBobber.cs
@@ -5,7 +5,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -64,7 +63,7 @@ namespace ExampleMod.Projectiles
 			//This variable is used to account for Gravitation Potions
 			float gravity = player.gravDir;
 
-			if (type == ItemType<ExampleFishingRod>()) {
+			if (type == ModContent.ItemType<ExampleFishingRod>()) {
 				lineOrigin.X += xPositionAdditive * player.direction;
 				if (player.direction < 0) {
 					lineOrigin.X -= 13f;

--- a/ExampleMod/Projectiles/ExampleJavelinProjectile.cs
+++ b/ExampleMod/Projectiles/ExampleJavelinProjectile.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -91,7 +90,7 @@ namespace ExampleMod.Projectiles
 				// Drop a javelin item, 1 in 18 chance (~5.5% chance)
 				int item =
 				Main.rand.NextBool(18)
-					? Item.NewItem(projectile.getRect(), ItemType<ExampleJavelin>())
+					? Item.NewItem(projectile.getRect(), ModContent.ItemType<ExampleJavelin>())
 					: 0;
 
 				// Sync the drop for multiplayer
@@ -131,7 +130,7 @@ namespace ExampleMod.Projectiles
 				(target.Center - projectile.Center) *
 				0.75f; // Change velocity based on delta center of targets (difference between entity centers)
 			projectile.netUpdate = true; // netUpdate this javelin
-			target.AddBuff(BuffType<Buffs.ExampleJavelin>(), 900); // Adds the ExampleJavelin debuff for a very small DoT
+			target.AddBuff(ModContent.BuffType<Buffs.ExampleJavelin>(), 900); // Adds the ExampleJavelin debuff for a very small DoT
 
 			projectile.damage = 0; // Makes sure the sticking javelins do not deal damage anymore
 
@@ -230,13 +229,13 @@ namespace ExampleMod.Projectiles
 
 			// Spawn some random dusts as the javelin travels
 			if (Main.rand.NextBool(3)) {
-				Dust dust = Dust.NewDustDirect(projectile.position, projectile.height, projectile.width, DustType<Sparkle>(),
+				Dust dust = Dust.NewDustDirect(projectile.position, projectile.height, projectile.width, ModContent.DustType<Sparkle>(),
 					projectile.velocity.X * .2f, projectile.velocity.Y * .2f, 200, Scale: 1.2f);
 				dust.velocity += projectile.velocity * 0.3f;
 				dust.velocity *= 0.2f;
 			}
 			if (Main.rand.NextBool(4)) {
-				Dust dust = Dust.NewDustDirect(projectile.position, projectile.height, projectile.width, DustType<Sparkle>(),
+				Dust dust = Dust.NewDustDirect(projectile.position, projectile.height, projectile.width, ModContent.DustType<Sparkle>(),
 					0, 0, 254, Scale: 0.3f);
 				dust.velocity += projectile.velocity * 0.5f;
 				dust.velocity *= 0.5f;

--- a/ExampleMod/Projectiles/ExampleLastPrismHoldout.cs
+++ b/ExampleMod/Projectiles/ExampleLastPrismHoldout.cs
@@ -4,7 +4,6 @@ using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -228,7 +227,7 @@ namespace ExampleMod.Projectiles
 			int damage = projectile.damage;
 			float knockback = projectile.knockBack;
 			for (int b = 0; b < NumBeams; ++b) {
-				Projectile.NewProjectile(projectile.Center, beamVelocity, ProjectileType<ExampleLastPrismBeam>(), damage, knockback, projectile.owner, b, uuid);
+				Projectile.NewProjectile(projectile.Center, beamVelocity, ModContent.ProjectileType<ExampleLastPrismBeam>(), damage, knockback, projectile.owner, b, uuid);
 			}
 
 			// After creating the beams, mark the Prism as having an important network event. This will make Terraria sync its data to other players ASAP.

--- a/ExampleMod/Projectiles/ExampleSolution.cs
+++ b/ExampleMod/Projectiles/ExampleSolution.cs
@@ -5,7 +5,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -28,7 +27,7 @@ namespace ExampleMod.Projectiles
 
 		public override void AI() {
 			//Set the dust type to ExampleSolution
-			int dustType = DustType<Dusts.ExampleSolution>();
+			int dustType = ModContent.DustType<Dusts.ExampleSolution>();
 
 			if (projectile.owner == Main.myPlayer)
 				Convert((int)(projectile.position.X + projectile.width / 2) / 16, (int)(projectile.position.Y + projectile.height / 2) / 16, 2);
@@ -75,34 +74,34 @@ namespace ExampleMod.Projectiles
 
 						//Convert all walls to ExampleWall
 						if (wall != 0) {
-							Main.tile[k, l].wall = (ushort)WallType<ExampleWall>();
+							Main.tile[k, l].wall = (ushort)ModContent.WallType<ExampleWall>();
 							WorldGen.SquareWallFrame(k, l, true);
 							NetMessage.SendTileSquare(-1, k, l, 1);
 						}
 
 						//If the tile is stone, convert to ExampleBlock
 						if (TileID.Sets.Conversion.Stone[type]) {
-							Main.tile[k, l].type = (ushort)TileType<ExampleBlock>();
+							Main.tile[k, l].type = (ushort)ModContent.TileType<ExampleBlock>();
 							WorldGen.SquareTileFrame(k, l, true);
 							NetMessage.SendTileSquare(-1, k, l, 1);
 						}
 						//If the tile is sand, convert to ExampleSand
 						else if (TileID.Sets.Conversion.Sand[type]) {
-							Main.tile[k, l].type = (ushort)TileType<ExampleSand>();
+							Main.tile[k, l].type = (ushort)ModContent.TileType<ExampleSand>();
 							WorldGen.SquareTileFrame(k, l, true);
 							NetMessage.SendTileSquare(-1, k, l, 1);
 						}
 						//If the tile is a chair, convert to ExampleChair
 						else if (type == TileID.Chairs && Main.tile[k, l - 1].type == TileID.Chairs) {
-							Main.tile[k, l].type = (ushort)TileType<ExampleChair>();
-							Main.tile[k, l - 1].type = (ushort)TileType<ExampleChair>();
+							Main.tile[k, l].type = (ushort)ModContent.TileType<ExampleChair>();
+							Main.tile[k, l - 1].type = (ushort)ModContent.TileType<ExampleChair>();
 							WorldGen.SquareTileFrame(k, l, true);
 							NetMessage.SendTileSquare(-1, k, l, 1);
 						}
 						//If the tile is a workbench, convert to ExampleWorkBench
 						else if (type == TileID.WorkBenches && Main.tile[k - 1, l].type == TileID.WorkBenches) {
-							Main.tile[k, l].type = (ushort)TileType<ExampleWorkbench>();
-							Main.tile[k - 1, l].type = (ushort)TileType<ExampleWorkbench>();
+							Main.tile[k, l].type = (ushort)ModContent.TileType<ExampleWorkbench>();
+							Main.tile[k - 1, l].type = (ushort)ModContent.TileType<ExampleWorkbench>();
 							WorldGen.SquareTileFrame(k, l, true);
 							NetMessage.SendTileSquare(-1, k, l, 1);
 						}

--- a/ExampleMod/Projectiles/ExampleSpearProjectile.cs
+++ b/ExampleMod/Projectiles/ExampleSpearProjectile.cs
@@ -2,7 +2,6 @@
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -79,13 +78,13 @@ namespace ExampleMod.Projectiles
 
 			// These dusts are added later, for the 'ExampleMod' effect
 			if (Main.rand.NextBool(3)) {
-				Dust dust = Dust.NewDustDirect(projectile.position, projectile.height, projectile.width, DustType<Sparkle>(),
+				Dust dust = Dust.NewDustDirect(projectile.position, projectile.height, projectile.width, ModContent.DustType<Sparkle>(),
 					projectile.velocity.X * .2f, projectile.velocity.Y * .2f, 200, Scale: 1.2f);
 				dust.velocity += projectile.velocity * 0.3f;
 				dust.velocity *= 0.2f;
 			}
 			if (Main.rand.NextBool(4)) {
-				Dust dust = Dust.NewDustDirect(projectile.position, projectile.height, projectile.width, DustType<Sparkle>(),
+				Dust dust = Dust.NewDustDirect(projectile.position, projectile.height, projectile.width, ModContent.DustType<Sparkle>(),
 					0, 0, 254, Scale: 0.3f);
 				dust.velocity += projectile.velocity * 0.5f;
 				dust.velocity *= 0.5f;

--- a/ExampleMod/Projectiles/HealProj.cs
+++ b/ExampleMod/Projectiles/HealProj.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework;
 using System;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -24,7 +23,7 @@ namespace ExampleMod.Projectiles
 							heal = damage;
 						}
 						if (heal > 0) {
-							player.AddBuff(BuffType<Undead2>(), 2 * heal, false);
+							player.AddBuff(ModContent.BuffType<Undead2>(), 2 * heal, false);
 						}
 					}
 				}

--- a/ExampleMod/Projectiles/MagicMissile.cs
+++ b/ExampleMod/Projectiles/MagicMissile.cs
@@ -4,7 +4,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -31,7 +30,7 @@ namespace ExampleMod.Projectiles
 			}
 
 			Vector2 dustPosition = projectile.Center + new Vector2(Main.rand.Next(-4, 5), Main.rand.Next(-4, 5));
-			Dust dust = Dust.NewDustPerfect(dustPosition, DustType<Sparkle>(), null, 100, Color.Lime, 0.8f);
+			Dust dust = Dust.NewDustPerfect(dustPosition, ModContent.DustType<Sparkle>(), null, 100, Color.Lime, 0.8f);
 			dust.velocity *= 0.3f;
 			dust.noGravity = true;
 
@@ -128,10 +127,10 @@ namespace ExampleMod.Projectiles
 
 			Main.PlaySound(SoundID.Item10, projectile.position);
 			for (int i = 0; i < 10; i++) {
-				Dust dust = Dust.NewDustDirect(projectile.position - projectile.velocity, projectile.width, projectile.height, DustType<Sparkle>(), 0, 0, 100, Color.Lime, 0.8f);
+				Dust dust = Dust.NewDustDirect(projectile.position - projectile.velocity, projectile.width, projectile.height, ModContent.DustType<Sparkle>(), 0, 0, 100, Color.Lime, 0.8f);
 				dust.noGravity = true;
 				dust.velocity *= 2f;
-				dust = Dust.NewDustDirect(projectile.position - projectile.velocity, projectile.width, projectile.height, DustType<Sparkle>(), 0f, 0f, 100, Color.Lime, 0.5f);
+				dust = Dust.NewDustDirect(projectile.position - projectile.velocity, projectile.width, projectile.height, ModContent.DustType<Sparkle>(), 0f, 0f, 100, Color.Lime, 0.5f);
 			}
 		}
 	}

--- a/ExampleMod/Projectiles/Minions/ExampleSimpleMinion/ExampleSimpleMinion.cs
+++ b/ExampleMod/Projectiles/Minions/ExampleSimpleMinion/ExampleSimpleMinion.cs
@@ -3,7 +3,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles.Minions.ExampleSimpleMinion
 {
@@ -31,7 +30,7 @@ namespace ExampleMod.Projectiles.Minions.ExampleSimpleMinion
 		}
 
 		public override void Update(Player player, ref int buffIndex) {
-			if (player.ownedProjectileCounts[ProjectileType<ExampleMinion>()] > 0) {
+			if (player.ownedProjectileCounts[ModContent.ProjectileType<ExampleMinion>()] > 0) {
 				player.buffTime[buffIndex] = 18000;
 			}
 			else {
@@ -66,9 +65,9 @@ namespace ExampleMod.Projectiles.Minions.ExampleSimpleMinion
 			// These below are needed for a minion weapon
 			item.noMelee = true;
 			item.summon = true;
-			item.buffType = BuffType<ExampleMinionBuff>();
+			item.buffType = ModContent.BuffType<ExampleMinionBuff>();
 			// No buffTime because otherwise the item tooltip would say something like "1 minute duration"
-			item.shoot = ProjectileType<ExampleMinion>();
+			item.shoot = ModContent.ProjectileType<ExampleMinion>();
 		}
 
 		public override bool Shoot(Player player, ref Vector2 position, ref float speedX, ref float speedY, ref int type, ref int damage, ref float knockBack) {
@@ -146,9 +145,9 @@ namespace ExampleMod.Projectiles.Minions.ExampleSimpleMinion
 			#region Active check
 			// This is the "active check", makes sure the minion is alive while the player is alive, and despawns if not
 			if (player.dead || !player.active) {
-				player.ClearBuff(BuffType<ExampleMinionBuff>());
+				player.ClearBuff(ModContent.BuffType<ExampleMinionBuff>());
 			}
-			if (player.HasBuff(BuffType<ExampleMinionBuff>())) {
+			if (player.HasBuff(ModContent.BuffType<ExampleMinionBuff>())) {
 				projectile.timeLeft = 2;
 			}
 			#endregion

--- a/ExampleMod/Projectiles/Minions/PurityWisp.cs
+++ b/ExampleMod/Projectiles/Minions/PurityWisp.cs
@@ -2,7 +2,7 @@ using ExampleMod.Dusts;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
-using static Terraria.ModLoader.ModContent;
+using Terraria.ModLoader;
 
 namespace ExampleMod.Projectiles.Minions
 {
@@ -31,7 +31,7 @@ namespace ExampleMod.Projectiles.Minions
 			projectile.tileCollide = false;
 			projectile.ignoreWater = true;
 			inertia = 20f;
-			shoot = ProjectileType<PurityBolt>();
+			shoot = ModContent.ProjectileType<PurityBolt>();
 			shootSpeed = 12f;
 		}
 
@@ -49,7 +49,7 @@ namespace ExampleMod.Projectiles.Minions
 		public override void CreateDust() {
 			if (projectile.ai[0] == 0f) {
 				if (Main.rand.NextBool(5)) {
-					int dust = Dust.NewDust(projectile.position, projectile.width, projectile.height / 2, DustType<PuriumFlame>());
+					int dust = Dust.NewDust(projectile.position, projectile.width, projectile.height / 2, ModContent.DustType<PuriumFlame>());
 					Main.dust[dust].velocity.Y -= 1.2f;
 				}
 			}
@@ -59,7 +59,7 @@ namespace ExampleMod.Projectiles.Minions
 					if (dustVel != Vector2.Zero) {
 						dustVel.Normalize();
 					}
-					int dust = Dust.NewDust(projectile.position, projectile.width, projectile.height, DustType<PuriumFlame>());
+					int dust = Dust.NewDust(projectile.position, projectile.width, projectile.height, ModContent.DustType<PuriumFlame>());
 					Main.dust[dust].velocity -= 1.2f * dustVel;
 				}
 			}

--- a/ExampleMod/Projectiles/OctopusArm.cs
+++ b/ExampleMod/Projectiles/OctopusArm.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Projectiles
@@ -55,7 +54,7 @@ namespace ExampleMod.Projectiles
 
 		public override void AI() {
 			NPC npc = Main.npc[octopus];
-			if (!npc.active || npc.type != NPCType<Octopus>()) {
+			if (!npc.active || npc.type != ModContent.NPCType<Octopus>()) {
 				return;
 			}
 			projectile.timeLeft = 2;

--- a/ExampleMod/Projectiles/PixelBall.cs
+++ b/ExampleMod/Projectiles/PixelBall.cs
@@ -2,7 +2,7 @@ using ExampleMod.Dusts;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
-using static Terraria.ModLoader.ModContent;
+using Terraria.ModLoader;
 
 namespace ExampleMod.Projectiles
 {
@@ -17,7 +17,7 @@ namespace ExampleMod.Projectiles
 		public override void CreateDust() {
 			Color? color = GetColor();
 			if (color.HasValue) {
-				int dust = Dust.NewDust(projectile.position, projectile.width, projectile.height, DustType<Pixel>(), 0f, 0f, 0, color.Value);
+				int dust = Dust.NewDust(projectile.position, projectile.width, projectile.height, ModContent.DustType<Pixel>(), 0f, 0f, 0, color.Value);
 				Main.dust[dust].velocity += projectile.velocity;
 				Main.dust[dust].scale = 0.9f;
 			}
@@ -34,7 +34,7 @@ namespace ExampleMod.Projectiles
 			if (projectile.ai[0] == 44f) {
 				return "Frost Sprite";
 			}
-			if (projectile.ai[0] == BuffType<Buffs.EtherealFlames>()) {
+			if (projectile.ai[0] == ModContent.BuffType<Buffs.EtherealFlames>()) {
 				return "Spirit Sprite";
 			}
 			if (projectile.ai[0] == 70f) {

--- a/ExampleMod/Projectiles/PuritySpirit/NegativeWall.cs
+++ b/ExampleMod/Projectiles/PuritySpirit/NegativeWall.cs
@@ -2,7 +2,6 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles.PuritySpirit
 {
@@ -61,7 +60,7 @@ namespace ExampleMod.Projectiles.PuritySpirit
 				}
 			}
 			projectile.timeLeft = 2;
-			if (!npc.active || npc.type != NPCType<NPCs.PuritySpirit.PuritySpirit>()) {
+			if (!npc.active || npc.type != ModContent.NPCType<NPCs.PuritySpirit.PuritySpirit>()) {
 				projectile.Kill();
 			}
 		}

--- a/ExampleMod/Projectiles/PuritySpirit/NullLaser.cs
+++ b/ExampleMod/Projectiles/PuritySpirit/NullLaser.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles.PuritySpirit
 {
@@ -42,7 +41,7 @@ namespace ExampleMod.Projectiles.PuritySpirit
 
 		public override void AI() {
 			NPC npc = Main.npc[(int)projectile.ai[0]];
-			if (!npc.active || npc.type != NPCType<NPCs.PuritySpirit.PuritySpirit>() || projectile.localAI[0] <= 0f) {
+			if (!npc.active || npc.type != ModContent.NPCType<NPCs.PuritySpirit.PuritySpirit>() || projectile.localAI[0] <= 0f) {
 				projectile.Kill();
 				return;
 			}
@@ -118,7 +117,7 @@ namespace ExampleMod.Projectiles.PuritySpirit
 
 		public override void ModifyHitPlayer(Player target, ref int damage, ref bool crit) {
 			if (Main.rand.NextBool(3) || Main.expertMode && Main.rand.NextBool(3)) {
-				target.AddBuff(BuffType<Nullified>(), Main.rand.Next(240, 300));
+				target.AddBuff(ModContent.BuffType<Nullified>(), Main.rand.Next(240, 300));
 			}
 		}
 

--- a/ExampleMod/Projectiles/PuritySpirit/PureCrystal.cs
+++ b/ExampleMod/Projectiles/PuritySpirit/PureCrystal.cs
@@ -4,7 +4,6 @@ using System;
 using System.IO;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles.PuritySpirit
 {
@@ -38,7 +37,7 @@ namespace ExampleMod.Projectiles.PuritySpirit
 
 		public override void AI() {
 			NPC center = Main.npc[(int)projectile.ai[0]];
-			if (!center.active || center.type != NPCType<NPCs.PuritySpirit.PuritySpirit>()) {
+			if (!center.active || center.type != ModContent.NPCType<NPCs.PuritySpirit.PuritySpirit>()) {
 				projectile.Kill();
 			}
 			if (timer < 120) {

--- a/ExampleMod/Projectiles/PuritySpirit/PuritySnake.cs
+++ b/ExampleMod/Projectiles/PuritySpirit/PuritySnake.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles.PuritySpirit
 {
@@ -32,7 +31,7 @@ namespace ExampleMod.Projectiles.PuritySpirit
 
 		public override void AI() {
 			NPC source = Main.npc[(int)projectile.ai[0]];
-			if (!source.active || source.type != NPCType<NPCs.PuritySpirit.PuritySpirit>()) {
+			if (!source.active || source.type != ModContent.NPCType<NPCs.PuritySpirit.PuritySpirit>()) {
 				projectile.Kill();
 				return;
 			}
@@ -95,7 +94,7 @@ namespace ExampleMod.Projectiles.PuritySpirit
 
 		public void CreateDust(Vector2 pos) {
 			if (Main.rand.NextBool(5)) {
-				int dust = Dust.NewDust(pos, projectile.width, projectile.height, DustType<Smoke>(), 0f, 0f, 0, new Color(0, 180, 0));
+				int dust = Dust.NewDust(pos, projectile.width, projectile.height, ModContent.DustType<Smoke>(), 0f, 0f, 0, new Color(0, 180, 0));
 				Main.dust[dust].scale = 2f;
 				Main.dust[dust].velocity *= 0.5f;
 				Main.dust[dust].noLight = true;

--- a/ExampleMod/Projectiles/ShadowArm.cs
+++ b/ExampleMod/Projectiles/ShadowArm.cs
@@ -5,7 +5,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -130,7 +129,7 @@ namespace ExampleMod.Projectiles
 
 		public void CreateDust(Vector2 pos) {
 			if (Main.rand.NextBool(5)) {
-				int dust = Dust.NewDust(pos, 16, 16, DustType<Smoke>(), 0f, 0f, 0, Color.Black);
+				int dust = Dust.NewDust(pos, 16, 16, ModContent.DustType<Smoke>(), 0f, 0f, 0, Color.Black);
 				Main.dust[dust].scale = 2f;
 				Main.dust[dust].velocity *= 0.5f;
 			}

--- a/ExampleMod/Projectiles/SparklingBall.cs
+++ b/ExampleMod/Projectiles/SparklingBall.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -21,7 +20,7 @@ namespace ExampleMod.Projectiles
 		public override void AI() {
 			projectile.velocity.Y += projectile.ai[0];
 			if (Main.rand.NextBool(3)) {
-				Dust.NewDust(projectile.position + projectile.velocity, projectile.width, projectile.height, DustType<Sparkle>(), projectile.velocity.X * 0.5f, projectile.velocity.Y * 0.5f);
+				Dust.NewDust(projectile.position + projectile.velocity, projectile.width, projectile.height, ModContent.DustType<Sparkle>(), projectile.velocity.X * 0.5f, projectile.velocity.Y * 0.5f);
 			}
 		}
 
@@ -46,7 +45,7 @@ namespace ExampleMod.Projectiles
 
 		public override void Kill(int timeLeft) {
 			for (int k = 0; k < 5; k++) {
-				Dust.NewDust(projectile.position + projectile.velocity, projectile.width, projectile.height, DustType<Sparkle>(), projectile.oldVelocity.X * 0.5f, projectile.oldVelocity.Y * 0.5f);
+				Dust.NewDust(projectile.position + projectile.velocity, projectile.width, projectile.height, ModContent.DustType<Sparkle>(), projectile.oldVelocity.X * 0.5f, projectile.oldVelocity.Y * 0.5f);
 			}
 			Main.PlaySound(SoundID.Item25, projectile.position);
 		}

--- a/ExampleMod/Projectiles/Wisp.cs
+++ b/ExampleMod/Projectiles/Wisp.cs
@@ -4,7 +4,6 @@ using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Projectiles
 {
@@ -56,7 +55,7 @@ namespace ExampleMod.Projectiles
 				AdjustMagnitude(ref projectile.velocity);
 			}
 			if (projectile.alpha <= 100) {
-				int dust = Dust.NewDust(projectile.position, projectile.width, projectile.height, DustType<SpectreDust>());
+				int dust = Dust.NewDust(projectile.position, projectile.width, projectile.height, ModContent.DustType<SpectreDust>());
 				Main.dust[dust].velocity /= 2f;
 			}
 		}
@@ -70,7 +69,7 @@ namespace ExampleMod.Projectiles
 
 		public override void OnHitNPC(NPC target, int damage, float knockback, bool crit) {
 			if (Main.rand.NextBool()) {
-				target.AddBuff(BuffType<Buffs.EtherealFlames>(), 300);
+				target.AddBuff(ModContent.BuffType<Buffs.EtherealFlames>(), 300);
 			}
 		}
 	}

--- a/ExampleMod/RecipeHelper.cs
+++ b/ExampleMod/RecipeHelper.cs
@@ -1,7 +1,6 @@
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod
 {
@@ -56,8 +55,8 @@ namespace ExampleMod
 			// Useful for those who program in an IDE who wish to avoid spelling mistakes.
 			// What's also neat is that the references to classes can be automatically included in refactors, string literals cannot. (unless you have ReSharper)
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(ItemType<Items.BossItem>(), 10); // Items is our namespace (ExampleMod.Items), BossItem our class
-			recipe.AddTile(TileType<Tiles.ExampleWorkbench>()); // Tiles is our namespace (ExampleMod.Tiles), ExampleWorkbench our class
+			recipe.AddIngredient(ModContent.ItemType<Items.BossItem>(), 10); // Items is our namespace (ExampleMod.Items), BossItem our class
+			recipe.AddTile(ModContent.TileType<Tiles.ExampleWorkbench>()); // Tiles is our namespace (ExampleMod.Tiles), ExampleWorkbench our class
 			recipe.SetResult(ItemID.LihzahrdPowerCell, 20);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Tiles/BossTrophy.cs
+++ b/ExampleMod/Tiles/BossTrophy.cs
@@ -4,7 +4,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -29,16 +28,16 @@ namespace ExampleMod.Tiles
 			int item = 0;
 			switch (frameX / 54) {
 				case 0:
-					item = ItemType<AbominationTrophy>();
+					item = ModContent.ItemType<AbominationTrophy>();
 					break;
 				case 1:
-					item = ItemType<PuritySpiritTrophy>();
+					item = ModContent.ItemType<PuritySpiritTrophy>();
 					break;
 				case 2:
-					item = ItemType<BunnyTrophy>();
+					item = ModContent.ItemType<BunnyTrophy>();
 					break;
 				case 3:
-					item = ItemType<TreeTrophy>();
+					item = ModContent.ItemType<TreeTrophy>();
 					break;
 			}
 			if (item > 0) {

--- a/ExampleMod/Tiles/ElementalPurge.cs
+++ b/ExampleMod/Tiles/ElementalPurge.cs
@@ -5,7 +5,6 @@ using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -17,7 +16,7 @@ namespace ExampleMod.Tiles
 			TileObjectData.newTile.Height = 3;
 			TileObjectData.newTile.Origin = new Point16(1, 2);
 			TileObjectData.newTile.CoordinateHeights = new[] { 16, 16, 18 };
-			TileObjectData.newTile.HookPostPlaceMyPlayer = new PlacementHook(GetInstance<TEElementalPurge>().Hook_AfterPlacement, -1, 0, false);
+			TileObjectData.newTile.HookPostPlaceMyPlayer = new PlacementHook(ModContent.GetInstance<TEElementalPurge>().Hook_AfterPlacement, -1, 0, false);
 			TileObjectData.addTile(Type);
 			ModTranslation name = CreateMapEntryName();
 			name.SetDefault("Elemental Purge");
@@ -27,8 +26,8 @@ namespace ExampleMod.Tiles
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 32, 48, ItemType<Items.Placeable.ElementalPurge>());
-			GetInstance<TEElementalPurge>().Kill(i, j);
+			Item.NewItem(i * 16, j * 16, 32, 48, ModContent.ItemType<Items.Placeable.ElementalPurge>());
+			ModContent.GetInstance<TEElementalPurge>().Kill(i, j);
 		}
 
 		public override void PostDraw(int i, int j, SpriteBatch spriteBatch) {

--- a/ExampleMod/Tiles/ExampleAnimatedTile.cs
+++ b/ExampleMod/Tiles/ExampleAnimatedTile.cs
@@ -4,7 +4,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -135,7 +134,7 @@ namespace ExampleMod.Tiles
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 16, 32, ItemType<ExampleAnimatedTileItem>());
+			Item.NewItem(i * 16, j * 16, 16, 32, ModContent.ItemType<ExampleAnimatedTileItem>());
 		}
 	}
 
@@ -147,7 +146,7 @@ namespace ExampleMod.Tiles
 
 		public override void SetDefaults() {
 			item.CloneDefaults(ItemID.FireflyinaBottle);
-			item.createTile = TileType<ExampleAnimatedTileTile>();
+			item.createTile = ModContent.TileType<ExampleAnimatedTileTile>();
 		}
 	}
 }

--- a/ExampleMod/Tiles/ExampleBar.cs
+++ b/ExampleMod/Tiles/ExampleBar.cs
@@ -3,7 +3,6 @@ using Terraria;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -30,7 +29,7 @@ namespace ExampleMod.Tiles
 			int style = t.frameX / 18;
 			if (style == 0) // It can be useful to share a single tile with multiple styles. This code will let you drop the appropriate bar if you had multiple.
 			{
-				Item.NewItem(i * 16, j * 16, 16, 16, ItemType<Items.Placeable.ExampleBar>());
+				Item.NewItem(i * 16, j * 16, 16, 16, ModContent.ItemType<Items.Placeable.ExampleBar>());
 			}
 			return base.Drop(i, j);
 		}

--- a/ExampleMod/Tiles/ExampleBed.cs
+++ b/ExampleMod/Tiles/ExampleBed.cs
@@ -4,7 +4,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -20,7 +19,7 @@ namespace ExampleMod.Tiles
 			ModTranslation name = CreateMapEntryName();
 			name.SetDefault("Example Bed");
 			AddMapEntry(new Color(200, 200, 200), name);
-			dustType = DustType<Sparkle>();
+			dustType = ModContent.DustType<Sparkle>();
 			disableSmartCursor = true;
 			adjTiles = new int[] { TileID.Beds };
 			bed = true;
@@ -35,7 +34,7 @@ namespace ExampleMod.Tiles
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 64, 32, ItemType<Items.Placeable.ExampleBed>());
+			Item.NewItem(i * 16, j * 16, 64, 32, ModContent.ItemType<Items.Placeable.ExampleBed>());
 		}
 
 		public override bool NewRightClick(int i, int j) {
@@ -63,7 +62,7 @@ namespace ExampleMod.Tiles
 			Player player = Main.LocalPlayer;
 			player.noThrow = 2;
 			player.showItemIcon = true;
-			player.showItemIcon2 = ItemType<Items.Placeable.ExampleBed>();
+			player.showItemIcon2 = ModContent.ItemType<Items.Placeable.ExampleBed>();
 		}
 	}
 }

--- a/ExampleMod/Tiles/ExampleBlock.cs
+++ b/ExampleMod/Tiles/ExampleBlock.cs
@@ -2,7 +2,6 @@ using ExampleMod.Dusts;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -13,8 +12,8 @@ namespace ExampleMod.Tiles
 			Main.tileMergeDirt[Type] = true;
 			Main.tileBlockLight[Type] = true;
 			Main.tileLighted[Type] = true;
-			dustType = DustType<Sparkle>();
-			drop = ItemType<Items.Placeable.ExampleBlock>();
+			dustType = ModContent.DustType<Sparkle>();
+			drop = ModContent.ItemType<Items.Placeable.ExampleBlock>();
 			AddMapEntry(new Color(200, 200, 200));
 			SetModTree(new Trees.ExampleTree());
 		}
@@ -35,7 +34,7 @@ namespace ExampleMod.Tiles
 
 		public override int SaplingGrowthType(ref int style) {
 			style = 0;
-			return TileType<ExampleSapling>();
+			return ModContent.TileType<ExampleSapling>();
 		}
 	}
 }

--- a/ExampleMod/Tiles/ExampleChair.cs
+++ b/ExampleMod/Tiles/ExampleChair.cs
@@ -5,7 +5,6 @@ using Terraria.Enums;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -29,7 +28,7 @@ namespace ExampleMod.Tiles
 			ModTranslation name = CreateMapEntryName();
 			name.SetDefault("Example Chair");
 			AddMapEntry(new Color(200, 200, 200), name);
-			dustType = DustType<Sparkle>();
+			dustType = ModContent.DustType<Sparkle>();
 			disableSmartCursor = true;
 			adjTiles = new int[] { TileID.Chairs };
 		}
@@ -39,7 +38,7 @@ namespace ExampleMod.Tiles
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 16, 32, ItemType<Items.Placeable.ExampleChair>());
+			Item.NewItem(i * 16, j * 16, 16, 32, ModContent.ItemType<Items.Placeable.ExampleChair>());
 		}
 	}
 }

--- a/ExampleMod/Tiles/ExampleChest.cs
+++ b/ExampleMod/Tiles/ExampleChest.cs
@@ -8,7 +8,6 @@ using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -39,11 +38,11 @@ namespace ExampleMod.Tiles
 			name = CreateMapEntryName(Name + "_Locked"); // With multiple map entries, you need unique translation keys.
 			name.SetDefault("Locked Example Chest");
 			AddMapEntry(new Color(0, 141, 63), name, MapChestName);
-			dustType = DustType<Sparkle>();
+			dustType = ModContent.DustType<Sparkle>();
 			disableSmartCursor = true;
 			adjTiles = new int[] { TileID.Containers };
 			chest = "Example Chest";
-			chestDrop = ItemType<Items.Placeable.ExampleChest>();
+			chestDrop = ModContent.ItemType<Items.Placeable.ExampleChest>();
 		}
 
 		public override ushort GetMapOption(int i, int j) => (ushort)(Main.tile[i, j].frameX / 36);
@@ -131,7 +130,7 @@ namespace ExampleMod.Tiles
 			}
 			else {
 				if (isLocked) {
-					int key = ItemType<Items.ExampleChestKey>();
+					int key = ModContent.ItemType<Items.ExampleChestKey>();
 					if (player.ConsumeItem(key) && Chest.Unlock(left, top)) {
 						if (Main.netMode == NetmodeID.MultiplayerClient) {
 							NetMessage.SendData(MessageID.Unlock, -1, -1, null, player.whoAmI, 1f, (float)left, (float)top);
@@ -180,9 +179,9 @@ namespace ExampleMod.Tiles
 			else {
 				player.showItemIconText = Main.chest[chest].name.Length > 0 ? Main.chest[chest].name : "Example Chest";
 				if (player.showItemIconText == "Example Chest") {
-					player.showItemIcon2 = ItemType<Items.Placeable.ExampleChest>();
+					player.showItemIcon2 = ModContent.ItemType<Items.Placeable.ExampleChest>();
 					if (Main.tile[left, top].frameX / 36 == 1)
-						player.showItemIcon2 = ItemType<Items.ExampleChestKey>();
+						player.showItemIcon2 = ModContent.ItemType<Items.ExampleChestKey>();
 					player.showItemIconText = "";
 				}
 			}

--- a/ExampleMod/Tiles/ExampleClock.cs
+++ b/ExampleMod/Tiles/ExampleClock.cs
@@ -4,7 +4,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -28,7 +27,7 @@ namespace ExampleMod.Tiles
 			ModTranslation name = CreateMapEntryName();
 			// name.SetDefault("Example Clock"); // Automatic from .lang files
 			AddMapEntry(new Color(200, 200, 200), name);
-			dustType = DustType<Pixel>();
+			dustType = ModContent.DustType<Pixel>();
 			adjTiles = new int[] { TileID.GrandfatherClocks };
 		}
 
@@ -87,7 +86,7 @@ namespace ExampleMod.Tiles
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 48, 32, ItemType<Items.Placeable.ExampleClock>());
+			Item.NewItem(i * 16, j * 16, 48, 32, ModContent.ItemType<Items.Placeable.ExampleClock>());
 		}
 	}
 }

--- a/ExampleMod/Tiles/ExampleCritterCage.cs
+++ b/ExampleMod/Tiles/ExampleCritterCage.cs
@@ -3,7 +3,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -26,7 +25,7 @@ namespace ExampleMod.Tiles
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 48, 32, ItemType<ExampleCritterCageItem>());
+			Item.NewItem(i * 16, j * 16, 48, 32, ModContent.ItemType<ExampleCritterCageItem>());
 		}
 
 		public override void AnimateIndividualTile(int type, int i, int j, ref int frameXOffset, ref int frameYOffset) {
@@ -61,13 +60,13 @@ namespace ExampleMod.Tiles
 			//item.height = 12;
 
 			item.CloneDefaults(ItemID.GlowingSnailCage);
-			item.createTile = TileType<ExampleCritterCage>();
+			item.createTile = ModContent.TileType<ExampleCritterCage>();
 		}
 
 		public override void AddRecipes() {
 			ModRecipe recipe = new ModRecipe(mod);
 			recipe.AddIngredient(ItemID.Terrarium);
-			recipe.AddIngredient(ItemType<NPCs.ExampleCritterItem>());
+			recipe.AddIngredient(ModContent.ItemType<NPCs.ExampleCritterItem>());
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 		}

--- a/ExampleMod/Tiles/ExampleCutTile.cs
+++ b/ExampleMod/Tiles/ExampleCutTile.cs
@@ -4,7 +4,6 @@ using Terraria.Enums;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -51,7 +50,7 @@ namespace ExampleMod.Tiles
 
 		public override void SetDefaults() {
 			item.CloneDefaults(ItemID.DartTrap);
-			item.createTile = TileType<ExampleCutTileTile>();
+			item.createTile = ModContent.TileType<ExampleCutTileTile>();
 			item.value = 1000;
 		}
 

--- a/ExampleMod/Tiles/ExampleDoorClosed.cs
+++ b/ExampleMod/Tiles/ExampleDoorClosed.cs
@@ -7,7 +7,6 @@ using Terraria.Enums;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -44,10 +43,10 @@ namespace ExampleMod.Tiles
 			ModTranslation name = CreateMapEntryName();
 			name.SetDefault("Example Door");
 			AddMapEntry(new Color(200, 200, 200), name);
-			dustType = DustType<Sparkle>();
+			dustType = ModContent.DustType<Sparkle>();
 			disableSmartCursor = true;
 			adjTiles = new int[] { TileID.ClosedDoor };
-			openDoorID = TileType<ExampleDoorOpen>();
+			openDoorID = ModContent.TileType<ExampleDoorOpen>();
 		}
 
 		public override bool HasSmartInteract() {
@@ -59,14 +58,14 @@ namespace ExampleMod.Tiles
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 16, 48, ItemType<ExampleDoor>());
+			Item.NewItem(i * 16, j * 16, 16, 48, ModContent.ItemType<ExampleDoor>());
 		}
 
 		public override void MouseOver(int i, int j) {
 			Player player = Main.LocalPlayer;
 			player.noThrow = 2;
 			player.showItemIcon = true;
-			player.showItemIcon2 = ItemType<ExampleDoor>();
+			player.showItemIcon2 = ModContent.ItemType<ExampleDoor>();
 		}
 	}
 }

--- a/ExampleMod/Tiles/ExampleDoorOpen.cs
+++ b/ExampleMod/Tiles/ExampleDoorOpen.cs
@@ -7,7 +7,6 @@ using Terraria.Enums;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -63,10 +62,10 @@ namespace ExampleMod.Tiles
 			ModTranslation name = CreateMapEntryName();
 			name.SetDefault("Example Door");
 			AddMapEntry(new Color(200, 200, 200), name);
-			dustType = DustType<Sparkle>();
+			dustType = ModContent.DustType<Sparkle>();
 			disableSmartCursor = true;
 			adjTiles = new int[] { TileID.OpenDoor };
-			closeDoorID = TileType<ExampleDoorClosed>();
+			closeDoorID = ModContent.TileType<ExampleDoorClosed>();
 		}
 
 		public override bool HasSmartInteract() {
@@ -78,14 +77,14 @@ namespace ExampleMod.Tiles
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 32, 48, ItemType<ExampleDoor>());
+			Item.NewItem(i * 16, j * 16, 32, 48, ModContent.ItemType<ExampleDoor>());
 		}
 
 		public override void MouseOver(int i, int j) {
 			Player player = Main.LocalPlayer;
 			player.noThrow = 2;
 			player.showItemIcon = true;
-			player.showItemIcon2 = ItemType<ExampleDoor>();
+			player.showItemIcon2 = ModContent.ItemType<ExampleDoor>();
 		}
 	}
 }

--- a/ExampleMod/Tiles/ExampleDresser.cs
+++ b/ExampleMod/Tiles/ExampleDresser.cs
@@ -8,7 +8,6 @@ using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -36,11 +35,11 @@ namespace ExampleMod.Tiles
 			ModTranslation name = CreateMapEntryName();
 			name.SetDefault("Example Dresser");
 			AddMapEntry(new Color(200, 200, 200), name);
-			dustType = DustType<Sparkle>();
+			dustType = ModContent.DustType<Sparkle>();
 			disableSmartCursor = true;
 			adjTiles = new int[] { TileID.Dressers };
 			dresser = "Example Dresser";
-			dresserDrop = ItemType<Items.Placeable.ExampleDresser>();
+			dresserDrop = ModContent.ItemType<Items.Placeable.ExampleDresser>();
 		}
 
 		public override bool HasSmartInteract() {
@@ -145,7 +144,7 @@ namespace ExampleMod.Tiles
 					player.showItemIconText = chest;
 				}
 				if (player.showItemIconText == chest) {
-					player.showItemIcon2 = ItemType<Items.Placeable.ExampleDresser>();
+					player.showItemIcon2 = ModContent.ItemType<Items.Placeable.ExampleDresser>();
 					player.showItemIconText = "";
 				}
 			}
@@ -179,7 +178,7 @@ namespace ExampleMod.Tiles
 					player.showItemIconText = chest;
 				}
 				if (player.showItemIconText == chest) {
-					player.showItemIcon2 = ItemType<Items.Placeable.ExampleDresser>();
+					player.showItemIcon2 = ModContent.ItemType<Items.Placeable.ExampleDresser>();
 					player.showItemIconText = "";
 				}
 			}

--- a/ExampleMod/Tiles/ExampleHerb.cs
+++ b/ExampleMod/Tiles/ExampleHerb.cs
@@ -5,7 +5,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -35,7 +34,7 @@ namespace ExampleMod.Tiles
 			{
 				TileID.Grass,
 				TileID.HallowedGrass,
-				TileType<ExampleBlock>()
+				ModContent.TileType<ExampleBlock>()
 			};
 
 			TileObjectData.newTile.AnchorAlternateTiles = new int[]
@@ -59,7 +58,7 @@ namespace ExampleMod.Tiles
 
 			//Only drop items if the herb is grown
 			if (stage == PlantStage.Grown)
-				Item.NewItem(new Vector2(i, j).ToWorldCoordinates(), ItemType<ExampleHerbSeeds>());
+				Item.NewItem(new Vector2(i, j).ToWorldCoordinates(), ModContent.ItemType<ExampleHerbSeeds>());
 
 			return false;
 		}

--- a/ExampleMod/Tiles/ExampleLamp.cs
+++ b/ExampleMod/Tiles/ExampleLamp.cs
@@ -6,7 +6,6 @@ using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -32,7 +31,7 @@ namespace ExampleMod.Tiles
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 16, 48, ItemType<Items.Placeable.ExampleLamp>());
+			Item.NewItem(i * 16, j * 16, 16, 48, ModContent.ItemType<Items.Placeable.ExampleLamp>());
 		}
 
 		public override void HitWire(int i, int j) {

--- a/ExampleMod/Tiles/ExampleMusicBox.cs
+++ b/ExampleMod/Tiles/ExampleMusicBox.cs
@@ -3,7 +3,6 @@ using Terraria;
 using Terraria.DataStructures;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -24,14 +23,14 @@ namespace ExampleMod.Tiles
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 16, 48, ItemType<Items.Placeable.ExampleMusicBox>());
+			Item.NewItem(i * 16, j * 16, 16, 48, ModContent.ItemType<Items.Placeable.ExampleMusicBox>());
 		}
 
 		public override void MouseOver(int i, int j) {
 			Player player = Main.LocalPlayer;
 			player.noThrow = 2;
 			player.showItemIcon = true;
-			player.showItemIcon2 = ItemType<Items.Placeable.ExampleMusicBox>();
+			player.showItemIcon2 = ModContent.ItemType<Items.Placeable.ExampleMusicBox>();
 		}
 	}
 }

--- a/ExampleMod/Tiles/ExampleOre.cs
+++ b/ExampleMod/Tiles/ExampleOre.cs
@@ -2,7 +2,6 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -24,7 +23,7 @@ namespace ExampleMod.Tiles
 			AddMapEntry(new Color(152, 171, 198), name);
 
 			dustType = 84;
-			drop = ItemType<Items.Placeable.ExampleOre>();
+			drop = ModContent.ItemType<Items.Placeable.ExampleOre>();
 			soundType = SoundID.Tink;
 			soundStyle = 1;
 			//mineResist = 4f;

--- a/ExampleMod/Tiles/ExamplePlatform.cs
+++ b/ExampleMod/Tiles/ExamplePlatform.cs
@@ -4,7 +4,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -30,8 +29,8 @@ namespace ExampleMod.Tiles
 			TileObjectData.addTile(Type);
 			AddToArray(ref TileID.Sets.RoomNeeds.CountsAsDoor);
 			AddMapEntry(new Color(200, 200, 200));
-			dustType = DustType<Sparkle>();
-			drop = ItemType<Items.Placeable.ExamplePlatform>();
+			dustType = ModContent.DustType<Sparkle>();
+			drop = ModContent.ItemType<Items.Placeable.ExamplePlatform>();
 			disableSmartCursor = true;
 			adjTiles = new int[] { TileID.Platforms };
 		}

--- a/ExampleMod/Tiles/ExampleSapling.cs
+++ b/ExampleMod/Tiles/ExampleSapling.cs
@@ -7,7 +7,6 @@ using Terraria.Enums;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -26,7 +25,7 @@ namespace ExampleMod.Tiles
 			TileObjectData.newTile.CoordinateHeights = new[] { 16, 18 };
 			TileObjectData.newTile.CoordinateWidth = 16;
 			TileObjectData.newTile.CoordinatePadding = 2;
-			TileObjectData.newTile.AnchorValidTiles = new[] { TileType<ExampleBlock>() };
+			TileObjectData.newTile.AnchorValidTiles = new[] { ModContent.TileType<ExampleBlock>() };
 			TileObjectData.newTile.StyleHorizontal = true;
 			TileObjectData.newTile.DrawFlipHorizontal = true;
 			TileObjectData.newTile.WaterPlacement = LiquidPlacement.NotAllowed;
@@ -34,7 +33,7 @@ namespace ExampleMod.Tiles
 			TileObjectData.newTile.RandomStyleRange = 3;
 			TileObjectData.newTile.StyleMultiplier = 3;
 			TileObjectData.newSubTile.CopyFrom(TileObjectData.newTile);
-			TileObjectData.newSubTile.AnchorValidTiles = new int[] { TileType<ExampleSand>() };
+			TileObjectData.newSubTile.AnchorValidTiles = new int[] { ModContent.TileType<ExampleSand>() };
 			TileObjectData.addSubTile(1);
 			TileObjectData.addTile(Type);
 
@@ -43,7 +42,7 @@ namespace ExampleMod.Tiles
 			AddMapEntry(new Color(200, 200, 200), name);
 
 			sapling = true;
-			dustType = DustType<Sparkle>();
+			dustType = ModContent.DustType<Sparkle>();
 			adjTiles = new int[] { TileID.Saplings };
 		}
 

--- a/ExampleMod/Tiles/ExampleStatue.cs
+++ b/ExampleMod/Tiles/ExampleStatue.cs
@@ -9,7 +9,6 @@ using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
 using Terraria.World.Generation;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -29,7 +28,7 @@ namespace ExampleMod.Tiles
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 32, 48, ItemType<ExampleStatueItem>());
+			Item.NewItem(i * 16, j * 16, 32, 48, ModContent.ItemType<ExampleStatueItem>());
 		}
 
 		public override void HitWire(int i, int j) {
@@ -89,7 +88,7 @@ namespace ExampleMod.Tiles
 
 		public override void SetDefaults() {
 			item.CloneDefaults(ItemID.ArmorStatue);
-			item.createTile = TileType<ExampleStatue>();
+			item.createTile = ModContent.TileType<ExampleStatue>();
 			item.placeStyle = 0;
 		}
 	}
@@ -103,13 +102,13 @@ namespace ExampleMod.Tiles
 					progress.Message = "Adding ExampleMod Statue";
 
 					// Not necessary, just a precaution.
-					if (WorldGen.statueList.Any(point => point.X == TileType<ExampleStatue>())) {
+					if (WorldGen.statueList.Any(point => point.X == ModContent.TileType<ExampleStatue>())) {
 						return;
 					}
 					// Make space in the statueList array, and then add a Point16 of (TileID, PlaceStyle)
 					Array.Resize(ref WorldGen.statueList, WorldGen.statueList.Length + 1);
 					for (int i = WorldGen.statueList.Length - 1; i < WorldGen.statueList.Length; i++) {
-						WorldGen.statueList[i] = new Point16(TileType<ExampleStatue>(), 0);
+						WorldGen.statueList[i] = new Point16(ModContent.TileType<ExampleStatue>(), 0);
 						// Do this if you want the statue to spawn with wire and pressure plate
 						// WorldGen.StatuesWithTraps.Add(i);
 					}

--- a/ExampleMod/Tiles/ExampleTorch.cs
+++ b/ExampleMod/Tiles/ExampleTorch.cs
@@ -7,7 +7,6 @@ using Terraria.Enums;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -39,8 +38,8 @@ namespace ExampleMod.Tiles
 			ModTranslation name = CreateMapEntryName();
 			name.SetDefault("Torch");
 			AddMapEntry(new Color(200, 200, 200), name);
-			dustType = DustType<Sparkle>();
-			drop = ItemType<Items.Placeable.ExampleTorch>();
+			dustType = ModContent.DustType<Sparkle>();
+			drop = ModContent.ItemType<Items.Placeable.ExampleTorch>();
 			disableSmartCursor = true;
 			adjTiles = new int[] { TileID.Torches };
 			torch = true;

--- a/ExampleMod/Tiles/ExampleTrap.cs
+++ b/ExampleMod/Tiles/ExampleTrap.cs
@@ -3,7 +3,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {

--- a/ExampleMod/Tiles/ExampleWorkbench.cs
+++ b/ExampleMod/Tiles/ExampleWorkbench.cs
@@ -4,7 +4,6 @@ using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -23,7 +22,7 @@ namespace ExampleMod.Tiles
 			ModTranslation name = CreateMapEntryName();
 			name.SetDefault("Example Workbench");
 			AddMapEntry(new Color(200, 200, 200), name);
-			dustType = DustType<Sparkle>();
+			dustType = ModContent.DustType<Sparkle>();
 			disableSmartCursor = true;
 			adjTiles = new int[] { TileID.WorkBenches };
 		}
@@ -33,7 +32,7 @@ namespace ExampleMod.Tiles
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 32, 16, ItemType<Items.Placeable.ExampleWorkbench>());
+			Item.NewItem(i * 16, j * 16, 32, 16, ModContent.ItemType<Items.Placeable.ExampleWorkbench>());
 		}
 	}
 }

--- a/ExampleMod/Tiles/Minesweeper.cs
+++ b/ExampleMod/Tiles/Minesweeper.cs
@@ -2,7 +2,6 @@
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -16,7 +15,7 @@ namespace ExampleMod.Tiles
 			// This tile is special because we need it to preserve the hidden mine tiles.
 			Main.tileFrameImportant[Type] = true; 
 			Main.tileSolid[Type] = true; // TODO: tModLoader hook for allowing non solid tiles to be hammer-able.
-			drop = ItemType<MinesweeperItem>();
+			drop = ModContent.ItemType<MinesweeperItem>();
 		}
 
 		public override bool Dangersense(int i, int j, Player player) => IsMine(i, j);
@@ -139,7 +138,7 @@ namespace ExampleMod.Tiles
 		public override void SetDefaults()
 		{
 			item.CloneDefaults(ItemID.DirtBlock);
-			item.createTile = TileType<Minesweeper>();
+			item.createTile = ModContent.TileType<Minesweeper>();
 		}
 	}
 }

--- a/ExampleMod/Tiles/MonsterBanner.cs
+++ b/ExampleMod/Tiles/MonsterBanner.cs
@@ -5,7 +5,6 @@ using Terraria.DataStructures;
 using Terraria.Enums;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {

--- a/ExampleMod/Tiles/TEElementalPurge.cs
+++ b/ExampleMod/Tiles/TEElementalPurge.cs
@@ -1,6 +1,5 @@
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 using Terraria.ID;
 
 namespace ExampleMod.Tiles
@@ -17,7 +16,7 @@ namespace ExampleMod.Tiles
 
 		public override bool ValidTile(int i, int j) {
 			Tile tile = Main.tile[i, j];
-			return tile.active() && tile.type == TileType<ElementalPurge>() && tile.frameX == 0 && tile.frameY == 0;
+			return tile.active() && tile.type == ModContent.TileType<ElementalPurge>() && tile.frameX == 0 && tile.frameY == 0;
 		}
 
 		public override int Hook_AfterPlacement(int i, int j, int type, int style, int direction) {

--- a/ExampleMod/Tiles/TEScoreBoard.cs
+++ b/ExampleMod/Tiles/TEScoreBoard.cs
@@ -11,7 +11,6 @@ using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -22,7 +21,7 @@ namespace ExampleMod.Tiles
 				//Main.NewText("Accidental Death, score unchanged");
 				return;
 			}
-			int TEScoreBoardType = TileEntityType<TEScoreBoard>();
+			int TEScoreBoardType = ModContent.TileEntityType<TEScoreBoard>();
 			foreach (TileEntity current in TileEntity.ByID.Values) {
 				if (current.type == TEScoreBoardType) {
 					//QuickBox is a neat tool for visualizing things while modding.
@@ -33,7 +32,7 @@ namespace ExampleMod.Tiles
 						int score = 0;
 						// Using HalfVector2 and ReinterpretCast.UIntAsFloat is a way to pack a Vector2 into a single float variable.
 						HalfVector2 halfVector = new HalfVector2((current.Position.X + 1) * 16, (current.Position.Y + 1) * 16);
-						Projectile.NewProjectile(npc.Center, Vector2.Zero, ProjectileType<Projectiles.ScorePoint>(), 0, 0, Main.myPlayer, ReLogic.Utilities.ReinterpretCast.UIntAsFloat(halfVector.PackedValue), npc.lastInteraction);
+						Projectile.NewProjectile(npc.Center, Vector2.Zero, ModContent.ProjectileType<Projectiles.ScorePoint>(), 0, 0, Main.myPlayer, ReLogic.Utilities.ReinterpretCast.UIntAsFloat(halfVector.PackedValue), npc.lastInteraction);
 						scoreboard.scores.TryGetValue(scoringPlayer.name, out score);
 						scoreboard.scores[scoringPlayer.name] = score + 1;
 						if (Main.dedServ) {
@@ -109,7 +108,7 @@ namespace ExampleMod.Tiles
 
 		public override bool ValidTile(int i, int j) {
 			Tile tile = Main.tile[i, j];
-			return tile.active() && tile.type == TileType<ScoreBoard>() && tile.frameX == 0 && tile.frameY == 0;
+			return tile.active() && tile.type == ModContent.TileType<ScoreBoard>() && tile.frameX == 0 && tile.frameY == 0;
 		}
 
 		public override int Hook_AfterPlacement(int i, int j, int type, int style, int direction) {
@@ -133,7 +132,7 @@ namespace ExampleMod.Tiles
 
 			TileObjectData.newTile.CopyFrom(TileObjectData.Style2x2);
 			// We set processedCoordinates to true so our Hook_AfterPlacement gets top left coordinates, regardless of Origin.
-			TileObjectData.newTile.HookPostPlaceMyPlayer = new PlacementHook(GetInstance<TEScoreBoard>().Hook_AfterPlacement, -1, 0, true);
+			TileObjectData.newTile.HookPostPlaceMyPlayer = new PlacementHook(ModContent.GetInstance<TEScoreBoard>().Hook_AfterPlacement, -1, 0, true);
 			TileObjectData.newTile.StyleHorizontal = true;
 			TileObjectData.newTile.StyleMultiplier = 5;
 			TileObjectData.newAlternate.CopyFrom(TileObjectData.newTile);
@@ -168,8 +167,8 @@ namespace ExampleMod.Tiles
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 32, 48, ItemType<Items.Placeable.ScoreBoard>());
-			GetInstance<TEScoreBoard>().Kill(i, j);
+			Item.NewItem(i * 16, j * 16, 32, 48, ModContent.ItemType<Items.Placeable.ScoreBoard>());
+			ModContent.GetInstance<TEScoreBoard>().Kill(i, j);
 		}
 
 		public override bool NewRightClick(int i, int j) {
@@ -177,7 +176,7 @@ namespace ExampleMod.Tiles
 			int left = i - tile.frameX % 36 / 18;
 			int top = j - tile.frameY / 18;
 
-			int index = GetInstance<TEScoreBoard>().Find(left, top);
+			int index = ModContent.GetInstance<TEScoreBoard>().Find(left, top);
 			if (index == -1) {
 				return false;
 			}

--- a/ExampleMod/Tiles/Trees/ExampleTree.cs
+++ b/ExampleMod/Tiles/Trees/ExampleTree.cs
@@ -1,7 +1,6 @@
 using ExampleMod.Dusts;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles.Trees
 {
@@ -10,7 +9,7 @@ namespace ExampleMod.Tiles.Trees
 		private Mod mod => ModLoader.GetMod("ExampleMod");
 
 		public override int CreateDust() {
-			return DustType<Sparkle>();
+			return ModContent.DustType<Sparkle>();
 		}
 
 		public override int GrowthFXGore() {
@@ -18,7 +17,7 @@ namespace ExampleMod.Tiles.Trees
 		}
 
 		public override int DropWood() {
-			return ItemType<Items.Placeable.ExampleBlock>();
+			return ModContent.ItemType<Items.Placeable.ExampleBlock>();
 		}
 
 		public override Texture2D GetTexture() {

--- a/ExampleMod/Tiles/VoidMonolith.cs
+++ b/ExampleMod/Tiles/VoidMonolith.cs
@@ -5,7 +5,6 @@ using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Tiles
 {
@@ -26,7 +25,7 @@ namespace ExampleMod.Tiles
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 32, 48, ItemType<Items.Placeable.VoidMonolith>());
+			Item.NewItem(i * 16, j * 16, 32, 48, ModContent.ItemType<Items.Placeable.VoidMonolith>());
 		}
 
 		public override void NearbyEffects(int i, int j, bool closer) {
@@ -74,7 +73,7 @@ namespace ExampleMod.Tiles
 			Player player = Main.LocalPlayer;
 			player.noThrow = 2;
 			player.showItemIcon = true;
-			player.showItemIcon2 = ItemType<Items.Placeable.VoidMonolith>();
+			player.showItemIcon2 = ModContent.ItemType<Items.Placeable.VoidMonolith>();
 		}
 
 		public override void HitWire(int i, int j) {

--- a/ExampleMod/UI/ExamplePersonUI.cs
+++ b/ExampleMod/UI/ExamplePersonUI.cs
@@ -8,7 +8,6 @@ using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.UI;
 using Terraria.UI.Chat;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.UI
 {
@@ -47,9 +46,9 @@ namespace ExampleMod.UI
 			base.Update(gameTime);
 
 			// talkNPC is the index of the NPC the player is currently talking to. By checking talkNPC, we can tell when the player switches to another NPC or closes the NPC chat dialog.
-			if (Main.LocalPlayer.talkNPC == -1 || Main.npc[Main.LocalPlayer.talkNPC].type != NPCType<ExamplePerson>()) {
+			if (Main.LocalPlayer.talkNPC == -1 || Main.npc[Main.LocalPlayer.talkNPC].type != ModContent.NPCType<ExamplePerson>()) {
 				// When that happens, we can set the state of our UserInterface to null, thereby closing this UIState. This will trigger OnDeactivate above.
-				GetInstance<ExampleMod>().ExamplePersonUserInterface.SetState(null);
+				ModContent.GetInstance<ExampleMod>().ExamplePersonUserInterface.SetState(null);
 			}
 		}
 
@@ -109,10 +108,10 @@ namespace ExampleMod.UI
 						reforgeItem = reforgeItem.CloneWithModdedDataFrom(_vanillaItemSlot.Item);
 						// This is the main effect of this slot. Giving the Awesome prefix 90% of the time and the ReallyAwesome prefix the other 10% of the time. All for a constant 1 gold. Useless, but informative.
 						if (Main.rand.NextBool(10)) {
-							reforgeItem.Prefix(GetInstance<ExampleMod>().PrefixType("ReallyAwesome"));
+							reforgeItem.Prefix(ModContent.GetInstance<ExampleMod>().PrefixType("ReallyAwesome"));
 						}
 						else {
-							reforgeItem.Prefix(GetInstance<ExampleMod>().PrefixType("Awesome"));
+							reforgeItem.Prefix(ModContent.GetInstance<ExampleMod>().PrefixType("Awesome"));
 						}
 						_vanillaItemSlot.Item = reforgeItem.Clone();
 						_vanillaItemSlot.Item.position.X = Main.LocalPlayer.position.X + (float)(Main.LocalPlayer.width / 2) - (float)(_vanillaItemSlot.Item.width / 2);

--- a/ExampleMod/UI/ExampleResourceBar.cs
+++ b/ExampleMod/UI/ExampleResourceBar.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.GameContent.UI.Elements;
 using Terraria.UI;
+using Terraria.ModLoader;
 
 namespace ExampleMod.UI
 {

--- a/ExampleMod/UI/ExampleResourceBar.cs
+++ b/ExampleMod/UI/ExampleResourceBar.cs
@@ -4,7 +4,6 @@ using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.GameContent.UI.Elements;
 using Terraria.UI;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.UI
 {
@@ -27,7 +26,7 @@ namespace ExampleMod.UI
 			area.Width.Set(182, 0f); // We will be placing the following 2 UIElements within this 182x60 area.
 			area.Height.Set(60, 0f);
 
-			barFrame = new UIImage(GetTexture("ExampleMod/UI/ExampleResourceFrame"));
+			barFrame = new UIImage(ModContent.GetTexture("ExampleMod/UI/ExampleResourceFrame"));
 			barFrame.Left.Set(22, 0f);
 			barFrame.Top.Set(0, 0f);
 			barFrame.Width.Set(138, 0f);

--- a/ExampleMod/UI/ExampleUI.cs
+++ b/ExampleMod/UI/ExampleUI.cs
@@ -7,7 +7,6 @@ using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.UI;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.UI
 {
@@ -188,7 +187,7 @@ namespace ExampleMod.UI
 	{
 		public override bool OnPickup(Item item, Player player) {
 			if (item.type >= ItemID.CopperCoin && item.type <= ItemID.PlatinumCoin)
-				GetInstance<ExampleMod>().ExampleUI.UpdateValue(item.stack * (item.value / 5));
+				ModContent.GetInstance<ExampleMod>().ExampleUI.UpdateValue(item.stack * (item.value / 5));
 
 			return base.OnPickup(item, player);
 		}

--- a/ExampleMod/Walls/ExampleWall.cs
+++ b/ExampleMod/Walls/ExampleWall.cs
@@ -2,7 +2,6 @@ using ExampleMod.Dusts;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Walls
 {
@@ -10,8 +9,8 @@ namespace ExampleMod.Walls
 	{
 		public override void SetDefaults() {
 			Main.wallHouse[Type] = true;
-			dustType = DustType<Sparkle>();
-			drop = ItemType<Items.Placeable.ExampleWall>();
+			dustType = ModContent.DustType<Sparkle>();
+			drop = ModContent.ItemType<Items.Placeable.ExampleWall>();
 			AddMapEntry(new Color(150, 150, 150));
 		}
 

--- a/ExampleMod/Waters/ExampleWaterStyle.cs
+++ b/ExampleMod/Waters/ExampleWaterStyle.cs
@@ -2,7 +2,6 @@ using ExampleMod.Dusts;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
-using static Terraria.ModLoader.ModContent;
 
 namespace ExampleMod.Waters
 {
@@ -15,7 +14,7 @@ namespace ExampleMod.Waters
 			=> mod.GetWaterfallStyleSlot("ExampleWaterfallStyle");
 
 		public override int GetSplashDust() 
-			=> DustType<ExampleWaterSplash>();
+			=> ModContent.DustType<ExampleWaterSplash>();
 
 		public override int GetDropletGore() 
 			=> mod.GetGoreSlot("Gores/ExampleDroplet");


### PR DESCRIPTION
### What are the changes to ExampleMod?
Removed `using static` from ExampleMod code, so that people don't get confused when `ItemType<>()` isn't working.
### Do these changes need additional documentation?
No

Extra: This is the 1.3 change, the 1.4 change is here: #1122 
