### PR TITLE
DamageClass additions and fixes.

### DIFF
--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -19,7 +19,7 @@ namespace Terraria
 		internal GlobalItem[] globalItems = new GlobalItem[0];
 
 		/// <summary>
-		/// The damage type of this Item. Assign to DamageClass.Melee/Ranged/Magic/Summon, or ModContent.GetInstance<T>() for custom damage types.
+		/// The damage type of this Item. Assign to DamageClass.Melee/Ranged/Magic/Summon/Throwing, or ModContent.GetInstance<T>() for custom damage types.
 		/// </summary>
 		public DamageClass DamageType { get; set; }
 

--- a/patches/tModLoader/Terraria/ModLoader/DamageClass.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DamageClass.cs
@@ -8,6 +8,7 @@ namespace Terraria.ModLoader
 		public static Ranged Ranged { get; private set; } = new Ranged();
 		public static Magic Magic { get; private set; } = new Magic();
 		public static Summon Summon { get; private set; } = new Summon();
+		public static Throwing Throwing { get; private set; } = new Throwing();
 
 		internal int index;
 
@@ -18,6 +19,14 @@ namespace Terraria.ModLoader
 		public string DisplayName => DisplayNameInternal;
 
 		internal protected virtual string DisplayNameInternal => ClassName.GetTranslation(Language.ActiveCulture);
+
+		public override void Load() {
+			Melee.index = 0;
+			Ranged.index = 1;
+			Magic.index = 2;
+			Summon.index = 3;
+			Throwing.index = 4;
+		}
 
 		protected override void Register() {
 			index = DamageClassLoader.Add(this);

--- a/patches/tModLoader/Terraria/ModLoader/DamageClassLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DamageClassLoader.cs
@@ -10,7 +10,8 @@ namespace Terraria.ModLoader
 			DamageClass.Melee,
 			DamageClass.Ranged,
 			DamageClass.Magic,
-			DamageClass.Summon
+			DamageClass.Summon,
+			DamageClass.Throwing
 		};
 
 		internal static readonly int DefaultDamageClassCount = DamageClasses.Count;

--- a/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
+++ b/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
@@ -21,4 +21,9 @@ namespace Terraria.ModLoader
 	{
 		internal protected override string DisplayNameInternal => Language.GetTextValue("LegacyTooltip.53");
 	}
+
+	public class Throwing : DamageClass
+	{
+		internal protected override string DisplayNameInternal => Language.GetTextValue("LegacyTooltip.58");
+	}
 }

--- a/patches/tModLoader/Terraria/Projectile.TML.cs
+++ b/patches/tModLoader/Terraria/Projectile.TML.cs
@@ -14,7 +14,7 @@ namespace Terraria
 		internal GlobalProjectile[] globalProjectiles = new GlobalProjectile[0];
 
 		/// <summary>
-		/// The damage type of this Item. Assign to DamageClass.Melee/Ranged/Magic/Summon/Throwing, or ModContent.GetInstance<T>() for custom damage types.
+		/// The damage type of this Projectile. Assign to DamageClass.Melee/Ranged/Magic/Summon/Throwing, or ModContent.GetInstance<T>() for custom damage types.
 		/// </summary>
 		public DamageClass DamageType { get; set; }
 

--- a/patches/tModLoader/Terraria/Projectile.TML.cs
+++ b/patches/tModLoader/Terraria/Projectile.TML.cs
@@ -13,6 +13,11 @@ namespace Terraria
 
 		internal GlobalProjectile[] globalProjectiles = new GlobalProjectile[0];
 
+		/// <summary>
+		/// The damage type of this Item. Assign to DamageClass.Melee/Ranged/Magic/Summon/Throwing, or ModContent.GetInstance<T>() for custom damage types.
+		/// </summary>
+		public DamageClass DamageType { get; set; }
+
 		// Get
 
 		/// <summary> Gets the instance of the specified GlobalProjectile type. This will throw exceptions on failure. </summary>

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -57,7 +57,7 @@
 +		}
 +		internal bool minion {
 +			get => DamageType == DamageClass.Summon;
-+			set => DamageType = value ? DamageClass.Summon : (summon ? null : DamageType);
++			set => DamageType = value ? DamageClass.Summon : (minion ? null : DamageType);
 +		}
  		public bool coldDamage;
  		public bool noEnchantments;

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -28,6 +28,40 @@
  		public int maxPenetrate = 1;
  		public int identity;
  		public float light;
+@@ -100,7 +_,6 @@
+ 		public Vector2[] oldPos = new Vector2[10];
+ 		public float[] oldRot = new float[10];
+ 		public int[] oldSpriteDirection = new int[10];
+-		public bool minion;
+ 		public float minionSlots;
+ 		public int minionPos;
+ 		public int restrikeDelay;
+@@ -112,9 +_,22 @@
+ 		public bool ownerHitCheck;
+ 		public int[] playerImmune = new int[255];
+ 		public string miscText = "";
+-		public bool melee;
+-		public bool ranged;
+-		public bool magic;
++		internal bool melee {
++			get => DamageType == DamageClass.Melee;
++			set => DamageType = value ? DamageClass.Melee : (melee ? null : DamageType);
++		}
++		internal bool magic {
++			get => DamageType == DamageClass.Magic;
++			set => DamageType = value ? DamageClass.Magic : (magic ? null : DamageType);
++		}
++		internal bool ranged {
++			get => DamageType == DamageClass.Ranged;
++			set => DamageType = value ? DamageClass.Ranged : (ranged ? null : DamageType);
++		}
++		internal bool minion {
++			get => DamageType == DamageClass.Summon;
++			set => DamageType = value ? DamageClass.Summon : (summon ? null : DamageType);
++		}
+ 		public bool coldDamage;
+ 		public bool noEnchantments;
+ 		public bool noEnchantmentVisuals;
 @@ -140,7 +_,12 @@
  		private static List<int> _ai156_blacklistedTargets = new List<int>();
  		private static float[] _CompanionCubeScreamCooldown = new float[255];


### PR DESCRIPTION
you may now use DamageClass.Throwing to define a throwing item/projectile, this is for modded convenience since everyone and their dog does a throwing class
you may now assign a DamageClass to projectiles through projectile.DamageType
also added an attempt at a fix for a problem where all DamageClasses are boosted by all stat bonuses for no good reason, and by that I mean I just made it so their indexes are actually set ever, it doesn't work 100% but it might help. see the issue I made on that for more info