### PR TITLE
Fixed multiple accessory-related issues.

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Orian.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Orian.cs
@@ -45,7 +45,7 @@ namespace Terraria.ModLoader.Default.Patreon
 			item.height = 18;
 		}
 
-		public override void UpdateVanity(Player player, EquipType type)
+		public override void EquipFrameEffects(Player player, EquipType type)
 		{
 			player.shoe = 0;
 		}

--- a/patches/tModLoader/Terraria/ModLoader/EquipLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/EquipLoader.cs
@@ -281,5 +281,17 @@ namespace Terraria.ModLoader
 
 			return 0;
 		}
+
+		/// <summary>
+		/// Hook Player.PlayerFrame
+		/// Calls each of the item's equipment texture's UpdateVanity hook.
+		/// </summary>
+		public static void EquipFrameEffects(Player player) {
+			foreach (EquipType type in EquipTypes) {
+				int slot = GetPlayerEquip(player, type);
+				EquipTexture texture = GetEquipTexture(type, slot);
+				texture?.FrameEffects(player, type);
+			}
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/EquipTexture.cs
+++ b/patches/tModLoader/Terraria/ModLoader/EquipTexture.cs
@@ -60,9 +60,9 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="player"></param>
 		/// <param name="type"></param>
-		public virtual void UpdateVanity(Player player, EquipType type) {
+		public virtual void FrameEffects(Player player, EquipType type) {
 			if (item != null) {
-				item.UpdateVanity(player, type);
+				item.EquipFrameEffects(player, type);
 			}
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -375,6 +375,12 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to give effects to this accessory when equipped in a vanity slot. Vanilla uses this for boot effects, wings and merman/werewolf visual flags
+		/// </summary>
+		public virtual void UpdateVanity(Item item, Player player) {
+		}
+
+		/// <summary>
 		/// Allows you to determine whether the player is wearing an armor set, and return a name for this set. 
 		/// If there is no armor set, return the empty string.
 		/// Returns the empty string by default.

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -816,10 +816,8 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookUpdateEquip = AddHook<Action<Item, Player>>(g => g.UpdateEquip);
-		//place in second for loop of Terraria.Player.UpdateEquips before prefix checking
-		//  call ItemLoader.UpdateEquip(this.armor[k], this)
 		/// <summary>
-		/// Calls ModItem.UpdateEquip and all GlobalItem.UpdateEquip hooks.
+		/// Hook at the end of Player.VanillaUpdateEquip can be called from modded slots for modded equipments
 		/// </summary>
 		public static void UpdateEquip(Item item, Player player) {
 			if (item.IsAir)
@@ -832,10 +830,8 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookUpdateAccessory = AddHook<Action<Item, Player, bool>>(g => g.UpdateAccessory);
-		//place at end of third for loop of Terraria.Player.UpdateEquips
-		//  call ItemLoader.UpdateAccessory(this.armor[l], this, this.hideVisual[l])
 		/// <summary>
-		/// Calls ModItem.UpdateAccessory and all GlobalItem.UpdateAccessory hooks.
+		/// Hook at the end of Player.ApplyEquipFunctional can be called from modded slots for modded equipments
 		/// </summary>
 		public static void UpdateAccessory(Item item, Player player, bool hideVisual) {
 			if (item.IsAir)
@@ -845,6 +841,20 @@ namespace Terraria.ModLoader
 
 			foreach (var g in HookUpdateAccessory.arr)
 				g.Instance(item).UpdateAccessory(item, player, hideVisual);
+		}
+
+		private static HookList HookUpdateVanity = AddHook<Action<Item, Player>>(g => g.UpdateVanity);
+		/// <summary>
+		/// Hook at the end of Player.ApplyEquipVanity can be called from modded slots for modded equipments
+		/// </summary>
+		public static void UpdateVanity(Item item, Player player) {
+			if (item.IsAir)
+				return;
+
+			item.modItem?.UpdateVanity(player);
+
+			foreach (var g in HookUpdateVanity.arr)
+				g.Instance(item).UpdateVanity(item, player);
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -857,17 +857,6 @@ namespace Terraria.ModLoader
 				g.Instance(item).UpdateVanity(item, player);
 		}
 
-		/// <summary>
-		/// Calls each of the item's equipment texture's UpdateVanity hook.
-		/// </summary>
-		public static void UpdateVanity(Player player) {
-			foreach (EquipType type in EquipLoader.EquipTypes) {
-				int slot = EquipLoader.GetPlayerEquip(player, type);
-				EquipTexture texture = EquipLoader.GetEquipTexture(type, slot);
-				texture?.UpdateVanity(player, type);
-			}
-		}
-
 		private static HookList HookUpdateArmorSet = AddHook<Action<Player, string>>(g => g.UpdateArmorSet);
 		//at end of Terraria.Player.UpdateArmorSets call ItemLoader.UpdateArmorSet(this, this.armor[0], this.armor[1], this.armor[2])
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1226,8 +1226,9 @@ namespace Terraria.ModLoader
 		/// Returns the wing item that the player is functionally using. If player.wingsLogic has been modified, so no equipped wing can be found to match what the player is using, this creates a new Item object to return.
 		/// </summary>
 		public static Item GetWing(Player player) {
+			//TODO: this doesn't work with wings in modded accessory slots
 			Item item = null;
-			for (int k = 3; k < 8 + player.extraAccessorySlots; k++) {
+			for (int k = 3; k < 10; k++) {
 				if (player.armor[k].wingSlot == player.wingsLogic) {
 					item = player.armor[k];
 				}

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -505,7 +505,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="player">The player.</param>
 		/// <param name="type">The type.</param>
-		public virtual void UpdateVanity(Player player, EquipType type) {
+		public virtual void EquipFrameEffects(Player player, EquipType type) {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -494,6 +494,13 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to give effects to this accessory when equipped in a vanity slot. Vanilla uses this for boot effects, wings and merman/werewolf visual flags
+		/// </summary>
+		/// <param name="player">The player.</param>
+		public virtual void UpdateVanity(Player player) {
+		}
+
+		/// <summary>
 		/// Allows you to create special effects (such as dust) when this item's equipment texture of the given equipment type is displayed on the player. Note that this hook is only ever called through this item's associated equipment texture.
 		/// </summary>
 		/// <param name="player">The player.</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -230,10 +230,7 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Called after Update Accessories. 
 		/// </summary>
-		/// <param name="wallSpeedBuff"></param>
-		/// <param name="tileSpeedBuff"></param>
-		/// <param name="tileRangeBuff"></param>
-		public virtual void UpdateEquips(ref bool wallSpeedBuff, ref bool tileSpeedBuff, ref bool tileRangeBuff) {
+		public virtual void UpdateEquips() {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/PlayerHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerHooks.cs
@@ -308,12 +308,12 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		private delegate void DelegateUpdateEquips(ref bool wallSpeedBuff, ref bool tileSpeedBuff, ref bool tileRangeBuff);
+		private delegate void DelegateUpdateEquips();
 		private static HookList HookUpdateEquips = AddHook<DelegateUpdateEquips>(p => p.UpdateEquips);
 
-		public static void UpdateEquips(Player player, ref bool wallSpeedBuff, ref bool tileSpeedBuff, ref bool tileRangeBuff) {
+		public static void UpdateEquips(Player player) {
 			foreach (int index in HookUpdateEquips.arr) {
-				player.modPlayers[index].UpdateEquips(ref wallSpeedBuff, ref tileSpeedBuff, ref tileRangeBuff);
+				player.modPlayers[index].UpdateEquips();
 			}
 		}
 

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2337,7 +2337,7 @@
  
 +			//TODO: Do these hooks go inside or outside the conditional?
 +			PlayerHooks.FrameEffects(this);
-+			ItemLoader.UpdateVanity(this);
++			EquipLoader.EquipFrameEffects(this);
  			if (!isDisplayDollOrInanimate) {
  				if (((body == 68 && legs == 57 && head == 106) || (body == 74 && legs == 63 && head == 106)) && Main.rand.Next(10) == 0) {
  					int num3 = Dust.NewDust(new Vector2(position.X - velocity.X * 2f, position.Y - 2f - velocity.Y * 2f), width, height, 43, 0f, 0f, 100, new Color(255, 0, 255), 0.3f);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1029,50 +1029,51 @@
  			}
  
  			if (whoAmI == Main.myPlayer && luckPotion != oldLuckPotion) {
-@@ -8256,12 +_,14 @@
+@@ -8256,12 +_,19 @@
  			}
  		}
  
 -		public void UpdateEquips(int i) {
 +		//public void UpdateEquips(int i) {
-+		public void VanillaUpdateInventory(Item item) {
++		public void VanillaPreUpdateInventory() {
  			if (inventory[selectedItem].type == 277 && (!mount.Active || !mount.Cart))
  				trident = true;
++		}
  
--			for (int j = 0; j < 58; j++) {
--				int type = inventory[j].type;
-+			//for (int j = 0; j < 58; j++)
++		public void VanillaUpdateInventory(Item item) {
++			/*
+ 			for (int j = 0; j < 58; j++) {
+ 				int type = inventory[j].type;
++			*/
 +			{
 +				int type = item.type;
  				if ((type == 15 || type == 707) && accWatch < 1)
  					accWatch = 1;
  
-@@ -8333,14 +_,21 @@
+@@ -8333,13 +_,21 @@
  
  				if (type == 4743)
  					hasFootball = true;
--			}
- 
++
 +				ItemLoader.UpdateInventory(item, this);
-+			}
+ 			}
+ 
++		}
++
++		public void VanillaPostUpdateInventory() {
  			if (inventory[58].type == 4743)
  				hasFootball = true;
 +		}
  
 -			for (int k = 0; k < 10; k++) {
 -				if (!IsAValidEquipmentSlotForIteration(k) || (armor[k].expertOnly && !Main.expertMode))
--					continue;
 +		public void VanillaUpdateEquip(Item item) {
-+			// for (int k = 0; k < 10; k++)
-+			// fake array and loop to keep patches small
 +			Item[] armor = {item};
-+			int k = 0;
-+			{
-+				if (!IsAValidEquipmentSlotForIteration(k) || (armor[k].expertOnly && !Main.expertMode) || (armor[k].masterOnly && !Main.masterMode))
-+					return;
++			for (k = 0; k < 1; k++) {
++				if ((armor[k].expertOnly && !Main.expertMode) || (armor[k].masterOnly && !Main.masterMode))
+ 					continue;
  
  				int type2 = armor[k].type;
- 				if ((type2 == 15 || type2 == 707) && accWatch < 1)
 @@ -8557,10 +_,13 @@
  					armorPenetration += 5;
  
@@ -1158,84 +1159,39 @@
  				}
  
  				if (armor[k].prefix == 73)
-@@ -9245,56 +_,89 @@
+@@ -9245,6 +_,22 @@
  
  				if (armor[k].prefix == 80)
  					meleeSpeed += 0.04f;
 +
 +				ItemLoader.UpdateEquip(armor[k], this);
- 			}
- 
--			equippedAnyWallSpeedAcc = false;
--			equippedAnyTileSpeedAcc = false;
--			equippedAnyTileRangeAcc = false;
- 			if (whoAmI == Main.myPlayer)
- 				Main.musicBoxNotModifiedByVolume = -1;
--
--			for (int l = 3; l < 10; l++) {
--				if (IsAValidEquipmentSlotForIteration(l))
--					ApplyEquipFunctional(l, armor[l]);
-+		}
-+		public void VanillaUpdateAccessory(int l, Item item, bool hideVisual, ref bool flag, ref bool flag2, ref bool flag3) {
-+			if (IsAValidEquipmentSlotForIteration(l))
-+				ApplyEquipFunctional(l, item);
-+
-+			if (SoundLoader.itemToMusic.ContainsKey(item.type))
-+				Main.musicBox2 = SoundLoader.itemToMusic[item.type];
-+
-+			if (item.wingSlot > 0) {
-+				if (!hideVisual || velocity.Y != 0f && !mount.Active)
-+					wings = item.wingSlot;
-+
-+				wingsLogic = item.wingSlot;
 +			}
-+
-+			ApplyEquipVanity(l, item);
-+			ItemLoader.UpdateAccessory(item, this, hideVisual);
 +		}
 +
-+		public void VanillaUpdateVanityAccessory(Item item) {
-+			//for (int n = 13; n < 18 + this.extraAccessorySlots; n++)
-+			{
-+				int type3 = item.type;
-+				if (item.wingSlot > 0)
-+					wings = item.wingSlot;
-+			}
-+			if (wet && ShouldFloatInWater)
-+				accFlipper = true;
-+		}
-+
-+		public void UpdateEquips(int i) //Noise for the Diff
++		public void UpdateEquips(int i)
 +		{
++			VanillaPreUpdateInventory();
 +			for (int j = 0; j < 58; j++) {
 +				VanillaUpdateInventory(inventory[j]);
 +			}
++			VanillaPostUpdateInventory();
 +
-+			for (int k = 0; k < 8 + extraAccessorySlots; k++) {
-+				VanillaUpdateEquip(armor[k]);
-+			}
-+
-+			bool flag = false;
-+			bool flag2 = false;
-+			bool flag3 = false;
-+			for (int l = 3; l < 8 + extraAccessorySlots; l++) {
-+				VanillaUpdateAccessory(l, armor[l], hideVisibleAccessory[l], ref flag, ref flag2, ref flag3);
-+			}
-+
-+			PlayerHooks.UpdateEquips(this, ref flag, ref flag2, ref flag3);
-+			// wing loop is merged into VanillaUpdateAccessory
-+			for (int n = 13; n < 18 + extraAccessorySlots; n++) {
-+				if (IsAValidEquipmentSlotForIteration(n))
-+					ApplyEquipVanity(n, armor[n]);
-+			}
-+
-+			PlayerHooks.UpdateVanityAccessories(this);
-+
-+			if (dd2Accessory) {
-+				minionDamage += 0.1f;
-+				maxTurrets++;
++			for (int k = 0; k < 10; k++) {
++				if (IsAValidEquipmentSlotForIteration(k))
++					VanillaUpdateEquip(armor[k]);
  			}
  
+ 			equippedAnyWallSpeedAcc = false;
+@@ -9255,21 +_,24 @@
+ 
+ 			for (int l = 3; l < 10; l++) {
+ 				if (IsAValidEquipmentSlotForIteration(l))
+-					ApplyEquipFunctional(l, armor[l]);
++					ApplyEquipFunctional(armor[l], hideVisibleAccessory[l]);
+ 			}
+ 
++			PlayerHooks.UpdateEquips(this);
++			
  			if (skyStoneEffects) {
  				lifeRegen += 2;
  				statDefense += 4;
@@ -1256,36 +1212,61 @@
  				minionKB += 0.5f;
  			}
  
--			if (dd2Accessory) {
--				minionDamage += 0.1f;
--				maxTurrets++;
--			}
--
--			for (int m = 3; m < 10; m++) {
--				if (armor[m].wingSlot > 0 && IsAValidEquipmentSlotForIteration(m)) {
--					if (!hideVisibleAccessory[m] || (velocity.Y != 0f && !mount.Active))
--						wings = armor[m].wingSlot;
--
--					wingsLogic = armor[m].wingSlot;
--				}
--			}
--
--			for (int n = 13; n < 20; n++) {
--				if (IsAValidEquipmentSlotForIteration(n))
--					ApplyEquipVanity(n, armor[n]);
--			}
--
--			if (wet && ShouldFloatInWater)
--				accFlipper = true;
--
- 			if (whoAmI == Main.myPlayer && Main.SceneMetrics.HasClock && accWatch < 3)
- 				accWatch++;
+@@ -9278,6 +_,7 @@
+ 				maxTurrets++;
+ 			}
  
-@@ -9494,7 +_,7 @@
++			/* wing loop is merged into ApplyEquipFunctional
+ 			for (int m = 3; m < 10; m++) {
+ 				if (armor[m].wingSlot > 0 && IsAValidEquipmentSlotForIteration(m)) {
+ 					if (!hideVisibleAccessory[m] || (velocity.Y != 0f && !mount.Active))
+@@ -9286,12 +_,15 @@
+ 					wingsLogic = armor[m].wingSlot;
+ 				}
+ 			}
++			*/
+ 
+ 			for (int n = 13; n < 20; n++) {
+ 				if (IsAValidEquipmentSlotForIteration(n))
+ 					ApplyEquipVanity(n, armor[n]);
+ 			}
+ 
++			PlayerHooks.UpdateVanityAccessories(this);
++
+ 			if (wet && ShouldFloatInWater)
+ 				accFlipper = true;
+ 
+@@ -9463,6 +_,10 @@
  		}
  
- 		private void ApplyEquipFunctional(int itemSlot, Item currentItem) {
+ 		private void ApplyEquipVanity(int itemSlot, Item currentItem) {
++			ApplyEquipVanity(currentItem); //remove itemSlot parameter and make public so mods can call from their own accessory slots
++		}
++
++		public void ApplyEquipVanity(Item currentItem) {
+ 			int type = currentItem.type;
+ 			if (currentItem.wingSlot > 0)
+ 				wings = currentItem.wingSlot;
+@@ -9484,6 +_,8 @@
+ 				ApplyMusicBox(currentItem);
+ 
+ 			UpdateBootVisualEffects(currentItem);
++
++			ItemLoader.UpdateVanity(currentItem, this);
+ 		}
+ 
+ 		private WingStats GetWingStats(int wingID) {
+@@ -9493,8 +_,12 @@
+ 			return ArmorIDs.Wing.Sets.Stats[wingID];
+ 		}
+ 
+-		private void ApplyEquipFunctional(int itemSlot, Item currentItem) {
 -			if (currentItem.expertOnly && !Main.expertMode)
++		// made public and itemSlot parameter removed, so mods can call this method from their own accessory slots
++		public void ApplyEquipFunctional(Item currentItem, bool hideVisual) {
++			int itemSlot = 0;
++			bool[] hideVisibleAccessory = { hideVisual };
++
 +			if ((currentItem.expertOnly && !Main.expertMode) || (currentItem.masterOnly && !Main.masterMode))
  				return;
  
@@ -1351,7 +1332,7 @@
  				SoundEngine.PlaySound(SoundID.Item166, base.Center);
  				int num3 = -1;
  				if (Main.curMusic == 1)
-@@ -10521,10 +_,14 @@
+@@ -10521,13 +_,26 @@
  					currentItem.SetDefaults(5040);
  				else if (Main.curMusic == 89)
  					currentItem.SetDefaults(5044);
@@ -1362,11 +1343,33 @@
 +					;//Silence
 +				else if (Main.curMusic < Main.maxMusic)
  					currentItem.SetDefaults(num3 + 562);
-+				else if (SoundLoader.musicToItem.ContainsKey(Main.curMusic))
-+					currentItem.SetDefaults(SoundLoader.musicToItem[Main.curMusic]);
++				else if (SoundLoader.musicToItem.TryGetValue(Main.curMusic, out int modMusicBoxType))
++					currentItem.SetDefaults(modMusicBoxType);
  			}
  
  			ApplyMusicBox(currentItem);
++
++			if (currentItem.wingSlot > 0) {
++				if (!hideVisibleAccessory[itemSlot] || velocity.Y != 0f && !mount.Active)
++					wings = currentItem.wingSlot;
++
++				wingsLogic = currentItem.wingSlot;
++			}
++
++			ItemLoader.UpdateAccessory(currentItem, this, hideVisual);
+ 		}
+ 
+ 		private void ApplyMusicBox(Item currentItem) {
+@@ -10714,6 +_,9 @@
+ 			if (currentItem.type == 5044)
+ 				Main.musicBox2 = 85;
+ 
++			if (SoundLoader.itemToMusic.TryGetValue(currentItem.type, out int modMusicBox))
++				Main.musicBox2 = modMusicBox;
++
+ 			Main.musicBoxNotModifiedByVolume = Main.musicBox2;
+ 		}
+ 
 @@ -10746,10 +_,13 @@
  
  			if (head == 112 && body == 75 && legs == 64) {

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1065,11 +1065,11 @@
  				hasFootball = true;
 +		}
  
--			for (int k = 0; k < 10; k++) {
--				if (!IsAValidEquipmentSlotForIteration(k) || (armor[k].expertOnly && !Main.expertMode))
 +		public void VanillaUpdateEquip(Item item) {
 +			Item[] armor = {item};
-+			for (k = 0; k < 1; k++) {
+-			for (int k = 0; k < 10; k++) {
++			for (int k = 0; k < 1; k++) {
+-				if (!IsAValidEquipmentSlotForIteration(k) || (armor[k].expertOnly && !Main.expertMode))
 +				if ((armor[k].expertOnly && !Main.expertMode) || (armor[k].masterOnly && !Main.masterMode))
  					continue;
  

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1158,7 +1158,7 @@
  				}
  
  				if (armor[k].prefix == 73)
-@@ -9245,56 +_,90 @@
+@@ -9245,56 +_,89 @@
  
  				if (armor[k].prefix == 80)
  					meleeSpeed += 0.04f;
@@ -1177,12 +1177,11 @@
 -					ApplyEquipFunctional(l, armor[l]);
 +		}
 +		public void VanillaUpdateAccessory(int l, Item item, bool hideVisual, ref bool flag, ref bool flag2, ref bool flag3) {
-+
 +			if (IsAValidEquipmentSlotForIteration(l))
 +				ApplyEquipFunctional(l, item);
 +
 +			if (SoundLoader.itemToMusic.ContainsKey(item.type))
-+					Main.musicBox2 = SoundLoader.itemToMusic[item.type];
++				Main.musicBox2 = SoundLoader.itemToMusic[item.type];
 +
 +			if (item.wingSlot > 0) {
 +				if (!hideVisual || velocity.Y != 0f && !mount.Active)

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -53,7 +53,7 @@
  		public DateTime lastDeathTime;
  		public bool showLastDeath;
 -		public int extraAccessorySlots = 2;
-+		public int extraAccessorySlots;
++		private int extraAccessorySlots; //unused vanilla field, noob trap
  		public bool extraAccessory;
  		private bool dontConsumeWand;
  		public int tankPet = -1;
@@ -1519,21 +1519,6 @@
  								SmartSelect_SelectItem(i);
  								return;
  						}
-@@ -12667,10 +_,11 @@
- 		public static float GetClosestRollLuck(int x, int y, int range) => Main.player[FindClosest(new Vector2(x * 16, y * 16), 1, 1)].RollLuck(range);
- 
- 		public void ResetEffects() {
-+			extraAccessorySlots = 0;
-+			if (Main.masterMode || Main.gameMenu)
-+				extraAccessorySlots += 1;
- 			if (extraAccessory && (Main.expertMode || Main.gameMenu))
--				extraAccessorySlots = 1;
-+				extraAccessorySlots += 1;
--			else
--				extraAccessorySlots = 0;
- 
- 			fairyBoots = false;
- 			moonLordLegs = false;
 @@ -12689,13 +_,14 @@
  			lifeRegen = 0;
  			manaCost = 1f;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1225,7 +1225,7 @@
 +
 +			PlayerHooks.UpdateEquips(this, ref flag, ref flag2, ref flag3);
 +			PlayerHooks.UpdateVanityAccessories(this);
-+			// wing loop and vanity thing are merged into VanillaUpdateAccessory
++			// wing loop is merged into VanillaUpdateAccessory
 +			for (int n = 13; n < 18 + extraAccessorySlots; n++) {
 +				if (IsAValidEquipmentSlotForIteration(n))
 +					ApplyEquipVanity(n, armor[n]);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1158,7 +1158,7 @@
  				}
  
  				if (armor[k].prefix == 73)
-@@ -9245,56 +_,89 @@
+@@ -9245,56 +_,90 @@
  
  				if (armor[k].prefix == 80)
  					meleeSpeed += 0.04f;
@@ -1224,12 +1224,13 @@
 +			}
 +
 +			PlayerHooks.UpdateEquips(this, ref flag, ref flag2, ref flag3);
-+			PlayerHooks.UpdateVanityAccessories(this);
 +			// wing loop is merged into VanillaUpdateAccessory
 +			for (int n = 13; n < 18 + extraAccessorySlots; n++) {
 +				if (IsAValidEquipmentSlotForIteration(n))
 +					ApplyEquipVanity(n, armor[n]);
 +			}
++
++			PlayerHooks.UpdateVanityAccessories(this);
 +
 +			if (dd2Accessory) {
 +				minionDamage += 0.1f;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -48,6 +48,15 @@
  		public OverheadMessage chatOverhead;
  		public SelectionRadial DpadRadial = new SelectionRadial();
  		public SelectionRadial CircularRadial = new SelectionRadial(SelectionRadial.SelectionMode.RadialCircular);
+@@ -436,7 +_,7 @@
+ 		public Vector2 lastDeathPostion;
+ 		public DateTime lastDeathTime;
+ 		public bool showLastDeath;
+-		public int extraAccessorySlots = 2;
++		public int extraAccessorySlots;
+ 		public bool extraAccessory;
+ 		private bool dontConsumeWand;
+ 		public int tankPet = -1;
 @@ -690,7 +_,7 @@
  		public bool poundRelease;
  		public float ghostFade;
@@ -1149,7 +1158,7 @@
  				}
  
  				if (armor[k].prefix == 73)
-@@ -9245,15 +_,20 @@
+@@ -9245,56 +_,89 @@
  
  				if (armor[k].prefix == 80)
  					meleeSpeed += 0.04f;
@@ -1162,50 +1171,28 @@
 -			equippedAnyTileRangeAcc = false;
  			if (whoAmI == Main.myPlayer)
  				Main.musicBoxNotModifiedByVolume = -1;
-+		}
-+		public void VanillaUpdateAccessory(int i, Item item, bool hideVisual, ref bool flag, ref bool flag2, ref bool flag3) {
-+			// for (int l = 3; l < 10 + extraAccessorySlots; l++)
-+			// fake array and loop to keep patches small
-+			var armor = new[] { item };
-+			int l = 0;
- 
+-
 -			for (int l = 3; l < 10; l++) {
-+			{
- 				if (IsAValidEquipmentSlotForIteration(l))
- 					ApplyEquipFunctional(l, armor[l]);
- 			}
-@@ -9262,15 +_,58 @@
- 				lifeRegen += 2;
- 				statDefense += 4;
- 				meleeSpeed += 0.1f;
--				meleeDamage += 0.1f;
-+				allDamage += 0.1f;
-+				//meleeDamage += 0.1f;
- 				meleeCrit += 2;
--				rangedDamage += 0.1f;
-+				//rangedDamage += 0.1f;
- 				rangedCrit += 2;
--				magicDamage += 0.1f;
-+				//magicDamage += 0.1f;
- 				magicCrit += 2;
- 				pickSpeed -= 0.15f;
--				minionDamage += 0.1f;
-+				//minionDamage += 0.1f;
- 				minionKB += 0.5f;
+-				if (IsAValidEquipmentSlotForIteration(l))
+-					ApplyEquipFunctional(l, armor[l]);
++		}
++		public void VanillaUpdateAccessory(int l, Item item, bool hideVisual, ref bool flag, ref bool flag2, ref bool flag3) {
 +
-+				if (SoundLoader.itemToMusic.ContainsKey(armor[l].type))
-+					Main.musicBox2 = SoundLoader.itemToMusic[armor[l].type];
-+			}
++			if (IsAValidEquipmentSlotForIteration(l))
++				ApplyEquipFunctional(l, item);
 +
-+			if (armor[l].wingSlot > 0) {
++			if (SoundLoader.itemToMusic.ContainsKey(item.type))
++					Main.musicBox2 = SoundLoader.itemToMusic[item.type];
++
++			if (item.wingSlot > 0) {
 +				if (!hideVisual || velocity.Y != 0f && !mount.Active)
-+					wings = armor[l].wingSlot;
++					wings = item.wingSlot;
 +
-+				wingsLogic = armor[l].wingSlot;
++				wingsLogic = item.wingSlot;
 +			}
 +
-+			ApplyEquipVanity(l, armor[l]);
-+			ItemLoader.UpdateAccessory(armor[l], this, hideVisual);
++			ApplyEquipVanity(l, item);
++			ItemLoader.UpdateAccessory(item, this, hideVisual);
 +		}
 +
 +		public void VanillaUpdateVanityAccessory(Item item) {
@@ -1225,22 +1212,55 @@
 +				VanillaUpdateInventory(inventory[j]);
 +			}
 +
-+			for (int k = 0; k < 10 + extraAccessorySlots; k++) {
++			for (int k = 0; k < 8 + extraAccessorySlots; k++) {
 +				VanillaUpdateEquip(armor[k]);
 +			}
 +
 +			bool flag = false;
 +			bool flag2 = false;
 +			bool flag3 = false;
-+			for (int l = 3; l < 10 + extraAccessorySlots; l++) {
-+				VanillaUpdateAccessory(i, armor[l], hideVisibleAccessory[l], ref flag, ref flag2, ref flag3);
++			for (int l = 3; l < 8 + extraAccessorySlots; l++) {
++				VanillaUpdateAccessory(l, armor[l], hideVisibleAccessory[l], ref flag, ref flag2, ref flag3);
++			}
++
++			PlayerHooks.UpdateEquips(this, ref flag, ref flag2, ref flag3);
++			PlayerHooks.UpdateVanityAccessories(this);
++			// wing loop and vanity thing are merged into VanillaUpdateAccessory
++			for (int n = 13; n < 18 + extraAccessorySlots; n++) {
++				if (IsAValidEquipmentSlotForIteration(n))
++					ApplyEquipVanity(n, armor[n]);
++			}
++
++			if (dd2Accessory) {
++				minionDamage += 0.1f;
++				maxTurrets++;
  			}
  
- 			if (dd2Accessory) {
-@@ -9278,23 +_,14 @@
- 				maxTurrets++;
+ 			if (skyStoneEffects) {
+ 				lifeRegen += 2;
+ 				statDefense += 4;
+ 				meleeSpeed += 0.1f;
+-				meleeDamage += 0.1f;
++				allDamage += 0.1f;
++				//meleeDamage += 0.1f;
+ 				meleeCrit += 2;
+-				rangedDamage += 0.1f;
++				//rangedDamage += 0.1f;
+ 				rangedCrit += 2;
+-				magicDamage += 0.1f;
++				//magicDamage += 0.1f;
+ 				magicCrit += 2;
+ 				pickSpeed -= 0.15f;
+-				minionDamage += 0.1f;
++				//minionDamage += 0.1f;
+ 				minionKB += 0.5f;
  			}
  
+-			if (dd2Accessory) {
+-				minionDamage += 0.1f;
+-				maxTurrets++;
+-			}
+-
 -			for (int m = 3; m < 10; m++) {
 -				if (armor[m].wingSlot > 0 && IsAValidEquipmentSlotForIteration(m)) {
 -					if (!hideVisibleAccessory[m] || (velocity.Y != 0f && !mount.Active))
@@ -1250,17 +1270,14 @@
 -				}
 -			}
 -
-+			PlayerHooks.UpdateEquips(this, ref flag, ref flag2, ref flag3);
-+			//wing loop merged into VanillaUpdateAccessory
- 			for (int n = 13; n < 20; n++) {
- 				if (IsAValidEquipmentSlotForIteration(n))
- 					ApplyEquipVanity(n, armor[n]);
- 			}
- 
+-			for (int n = 13; n < 20; n++) {
+-				if (IsAValidEquipmentSlotForIteration(n))
+-					ApplyEquipVanity(n, armor[n]);
+-			}
+-
 -			if (wet && ShouldFloatInWater)
 -				accFlipper = true;
 -
-+			PlayerHooks.UpdateVanityAccessories(this);
  			if (whoAmI == Main.myPlayer && Main.SceneMetrics.HasClock && accWatch < 3)
  				accWatch++;
  
@@ -1499,6 +1516,21 @@
  								SmartSelect_SelectItem(i);
  								return;
  						}
+@@ -12667,10 +_,11 @@
+ 		public static float GetClosestRollLuck(int x, int y, int range) => Main.player[FindClosest(new Vector2(x * 16, y * 16), 1, 1)].RollLuck(range);
+ 
+ 		public void ResetEffects() {
++			extraAccessorySlots = 0;
++			if (Main.masterMode || Main.gameMenu)
++				extraAccessorySlots += 1;
+ 			if (extraAccessory && (Main.expertMode || Main.gameMenu))
+-				extraAccessorySlots = 1;
++				extraAccessorySlots += 1;
+-			else
+-				extraAccessorySlots = 0;
+ 
+ 			fairyBoots = false;
+ 			moonLordLegs = false;
 @@ -12689,13 +_,14 @@
  			lifeRegen = 0;
  			manaCost = 1f;


### PR DESCRIPTION
- VanillaUpdateAccessory no longer erroneously uses player.whoAmI as an input.
- VanillaUpdateAccessory and ApplyEquipsVanity now account for extra acc slots properly, preventing the game from hanging upon having one.
- extraAccessorySlots now properly updates itself in ResetEffects.
- skyStoneEffects (Sun/Moon Stone statsheet) is no longer applied for every slot starting with the one where the stone in question is equipped.