### PR TITLE
[1.4] Fixed and reworked ModGore

### DIFF
--- a/patches/tModLoader/Terraria/Gore.TML.cs
+++ b/patches/tModLoader/Terraria/Gore.TML.cs
@@ -11,7 +11,7 @@ namespace Terraria
 
 		public ModGore ModGore { get; internal set; }
 
-		internal void ResetNewFields() {
+		private void ResetNewFields() {
 			drawOffset = Vector2.Zero;
 			realType = 0;
 		}

--- a/patches/tModLoader/Terraria/Gore.TML.cs
+++ b/patches/tModLoader/Terraria/Gore.TML.cs
@@ -9,7 +9,7 @@ namespace Terraria
 
 		internal int realType;
 
-		public ModGore ModGore { get; internal set; }
+		public ModGore ModGore { get; private set; }
 
 		private void ResetNewFields() {
 			drawOffset = Vector2.Zero;

--- a/patches/tModLoader/Terraria/Gore.TML.cs
+++ b/patches/tModLoader/Terraria/Gore.TML.cs
@@ -5,7 +5,7 @@ namespace Terraria
 {
 	public partial class Gore
 	{
-		public Vector2 drawOffset = Vector2.Zero;
+		public Vector2 drawOffset;
 
 		internal int realType;
 

--- a/patches/tModLoader/Terraria/Gore.TML.cs
+++ b/patches/tModLoader/Terraria/Gore.TML.cs
@@ -1,0 +1,19 @@
+using Microsoft.Xna.Framework;
+using Terraria.ModLoader;
+
+namespace Terraria
+{
+	public partial class Gore
+	{
+		public Vector2 drawOffset = Vector2.Zero;
+
+		internal int realType;
+
+		public ModGore ModGore { get; internal set; }
+
+		internal void ResetNewFields() {
+			drawOffset = Vector2.Zero;
+			realType = 0;
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/Gore.cs.patch
+++ b/patches/tModLoader/Terraria/Gore.cs.patch
@@ -32,13 +32,18 @@
  		}
  
  		private void Gore_UpdateLeaf() {
-@@ -1035,6 +_,10 @@
+@@ -1035,6 +_,15 @@
  			Main.gore[num].alpha = 0;
  			Main.gore[num].rotation = 0f;
  			Main.gore[num].scale = Scale;
 +			
-+			ResetNewFields();
-+			GoreLoader.SetupGore(Main.gore[num]);
++			var gore = Main.gore[num];
++			
++			gore.ResetNewFields();
++			
++			gore.ModGore = GoreLoader.SetupGore(gore);
++			
++			gore.ModGore?.OnSpawn(gore);
 +			
  			if (!ChildSafety.Disabled && ChildSafety.DangerousGore(Type)) {
  				Main.gore[num].type = Main.rand.Next(11, 14);

--- a/patches/tModLoader/Terraria/Gore.cs.patch
+++ b/patches/tModLoader/Terraria/Gore.cs.patch
@@ -26,7 +26,7 @@
 +			if (modGore != null && !modGore.Update(this))
 +				return;
 +
-+			ModGore.SetupUpdateType(this);
++			GoreLoader.SetupUpdateType(this);
  			switch (GoreID.Sets.SpecialAI[type]) {
  				case 4:
  					UpdateAmbientFloorCloud();
@@ -34,7 +34,7 @@
  				else
  					Lighting.AddLight((int)((position.X + 32f * scale / 2f) / 16f), (int)((position.Y + 32f * scale / 2f) / 16f), num37, num38, num39);
  			}
-+			ModGore.TakeDownUpdateType(this);
++			GoreLoader.TakeDownUpdateType(this);
  		}
  
  		private void Gore_UpdateLeaf() {
@@ -42,7 +42,7 @@
  			Main.gore[num].alpha = 0;
  			Main.gore[num].rotation = 0f;
  			Main.gore[num].scale = Scale;
-+			ModGore.SetupGore(Main.gore[num]);
++			GoreLoader.SetupGore(Main.gore[num]);
  			if (!ChildSafety.Disabled && ChildSafety.DangerousGore(Type)) {
  				Main.gore[num].type = Main.rand.Next(11, 14);
  				Main.gore[num].scale = Main.rand.NextFloat() * 0.5f + 0.5f;

--- a/patches/tModLoader/Terraria/Gore.cs.patch
+++ b/patches/tModLoader/Terraria/Gore.cs.patch
@@ -32,11 +32,14 @@
  		}
  
  		private void Gore_UpdateLeaf() {
-@@ -1035,6 +_,7 @@
+@@ -1035,6 +_,10 @@
  			Main.gore[num].alpha = 0;
  			Main.gore[num].rotation = 0f;
  			Main.gore[num].scale = Scale;
++			
++			ResetNewFields();
 +			GoreLoader.SetupGore(Main.gore[num]);
++			
  			if (!ChildSafety.Disabled && ChildSafety.DangerousGore(Type)) {
  				Main.gore[num].type = Main.rand.Next(11, 14);
  				Main.gore[num].scale = Main.rand.NextFloat() * 0.5f + 0.5f;

--- a/patches/tModLoader/Terraria/Gore.cs.patch
+++ b/patches/tModLoader/Terraria/Gore.cs.patch
@@ -41,7 +41,7 @@
 +			
 +			gore.ResetNewFields();
 +			
-+			gore.ModGore = GoreLoader.SetupGore(gore);
++			gore.ModGore = GoreLoader.GetModGore(gore.type);
 +			
 +			gore.ModGore?.OnSpawn(gore);
 +			

--- a/patches/tModLoader/Terraria/Gore.cs.patch
+++ b/patches/tModLoader/Terraria/Gore.cs.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/Gore.cs
 +++ src/tModLoader/Terraria/Gore.cs
-@@ -7,11 +_,18 @@
+@@ -7,10 +_,11 @@
  using Terraria.Graphics.Effects;
  using Terraria.ID;
  using Terraria.Utilities;
@@ -8,22 +8,16 @@
  
  namespace Terraria
  {
- 	public class Gore
+-	public class Gore
++	public partial class Gore
  	{
-+		public ModGore modGore {
-+			get;
-+			internal set;
-+		}
-+		internal int realType = 0;
-+		public Vector2 drawOffset = Vector2.Zero;
  		public static int goreTime = 600;
  		public Vector2 position;
- 		public Vector2 velocity;
 @@ -239,6 +_,10 @@
  			if (Main.netMode == 2 || !active)
  				return;
  
-+			if (modGore != null && !modGore.Update(this))
++			if (ModGore != null && !ModGore.Update(this))
 +				return;
 +
 +			GoreLoader.SetupUpdateType(this);
@@ -50,8 +44,8 @@
  		}
  
  		public Color GetAlpha(Color newColor) {
-+			if (modGore != null) {
-+				Color? modColor = modGore.GetAlpha(this, newColor);
++			if (ModGore != null) {
++				Color? modColor = ModGore.GetAlpha(this, newColor);
 +				if (modColor.HasValue)
 +					return modColor.Value;
 +			}

--- a/patches/tModLoader/Terraria/Gore.cs.patch
+++ b/patches/tModLoader/Terraria/Gore.cs.patch
@@ -32,17 +32,15 @@
  		}
  
  		private void Gore_UpdateLeaf() {
-@@ -1035,6 +_,15 @@
+@@ -1035,6 +_,13 @@
  			Main.gore[num].alpha = 0;
  			Main.gore[num].rotation = 0f;
  			Main.gore[num].scale = Scale;
 +			
 +			var gore = Main.gore[num];
-+			
 +			gore.ResetNewFields();
 +			
 +			gore.ModGore = GoreLoader.GetModGore(gore.type);
-+			
 +			gore.ModGore?.OnSpawn(gore);
 +			
  			if (!ChildSafety.Disabled && ChildSafety.DangerousGore(Type)) {

--- a/patches/tModLoader/Terraria/ID/GoreID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/GoreID.cs.patch
@@ -10,7 +10,7 @@
  		public static class Sets
  		{
 -			public static SetFactory Factory = new SetFactory(1270);
-+			public static SetFactory Factory = new SetFactory(ModGore.GoreCount);
++			public static SetFactory Factory = new SetFactory(GoreLoader.GoreCount);
  			public static int[] SpecialAI = Factory.CreateIntSet(0, 860, 1, 892, 1, 893, 1, 825, 2, 826, 2, 827, 2, 1014, 1, 1015, 1, 1016, 1, 910, 3, 911, 3, 912, 3, 913, 3, 914, 3, 915, 3, 916, 3, 917, 3, 918, 3, 919, 3, 920, 3, 921, 3, 922, 3, 923, 3, 924, 3, 925, 3, 1113, 3, 1114, 3, 1115, 3, 1116, 3, 1117, 3, 1118, 3, 1119, 3, 1120, 3, 1121, 3, 1248, 3, 1249, 3, 1250, 3, 1251, 3, 1252, 3, 1253, 3, 1254, 3, 1255, 3, 1257, 3, 1007, 3, 1008, 3, 1087, 4, 1088, 4, 1089, 4, 1090, 4, 1091, 5, 1092, 5, 1093, 5, 1202, 6, 1203, 6, 1204, 6, 1225, 7);
  			public static int[] DisappearSpeed = Factory.CreateIntSet(1, 1007, 3, 1008, 10, 1024, 7, 1025, 7, 1026, 7);
  			public static int[] DisappearSpeedAlpha = Factory.CreateIntSet(1, 1007, 3, 1008, 10, 1024, 7, 1025, 7, 1026, 7, 1218, 3);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1994,7 +1994,7 @@
  
  				bool flag = false;
 -				if (((gore[i].type >= 706 && gore[i].type <= 717) || gore[i].type == 943 || gore[i].type == 1147 || (gore[i].type >= 1160 && gore[i].type <= 1162)) && (gore[i].frame < 7 || gore[i].frame > 9))
-+				if (ModGore.DrawBackGore(gore[i]))
++				if (GoreLoader.DrawBackGore(gore[i]))
  					flag = true;
  
  				if (flag) {
@@ -2017,7 +2017,7 @@
  					continue;
  
 -				if (((gore[i].type >= 706 && gore[i].type <= 717) || gore[i].type == 943 || gore[i].type == 1147 || (gore[i].type >= 1160 && gore[i].type <= 1162)) && (gore[i].frame < 7 || gore[i].frame > 9)) {
-+				if (ModGore.DrawBackGore(gore[i])) {
++				if (GoreLoader.DrawBackGore(gore[i])) {
  					drawBackGore = true;
  					continue;
  				}

--- a/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
@@ -78,8 +78,8 @@ namespace Terraria.ModLoader
 			GoreCount = GoreID.Count;
 		}
 
-		internal static ModGore SetupGore(Gore gore) {
-			gores.TryGetValue(gore.type, out var modGore);
+		internal static ModGore GetModGore(int type) {
+			gores.TryGetValue(type, out var modGore);
 			
 			return modGore;
 		}

--- a/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
@@ -112,6 +112,7 @@ namespace Terraria.ModLoader
 				return gore.ModGore.DrawBehind(gore);
 			}
 
+			//TODO: Whatever calls this is a very bad patch. Don't move vanilla code, reuse it where it is instead.
 			return (((gore.type >= 706 && gore.type <= 717) || gore.type == 943 || gore.type == 1147 || (gore.type >= 1160 && gore.type <= 1162)) && (gore.frame < 7 || gore.frame > 9));
 		}
 	}

--- a/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
@@ -78,16 +78,10 @@ namespace Terraria.ModLoader
 			GoreCount = GoreID.Count;
 		}
 
-		//in Terraria.Gore add modGore property (internal set)
-		//in Terraria.Gore.NewGore after resetting properties call ModGore.SetupGore(Main.gore[num]);
-		internal static void SetupGore(Gore gore) {
-			if (gores.ContainsKey(gore.type)) {
-				gore.ModGore = gores[gore.type];
-				gore.ModGore.OnSpawn(gore);
-			}
-			else {
-				gore.ModGore = null;
-			}
+		internal static ModGore SetupGore(Gore gore) {
+			gores.TryGetValue(gore.type, out var modGore);
+			
+			return modGore;
 		}
 
 		internal static void SetupUpdateType(Gore gore) {

--- a/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
@@ -74,7 +74,7 @@ namespace Terraria.ModLoader
 
 		internal static void Unload() {
 			gores.Clear();
-			gores.Clear();
+			
 			GoreCount = GoreID.Count;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
@@ -77,19 +77,21 @@ namespace Terraria.ModLoader
 		//in Terraria.Gore add modGore property (internal set)
 		//in Terraria.Gore.NewGore after resetting properties call ModGore.SetupGore(Main.gore[num]);
 		internal static void SetupGore(Gore gore) {
+			gore.ResetNewFields();
+
 			if (gores.ContainsKey(gore.type)) {
-				gore.modGore = gores[gore.type];
-				gore.modGore.OnSpawn(gore);
+				gore.ModGore = gores[gore.type];
+				gore.ModGore.OnSpawn(gore);
 			}
 			else {
-				gore.modGore = null;
+				gore.ModGore = null;
 			}
 		}
 
 		internal static void SetupUpdateType(Gore gore) {
-			if (gore.modGore != null && gore.modGore.updateType > 0) {
+			if (gore.ModGore != null && gore.ModGore.updateType > 0) {
 				gore.realType = gore.type;
-				gore.type = gore.modGore.updateType;
+				gore.type = gore.ModGore.updateType;
 			}
 		}
 
@@ -102,8 +104,8 @@ namespace Terraria.ModLoader
 
 		//in Terraria.Main.DrawGore and DrawGoreBehind replace type checks with this
 		internal static bool DrawBackGore(Gore gore) {
-			if (gore.modGore != null) {
-				return gore.modGore.DrawBehind(gore);
+			if (gore.ModGore != null) {
+				return gore.ModGore.DrawBehind(gore);
 			}
 
 			return (((gore.type >= 706 && gore.type <= 717) || gore.type == 943 || gore.type == 1147 || (gore.type >= 1160 && gore.type <= 1162)) && (gore.frame < 7 || gore.frame > 9));

--- a/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using Terraria.GameContent;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader.Core;
 
 namespace Terraria.ModLoader
@@ -22,6 +23,9 @@ namespace Terraria.ModLoader
 
 			if (texture == null)
 				throw new ArgumentNullException(nameof(texture));
+			
+			if (!mod.loading)
+				throw new Exception(Language.GetTextValue("tModLoader.LoadErrorNotLoading"));
 
 			var modGore = Activator.CreateInstance<T>();
 

--- a/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Terraria.GameContent;
 using Terraria.ID;
@@ -10,70 +11,74 @@ namespace Terraria.ModLoader
 {
 	public static class GoreLoader
 	{
-		internal static readonly IDictionary<string, int> gores = new Dictionary<string, int>();
-		internal static readonly IDictionary<int, ModGore> modGores = new Dictionary<int, ModGore>();
+		internal static readonly IDictionary<int, ModGore> gores = new Dictionary<int, ModGore>();
 
-		private static int nextGore = GoreID.Count;
+		public static int GoreCount { get; private set; } = GoreID.Count;
 
-		public static int GoreCount => nextGore;
+		/// <summary> Registers a new gore with the provided texture. </summary>
+		public static void AddGoreFromTexture<T>(Mod mod, string texture) where T : ModGore, new() {
+			if (mod == null)
+				throw new ArgumentNullException(nameof(mod));
 
-		internal static int ReserveGoreID() => nextGore++;
+			if (texture == null)
+				throw new ArgumentNullException(nameof(texture));
 
-		internal static void AddGore(string texture, ModGore modGore = null) {
-			int id = ReserveGoreID();
+			var modGore = Activator.CreateInstance<T>();
 
-			gores[texture] = id;
+			modGore.nameOverride = Path.GetFileNameWithoutExtension(texture);
+			modGore.textureOverride = texture;
 
-			if (modGore != null) {
-				modGores[id] = modGore;
+			mod.AddContent(modGore);
+		}
+
+		//Called by ModGore.Register
+		internal static void RegisterModGore(ModGore modGore) {
+			int id = GoreCount++;
+
+			modGore.Type = id;
+
+			gores[id] = modGore;
+		}
+
+		internal static void AutoloadGores(Mod mod) {
+			foreach (string texturePath in mod.Assets.EnumeratePaths<Texture2D>().Where(t => t.StartsWith("Gores/"))) {
+				string textureKey = $"{mod.Name}/{texturePath}";
+
+				if (!mod.TryFind<ModGore>($"{mod.Name}/{Path.GetFileName(texturePath)}", out _)) //ModGore gores will already be loaded at this point.
+					AddGoreFromTexture<ModGore>(mod, textureKey);
 			}
 		}
 
 		//in Terraria.GameContent.ChildSafety make SafeGore internal and not readonly
 		internal static void ResizeAndFillArrays() {
 			//Textures
-			Array.Resize(ref TextureAssets.Gore, nextGore);
+			Array.Resize(ref TextureAssets.Gore, GoreCount);
 
 			//Sets
 			LoaderUtils.ResetStaticMembers(typeof(GoreID), true);
-			Array.Resize(ref ChildSafety.SafeGore, nextGore);
+			Array.Resize(ref ChildSafety.SafeGore, GoreCount);
 
-			for (int k = GoreID.Count; k < nextGore; k++) {
+			for (int k = GoreID.Count; k < GoreCount; k++) {
 				GoreID.Sets.DisappearSpeed[k] = 1;
 				GoreID.Sets.DisappearSpeedAlpha[k] = 1;
 			}
 
-			foreach (string texture in gores.Keys) {
-				TextureAssets.Gore[gores[texture]] = ModContent.GetTexture(texture);
-			}
-		}
-
-		internal static void AutoloadGores(Mod mod, IList<Type> modGores) {
-			var modGoreNames = modGores.ToDictionary(t => t.FullName);
-
-			foreach (string texturePath in mod.Assets.EnumeratePaths<Texture2D>().Where(t => t.StartsWith("Gores/"))) {
-				ModGore modGore = null;
-
-				if (modGoreNames.TryGetValue($"{mod.Name}.{texturePath.Replace('/', '.')}", out Type t))
-					modGore = (ModGore)Activator.CreateInstance(t);
-				else
-					modGore = new ModGore();
-
-				AddGore($"{mod.Name}/{texturePath}", modGore);
+			foreach (var pair in gores) {
+				TextureAssets.Gore[pair.Key] = ModContent.GetTexture(pair.Value.Texture);
 			}
 		}
 
 		internal static void Unload() {
 			gores.Clear();
-			modGores.Clear();
-			nextGore = GoreID.Count;
+			gores.Clear();
+			GoreCount = GoreID.Count;
 		}
 
 		//in Terraria.Gore add modGore property (internal set)
 		//in Terraria.Gore.NewGore after resetting properties call ModGore.SetupGore(Main.gore[num]);
 		internal static void SetupGore(Gore gore) {
-			if (modGores.ContainsKey(gore.type)) {
-				gore.modGore = modGores[gore.type];
+			if (gores.ContainsKey(gore.type)) {
+				gore.modGore = gores[gore.type];
 				gore.modGore.OnSpawn(gore);
 			}
 			else {

--- a/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Terraria.GameContent;
+using Terraria.ID;
+using Terraria.ModLoader.Core;
+
+namespace Terraria.ModLoader
+{
+	public static class GoreLoader
+	{
+		internal static readonly IDictionary<string, int> gores = new Dictionary<string, int>();
+		internal static readonly IDictionary<int, ModGore> modGores = new Dictionary<int, ModGore>();
+
+		private static int nextGore = GoreID.Count;
+
+		public static int GoreCount => nextGore;
+
+		internal static int ReserveGoreID() => nextGore++;
+
+		internal static void AddGore(string texture, ModGore modGore = null) {
+			int id = ReserveGoreID();
+
+			gores[texture] = id;
+
+			if (modGore != null) {
+				modGores[id] = modGore;
+			}
+		}
+
+		//in Terraria.GameContent.ChildSafety make SafeGore internal and not readonly
+		internal static void ResizeAndFillArrays() {
+			//Textures
+			Array.Resize(ref TextureAssets.Gore, nextGore);
+
+			//Sets
+			LoaderUtils.ResetStaticMembers(typeof(GoreID), true);
+			Array.Resize(ref ChildSafety.SafeGore, nextGore);
+
+			for (int k = GoreID.Count; k < nextGore; k++) {
+				GoreID.Sets.DisappearSpeed[k] = 1;
+				GoreID.Sets.DisappearSpeedAlpha[k] = 1;
+			}
+
+			foreach (string texture in gores.Keys) {
+				TextureAssets.Gore[gores[texture]] = ModContent.GetTexture(texture);
+			}
+		}
+
+		internal static void AutoloadGores(Mod mod, IList<Type> modGores) {
+			var modGoreNames = modGores.ToDictionary(t => t.FullName);
+
+			foreach (string texturePath in mod.Assets.EnumeratePaths<Texture2D>().Where(t => t.StartsWith("Gores/"))) {
+				ModGore modGore = null;
+
+				if (modGoreNames.TryGetValue($"{mod.Name}.{texturePath.Replace('/', '.')}", out Type t))
+					modGore = (ModGore)Activator.CreateInstance(t);
+				else
+					modGore = new ModGore();
+
+				AddGore($"{mod.Name}/{texturePath}", modGore);
+			}
+		}
+
+		internal static void Unload() {
+			gores.Clear();
+			modGores.Clear();
+			nextGore = GoreID.Count;
+		}
+
+		//in Terraria.Gore add modGore property (internal set)
+		//in Terraria.Gore.NewGore after resetting properties call ModGore.SetupGore(Main.gore[num]);
+		internal static void SetupGore(Gore gore) {
+			if (modGores.ContainsKey(gore.type)) {
+				gore.modGore = modGores[gore.type];
+				gore.modGore.OnSpawn(gore);
+			}
+			else {
+				gore.modGore = null;
+			}
+		}
+
+		internal static void SetupUpdateType(Gore gore) {
+			if (gore.modGore != null && gore.modGore.updateType > 0) {
+				gore.realType = gore.type;
+				gore.type = gore.modGore.updateType;
+			}
+		}
+
+		internal static void TakeDownUpdateType(Gore gore) {
+			if (gore.realType > 0) {
+				gore.type = gore.realType;
+				gore.realType = 0;
+			}
+		}
+
+		//in Terraria.Main.DrawGore and DrawGoreBehind replace type checks with this
+		internal static bool DrawBackGore(Gore gore) {
+			if (gore.modGore != null) {
+				return gore.modGore.DrawBehind(gore);
+			}
+
+			return (((gore.type >= 706 && gore.type <= 717) || gore.type == 943 || gore.type == 1147 || (gore.type >= 1160 && gore.type <= 1162)) && (gore.frame < 7 || gore.frame > 9));
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
@@ -81,8 +81,6 @@ namespace Terraria.ModLoader
 		//in Terraria.Gore add modGore property (internal set)
 		//in Terraria.Gore.NewGore after resetting properties call ModGore.SetupGore(Main.gore[num]);
 		internal static void SetupGore(Gore gore) {
-			gore.ResetNewFields();
-
 			if (gores.ContainsKey(gore.type)) {
 				gore.ModGore = gores[gore.type];
 				gore.ModGore.OnSpawn(gore);

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -93,7 +93,6 @@ namespace Terraria.ModLoader
 			IList<Type> modGores = new List<Type>();
 			IList<Type> modSounds = new List<Type>();
 
-
 			Type modType = GetType();
 			foreach (Type type in Code.GetTypes().OrderBy(type => type.FullName, StringComparer.InvariantCulture)) {
 				if (type == modType){continue;}
@@ -114,7 +113,7 @@ namespace Terraria.ModLoader
 				}
 			}
 			if (Properties.AutoloadGores) {
-				AutoloadGores(modGores);
+				GoreLoader.AutoloadGores(this, modGores);
 			}
 			if (Properties.AutoloadSounds) {
 				AutoloadSounds(modSounds);
@@ -178,18 +177,6 @@ namespace Terraria.ModLoader
 		private void AutoloadBackgrounds() {
 			foreach (string texture in Assets.EnumeratePaths<Texture2D>().Where(t => t.StartsWith("Backgrounds/"))) {
 				AddBackgroundTexture($"{Name}/{texture}");
-			}
-		}
-
-		private void AutoloadGores(IList<Type> modGores) {
-			var modGoreNames = modGores.ToDictionary(t => t.FullName);
-
-			foreach (string texturePath in Assets.EnumeratePaths<Texture2D>().Where(t => t.StartsWith("Gores/"))) {
-				ModGore modGore = null;
-				if (modGoreNames.TryGetValue($"{Name}.{texturePath.Replace('/', '.')}", out Type t))
-					modGore = (ModGore)Activator.CreateInstance(t);
-
-				AddGore($"{Name}/{texturePath}", modGore);
 			}
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -90,7 +90,6 @@ namespace Terraria.ModLoader
 				AsyncLoadQueue.Dequeue().Wait();
 
 			AutoloadLocalization();
-			IList<Type> modGores = new List<Type>();
 			IList<Type> modSounds = new List<Type>();
 
 			Type modType = GetType();
@@ -99,10 +98,7 @@ namespace Terraria.ModLoader
 				if (type.IsAbstract){continue;}
 				if (type.GetConstructor(new Type[0]) == null){continue;}//don't autoload things with no default constructor
 
-				if (type.IsSubclassOf(typeof(ModGore))) {
-					modGores.Add(type);
-				}
-				else if (type.IsSubclassOf(typeof(ModSound))) {
+				if (type.IsSubclassOf(typeof(ModSound))) {
 					modSounds.Add(type);
 				}
 				else if (typeof(ILoadable).IsAssignableFrom(type)) {
@@ -113,7 +109,7 @@ namespace Terraria.ModLoader
 				}
 			}
 			if (Properties.AutoloadGores) {
-				GoreLoader.AutoloadGores(this, modGores);
+				GoreLoader.AutoloadGores(this);
 			}
 			if (Properties.AutoloadSounds) {
 				AutoloadSounds(modSounds);

--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -263,37 +263,6 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Adds the given texture to the game as a custom gore, with the given custom gore behavior. If no custom gore behavior is provided, the custom gore will have the default vanilla behavior.
-		/// </summary>
-		/// <param name="texture">The texture.</param>
-		/// <param name="modGore">The mod gore.</param>
-		public void AddGore(string texture, ModGore modGore = null) {
-			if (!loading)
-				throw new Exception("AddGore can only be called from Mod.Load or Mod.Autoload");
-
-			int id = ModGore.ReserveGoreID();
-			ModGore.gores[texture] = id;
-			if (modGore != null) {
-				ModGore.modGores[id] = modGore;
-				ContentInstance.Register(modGore);
-			}
-		}
-
-		/// <summary>
-		/// Shorthand for calling ModGore.GetGoreSlot(this.Name + '/' + name).
-		/// </summary>
-		/// <param name="name">The name.</param>
-		/// <returns></returns>
-		public int GetGoreSlot(string name) => ModGore.GetGoreSlot(Name + '/' + name);
-
-		/// <summary>
-		/// Same as the other GetGoreSlot, but assumes that the class name and internal name are the same.
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <returns></returns>
-		public int GetGoreSlot<T>() where T : ModGore => GetGoreSlot(typeof(T).Name);
-
-		/// <summary>
 		/// Adds the given sound file to the game as the given type of sound and with the given custom sound playing. If no ModSound instance is provided, the custom sound will play in a similar manner as the default vanilla ones.
 		/// </summary>
 		/// <param name="type">The type.</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -298,6 +298,11 @@ namespace Terraria.ModLoader
 		public static ModUgBgStyle GetModUgBgStyle(int style) => UgBgStyleLoader.GetUgBgStyle(style);
 
 		/// <summary>
+		/// Get the id (type) of a ModGore by class. Assumes one instance per class.
+		/// </summary>
+		public static int GoreType<T>() where T : ModGore => GetInstance<T>()?.Type ?? 0;
+
+		/// <summary>
 		/// Get the id (type) of a ModItem by class. Assumes one instance per class.
 		/// </summary>
 		public static int ItemType<T>() where T : ModItem => GetInstance<T>()?.Type ?? 0;

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -485,7 +485,7 @@ namespace Terraria.ModLoader
 			MountLoader.Unload();
 			RarityLoader.Unload();
 			DamageClassLoader.Unload();
-			ModGore.Unload();
+			GoreLoader.Unload();
 			SoundLoader.Unload();
 			DisposeMusic();
 			BackgroundTextureLoader.Unload();
@@ -547,7 +547,7 @@ namespace Terraria.ModLoader
 				UgBgStyleLoader.ResizeAndFillArrays();
 				SurfaceBgStyleLoader.ResizeAndFillArrays();
 				GlobalBgStyleLoader.ResizeAndFillArrays(unloading);
-				ModGore.ResizeAndFillArrays();
+				GoreLoader.ResizeAndFillArrays();
 				WaterStyleLoader.ResizeArrays();
 				WaterfallStyleLoader.ResizeArrays();
 			}

--- a/patches/tModLoader/Terraria/ModLoader/ModGore.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModGore.cs
@@ -1,117 +1,32 @@
 using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using Terraria.GameContent;
-using Terraria.ID;
-using Terraria.ModLoader.Core;
 
 namespace Terraria.ModLoader
 {
 	/// <summary>
-	/// This class allows you to customize the behavior of a custom gore. Create a new instance of this and pass it as a parameter to Mod.AddGore to customize the gore you are adding. If you are autoloading gore, then give it the same name as the gore texture.
+	/// This class allows you to customize the behavior of a custom gore.
 	/// </summary>
-	public class ModGore
+	public class ModGore : ModTexturedType
 	{
-		private static int nextGore = GoreID.Count;
-		public static int GoreCount => nextGore;
-		internal static readonly IDictionary<string, int> gores = new Dictionary<string, int>();
-		internal static readonly IDictionary<int, ModGore> modGores = new Dictionary<int, ModGore>();
-
 		/// <summary> Allows you to copy the Update behavior of a different type of gore. This defaults to 0, which means no behavior is copied. </summary>
 		public int updateType = -1;
 
-		internal static int ReserveGoreID() {
-			int reserveID = nextGore;
-			nextGore++;
-			return reserveID;
-		}
+		protected override void Register() {
+			ModTypeLookup<ModGore>.Register(this);
 
-		/// <summary>
-		/// Gets the type of the custom gore corresponding to the given texture. Returns 0 if the texture does not represent a gore.
-		/// </summary>
-		public static int GetGoreSlot(string texture) {
-			if (gores.ContainsKey(texture)) {
-				return gores[texture];
-			}
-			else {
-				return 0;
-			}
-		}
-
-		//in Terraria.GameContent.ChildSafety make SafeGore internal and not readonly
-		internal static void ResizeAndFillArrays() {
-
-			//Textures
-			Array.Resize(ref TextureAssets.Gore, nextGore);
-
-			//Sets
-			LoaderUtils.ResetStaticMembers(typeof(GoreID), true);
-			Array.Resize(ref ChildSafety.SafeGore, nextGore);
-
-			for (int k = GoreID.Count; k < nextGore; k++) {
-				GoreID.Sets.DisappearSpeed[k] = 1;
-				GoreID.Sets.DisappearSpeedAlpha[k] = 1;
-			}
-
-			foreach (string texture in gores.Keys) {
-				TextureAssets.Gore[gores[texture]] = ModContent.GetTexture(texture);
-			}
-		}
-
-		internal static void Unload() {
-			gores.Clear();
-			modGores.Clear();
-			nextGore = GoreID.Count;
-		}
-
-		//in Terraria.Gore add modGore property (internal set)
-		//in Terraria.Gore.NewGore after resetting properties call ModGore.SetupGore(Main.gore[num]);
-		internal static void SetupGore(Gore gore) {
-			if (modGores.ContainsKey(gore.type)) {
-				gore.modGore = modGores[gore.type];
-				gore.modGore.OnSpawn(gore);
-			}
-			else {
-				gore.modGore = null;
-			}
-		}
-
-		internal static void SetupUpdateType(Gore gore) {
-			if (gore.modGore != null && gore.modGore.updateType > 0) {
-				gore.realType = gore.type;
-				gore.type = gore.modGore.updateType;
-			}
-		}
-
-		internal static void TakeDownUpdateType(Gore gore) {
-			if (gore.realType > 0) {
-				gore.type = gore.realType;
-				gore.realType = 0;
-			}
-		}
-
-		//in Terraria.Main.DrawGore and DrawGoreBehind replace type checks with this
-		internal static bool DrawBackGore(Gore gore) {
-			if (gore.modGore != null) {
-				return gore.modGore.DrawBehind(gore);
-			}
-			return (((gore.type >= 706 && gore.type <= 717) || gore.type == 943 || gore.type == 1147 || (gore.type >= 1160 && gore.type <= 1162)) && (gore.frame < 7 || gore.frame > 9));
+			GoreLoader.AddGore(Texture, this);
 		}
 
 		/// <summary>
 		/// Allows you to modify a gore's fields when it is created.
 		/// </summary>
-		public virtual void OnSpawn(Gore gore) {
-		}
+		public virtual void OnSpawn(Gore gore) { }
 
 		//in Terraria.Gore.Update at beginning of if block checking for active add
 		//  if(this.modGore != null && !this.modGore.Update(this)) { return; }
 		/// <summary>
 		/// Allows you to customize how you want this type of gore to behave. Return true to allow for vanilla gore updating to also take place; returns true by default.
 		/// </summary>
-		public virtual bool Update(Gore gore) {
-			return true;
-		}
+		public virtual bool Update(Gore gore) => true;
 
 		//at beginning of Terraria.Gore.Update add
 		//  if(this.modGore != null) { Color? modColor = this.modGore.GetAlpha(this, newColor);
@@ -120,15 +35,11 @@ namespace Terraria.ModLoader
 		/// Allows you to override the color this gore will draw in. Return null to draw it in the normal light color; returns null by default.
 		/// </summary>
 		/// <returns></returns>
-		public virtual Color? GetAlpha(Gore gore, Color lightColor) {
-			return null;
-		}
+		public virtual Color? GetAlpha(Gore gore, Color lightColor) => null;
 
 		/// <summary>
 		/// Allows you to determine whether or not this gore will draw behind tiles, etc. Returns false by default.
 		/// </summary>
-		public virtual bool DrawBehind(Gore gore) {
-			return false;
-		}
+		public virtual bool DrawBehind(Gore gore) => false;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModGore.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModGore.cs
@@ -15,8 +15,8 @@ namespace Terraria.ModLoader
 
 		public int Type { get; internal set; }
 
-		public override string Name => nameOverride;
-		public override string Texture => textureOverride;
+		public override string Name => nameOverride ?? base.Name;
+		public override string Texture => textureOverride ?? base.Texture;
 
 		protected override void Register() {
 			ModTypeLookup<ModGore>.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/ModGore.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModGore.cs
@@ -10,10 +10,17 @@ namespace Terraria.ModLoader
 		/// <summary> Allows you to copy the Update behavior of a different type of gore. This defaults to 0, which means no behavior is copied. </summary>
 		public int updateType = -1;
 
+		internal string nameOverride;
+		internal string textureOverride;
+
+		public int Type { get; internal set; }
+
+		public override string Name => nameOverride;
+		public override string Texture => textureOverride;
+
 		protected override void Register() {
 			ModTypeLookup<ModGore>.Register(this);
-
-			GoreLoader.AddGore(Texture, this);
+			GoreLoader.RegisterModGore(this);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This PR does the following:
- Fixes ModGore, as it just hasn't been working for some reason I don't even know.
- Splits ModGore into GoreLoader, improve some code quality in general.
- Turns ModGore into a ModTexturedType. Reduced the amount of hardcode in autoloading.
- Changes how Texture-only mod gores load. Now, for every such gore, a dummy ModGore is registered with ModName/TextureName FullName. This means that gores can now be gotten using Mod/ModContent.Find/TryFind, which do not use texture paths.
- Mod.AddGore is replaced with GoreLoader.AddGoreFromTexture, which does what you would think, i.e. what I described above.
- Removes by-texture-path GetGoreSlot methods, for less hardcode and way less confusion. Content devs seem to support the switch from texture paths to ModName/ContentName.
- Renamed Gore.modGore to Gore.ModGore. We did plenty of naming convention fixes like this, should just do it for everything on the main 1.4 branch.
- Splits tML's added fields of Gore.cs into Gore.TML.cs.
- Fixes tML's added fields not being reset in Gore.NewGore.
- Temporarily added ModContent.GoreType<T>(). I would like to replace all such methods with a generalized one.