### PR TITLE
Fix projectiles with both UUID and ExtraAI having misaligned netcode read/write

### DIFF
--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -108,7 +108,7 @@
  							break;
  						}
  					case 24:
-@@ -500,15 +_,21 @@
+@@ -500,9 +_,10 @@
  									bb14[num9] = true;
  							}
  
@@ -120,18 +120,16 @@
  							writer.Write(bb14);
  							for (int num10 = 0; num10 < Projectile.maxAI; num10++) {
  								if (bb14[num10])
- 									writer.Write(projectile.ai[num10]);
- 							}
+@@ -512,11 +_,19 @@
+ 							if (bb14[Projectile.maxAI])
+ 								writer.Write((short)projectile.projUUID);
  
 +							if (bb14[Projectile.maxAI + 1]) {
 +								writer.Write((byte)extraAI.Length);
 +								writer.Write(extraAI);
 +							}
 +
- 							if (bb14[Projectile.maxAI])
- 								writer.Write((short)projectile.projUUID);
- 
-@@ -516,7 +_,10 @@
+ 							break;
  						}
  					case 28:
  						writer.Write((short)number);


### PR DESCRIPTION
### What is the bug?
Modded projectiles which both use the vanilla UUID system `ProjectileID.Sets.NeedsUUID[i] = true` and TML's provided "Extra AI" (`ModProjectile.SendExtraAI` and `ModProjectile.ReceiveExtraAI`) run into misaligned netcode due to a typo in `NetMessage.cs`.

Specifically, when writing a `SyncProjectile` packet, TML sends the modded "Extra AI" before the vanilla code which sends UUID. But when reading a `SyncProjectile` packet, TML reads the "Extra AI" *after* vanilla code reads the UUID.

### How did you fix the bug?
I reordered `NetMessage.SendData case 27:` instructions so that the vanilla UUID is sent before the "Extra AI". This was the recommendation by @Chicken-Bones (mod data should always be at the end if feasible).

### Are there alternatives to your fix?
Instead of modifying the packet write, the packet read could be modified by making `MessageBuffer.GetData case 27:` read the "Extra AI" before the vanilla UUID. This would violate Chicken Bones' recommendation though.