### PR TITLE
Actually fix ExampleShield (best practice)

### DIFF
--- a/ExampleMod/Content/Items/Accessories/ExampleShield.cs
+++ b/ExampleMod/Content/Items/Accessories/ExampleShield.cs
@@ -64,11 +64,12 @@ namespace ExampleMod.Content.Items.Accessories
 		public int DashTimer = 0; // frames remaining in the dash
 
 		public override void ResetEffects() {
-			//ResetEffects() is called not long after player.doubleTapCardinalTimer's values have been set
+			// Reset our equipped flag. If the accessory is equipped somewhere, ExampleShield.UpdateAccessory will be called and set the flag before PreUpdateMovement
 			DashAccessoryEquipped = false;
 
-			//When a directional key is pressed and released, vanilla starts a 15 tick (1/4 second) timer during which a second press activates a dash
-			//If the timers are set to 15, then this is the first press just processed by the vanilla logic.  Otherwise, it's a double-tap
+			// ResetEffects is called not long after player.doubleTapCardinalTimer's values have been set
+			// When a directional key is pressed and released, vanilla starts a 15 tick (1/4 second) timer during which a second press activates a dash
+			// If the timers are set to 15, then this is the first press just processed by the vanilla logic.  Otherwise, it's a double-tap
 			if (player.controlDown && player.releaseDown && player.doubleTapCardinalTimer[DashDown] < 15) {
 				DashDir = DashDown;
 			}


### PR DESCRIPTION
### What are the changes to ExampleMod?
The dash accessory was implemented by enumerating the player's accessory slots. This approach is contrary to the vanilla and tML design where accessories enable capabilities on the player, and prevents all accessory related hooks or custom slots from working with it.

The new design also puts the movement code in the `PreUpdateMovement` hook, consistent with other movement affecting code.

Overall operation should be easier to understand. Posting here for feedback/thoughts.