### PR TITLE
Fixed a long-standing use sound desync issue

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3113,7 +3113,7 @@
  			if (Main.dedServ)
  				return;
  
-@@ -35342,8 +_,14 @@
+@@ -35342,8 +_,13 @@
  			attackCD = 0;
  			ApplyItemAnimation(sItem);
  			bool flag2 = ItemID.Sets.SkipsInitialUseSound[sItem.type];
@@ -3123,7 +3123,6 @@
 +				// If the projectile shoots no projectiles or is a broadsword or pre-JE shortsword, play the sound here.
 +				if (sItem.shoot == ProjectileID.None)
 +					SoundEngine.PlaySound(sItem.UseSound, base.Center);
-+
 +				else if ((sItem.useStyle == 1 || sItem.useStyle == 3) && !sItem.noMelee && !sItem.noUseGraphic)
 +					SoundEngine.PlaySound(sItem.UseSound, base.Center);
 +			}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3069,11 +3069,13 @@
  					int num178 = Projectile.NewProjectile(pointPoisition.X, pointPoisition.Y, num2, num3, projToShoot, Damage, KnockBack, i);
  					if (sItem.type == 726)
  						Main.projectile[num178].magic = true;
-@@ -33910,6 +_,9 @@
+@@ -33910,6 +_,11 @@
  					if (Main.projectile[num178].aiStyle == 160 && Main.IsItAHappyWindyDay)
  						AchievementsHelper.HandleSpecialEvent(this, 17);
  				}
 +
++				// If the item is not a broadsword or pre-JE shortsword, play the sound.
++				// This is done because this game is fucking hilarious and likes to play the sound one tick earlier than intended.
 +				if (sItem.UseSound != null && (!((sItem.useStyle == 1 || sItem.useStyle == 3) && !sItem.noMelee && !sItem.noUseGraphic) || sItem.fishingPole > 0))
 +					SoundEngine.PlaySound(sItem.UseSound, base.Center);
  			}
@@ -3111,14 +3113,15 @@
  			if (Main.dedServ)
  				return;
  
-@@ -35342,8 +_,13 @@
+@@ -35342,8 +_,14 @@
  			attackCD = 0;
  			ApplyItemAnimation(sItem);
  			bool flag2 = ItemID.Sets.SkipsInitialUseSound[sItem.type];
 -			if (sItem.UseSound != null && !flag2)
-+			if (sItem.UseSound != null && !flag2) {
-+				if (sItem.shoot == ProjectileID.None)
 -				SoundEngine.PlaySound(sItem.UseSound, base.Center);
++			if (sItem.UseSound != null && !flag2) {
++				// If the projectile shoots no projectiles or is a broadsword or pre-JE shortsword, play the sound here.
++				if (sItem.shoot == ProjectileID.None)
 +					SoundEngine.PlaySound(sItem.UseSound, base.Center);
 +
 +				else if ((sItem.useStyle == 1 || sItem.useStyle == 3) && !sItem.noMelee && !sItem.noUseGraphic)

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3069,6 +3069,16 @@
  					int num178 = Projectile.NewProjectile(pointPoisition.X, pointPoisition.Y, num2, num3, projToShoot, Damage, KnockBack, i);
  					if (sItem.type == 726)
  						Main.projectile[num178].magic = true;
+@@ -33910,6 +_,9 @@
+ 					if (Main.projectile[num178].aiStyle == 160 && Main.IsItAHappyWindyDay)
+ 						AchievementsHelper.HandleSpecialEvent(this, 17);
+ 				}
++
++				if (sItem.UseSound != null && (!((sItem.useStyle == 1 || sItem.useStyle == 3) && !sItem.noMelee && !sItem.noUseGraphic) || sItem.fishingPole > 0))
++					SoundEngine.PlaySound(sItem.UseSound, base.Center);
+ 			}
+ 			else if (sItem.useStyle == 5 || sItem.useStyle == 13) {
+ 				itemRotation = 0f;
 @@ -34434,6 +_,8 @@
  		}
  
@@ -3101,6 +3111,22 @@
  			if (Main.dedServ)
  				return;
  
+@@ -35342,8 +_,13 @@
+ 			attackCD = 0;
+ 			ApplyItemAnimation(sItem);
+ 			bool flag2 = ItemID.Sets.SkipsInitialUseSound[sItem.type];
+-			if (sItem.UseSound != null && !flag2)
++			if (sItem.UseSound != null && !flag2) {
++				if (sItem.shoot == ProjectileID.None)
+-				SoundEngine.PlaySound(sItem.UseSound, base.Center);
++					SoundEngine.PlaySound(sItem.UseSound, base.Center);
++
++				else if ((sItem.useStyle == 1 || sItem.useStyle == 3) && !sItem.noMelee && !sItem.noUseGraphic)
++					SoundEngine.PlaySound(sItem.UseSound, base.Center);
++			}
+ 		}
+ 
+ 		private void FreeUpPetsAndMinions(Item sItem) {
 @@ -35463,6 +_,9 @@
  		}
  
@@ -3123,6 +3149,15 @@
  			if (sItem.type != 3269 && (!spaceGun || (sItem.type != 127 && sItem.type != 4347 && sItem.type != 4348))) {
  				if (statMana >= num) {
  					if (!flag2)
+@@ -36000,8 +_,6 @@
+ 				if (itemAnimation == 1 && sItem.stack > 0) {
+ 					if (sItem.shoot > 0 && whoAmI != Main.myPlayer && controlUseItem && sItem.useStyle == 5 && sItem.reuseDelay == 0) {
+ 						ApplyItemAnimation(sItem);
+-						if (sItem.UseSound != null)
+-							SoundEngine.PlaySound(sItem.UseSound, base.Center);
+ 					}
+ 					else {
+ 						itemAnimation = 0;
 @@ -36027,6 +_,7 @@
  			if (!mount.Active)
  				return;


### PR DESCRIPTION
Non-(broadsword/shortsword) items which fire projectiles should no longer have their usage sound(s) desynced from their actual usage animation(s) as you continue to fire them.

Allow me to elaborate.
Whenever an item is used in Terraria, generally it makes a sound. It also possesses an animation for usin' it, and the important thing here is the animation variable, `useAnimation`. To explain why the fix is programmed the way it is, it's because of the way broadswords (and shortswords, presuming my research from pre-JE still holds up) work.
When a broadsword or shortsword is...swung, let's say, to keep it simple...it uses the `useAnimation` variable to determine how long it should swing for. Now, this would be all fine and dandy, except for one thing: whenever a broadsword is swung, it skips the last frame of its animation. This means an autoswing sword actually gets used one tick faster than its `useAnimation` value would imply.
(You may think `useTime` is used for this, but it's not --- it is instead used to dictate the cooldown on certain weapons' projectiles, such as the Enchanted Sword.)
For any other type of weapon, this isn't the case. Their usage animation is exactly the number of frames long that the `useAnimation` value dictates. HOWEVER, because the sound system still relies on the idea that everything skips the last frame, the sound is played again one tick before the animation restarts. This causes things such as staves and guns to become incredibly desynced between their usage animations and usage sounds, while broadswords and shortswords remain fine.
The question of whether or not the sound desyncs is also dependent upon other factors, most of which I simply can't explain --- but I wanted to make it a point regardless to cover all the bases.
This is why the fix is programmed the way it is; a specific exception has to be put in place for broadsword- and shortsword-style weapons without potentially changing the game on a major balance level; because of how broadswords in particular work, it's possible that this could majorly affect the damage output of multiple weapons if just left as a one-and-done fix.

I know hardcode isn't my thing, but it's important here to retain the stability of the game.