### PR TITLE
Make AmmoIDs constant

### DIFF
--- a/patches/tModLoader/Terraria.ID/AmmoID.cs.patch
+++ b/patches/tModLoader/Terraria.ID/AmmoID.cs.patch
@@ -1,0 +1,42 @@
+--- src/Terraria/Terraria.ID/AmmoID.cs
++++ src/tModLoader/Terraria.ID/AmmoID.cs
+@@ -2,22 +_,22 @@
+ {
+ 	public static class AmmoID
+ 	{
+-		public static int None = 0;
++		public const int None = 0;
+-		public static int Gel = 23;
++		public const int Gel = 23;
+-		public static int Arrow = 40;
++		public const int Arrow = 40;
+-		public static int Coin = 71;
++		public const int Coin = 71;
+-		public static int FallenStar = 75;
++		public const int FallenStar = 75;
+-		public static int Bullet = 97;
++		public const int Bullet = 97;
+-		public static int Sand = 169;
++		public const int Sand = 169;
+-		public static int Dart = 283;
++		public const int Dart = 283;
+-		public static int Rocket = 771;
++		public const int Rocket = 771;
+-		public static int Solution = 780;
++		public const int Solution = 780;
+-		public static int Flare = 931;
++		public const int Flare = 931;
+-		public static int Snowball = 949;
++		public const int Snowball = 949;
+-		public static int StyngerBolt = 1261;
++		public const int StyngerBolt = 1261;
+-		public static int CandyCorn = 1783;
++		public const int CandyCorn = 1783;
+-		public static int JackOLantern = 1785;
++		public const int JackOLantern = 1785;
+-		public static int Stake = 1836;
++		public const int Stake = 1836;
+-		public static int NailFriendly = 3108;
++		public const int NailFriendly = 3108;
+ 	}
+ }


### PR DESCRIPTION
### What is the bug?
AmmoIDs aren't constant making them unusable in switch cases
### How did you fix the bug?
Made them constant
### Are there alternatives to your fix?
I don't think so
