### PR TITLE
Gave KillTile an easier to understand summary

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalTile.cs
@@ -143,7 +143,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to determine what happens when the tile at the given coordinates is killed or hit with a pickaxe. Fail determines whether the tile is mined, effectOnly makes it so that only dust is created, and noItem stops items from dropping.
+		/// Allows you to determine what happens when the tile at the given coordinates is killed or hit with a pickaxe. fail determines whether the tile is mined. Being true means not mined, effectOnly makes it so that only dust is created, and noItem stops items from dropping.
 		/// </summary>
 		/// <param name="i"></param>
 		/// <param name="j"></param>

--- a/patches/tModLoader/Terraria.ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalTile.cs
@@ -143,7 +143,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to determine what happens when the tile at the given coordinates is killed or hit with a pickaxe. fail determines whether the tile is mined. Being true means not mined, effectOnly makes it so that only dust is created, and noItem stops items from dropping.
+		/// Allows you to determine what happens when the tile at the given coordinates is killed or hit with a pickaxe. If <paramref name="fail"/> is true, the tile will not be mined; <paramref name="effectsOnly"/> makes it so that only dust is created; <paramref name="noItem"/> stops items from dropping.
 		/// </summary>
 		/// <param name="i"></param>
 		/// <param name="j"></param>


### PR DESCRIPTION
### What is the bug?
Not necessarily a bug, but made KillTile easier to read
### How did you fix the bug?
change from "fail determines whether the tile is mined" to that *and* "fail determines whether the tile is mined. Being true means not mined"
### Are there alternatives to your fix?
Nope.