### PR TITLE
made TagSerializer implement ILoadable

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/IO/TagSerializer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TagSerializer.cs
@@ -72,7 +72,7 @@ namespace Terraria.ModLoader.IO
 			return null;
 		}
 
-		protected override void Register() {
+		protected sealed override void Register() {
 			AddSerializer(this);
 		}
 	}

--- a/patches/tModLoader/Terraria/ModLoader/IO/TagSerializer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TagSerializer.cs
@@ -7,7 +7,7 @@ using Terraria.DataStructures;
 
 namespace Terraria.ModLoader.IO
 {
-	public abstract class TagSerializer : ILoadable
+	public abstract class TagSerializer : ModType
 	{
 		public abstract Type Type { get; }
 		public abstract Type TagType { get; }
@@ -51,7 +51,7 @@ namespace Terraria.ModLoader.IO
 			return false;
 		}
 
-		public static void AddSerializer(TagSerializer serializer) {
+		internal static void AddSerializer(TagSerializer serializer) {
 			serializers.Add(serializer.Type, serializer);
 		}
 
@@ -72,11 +72,8 @@ namespace Terraria.ModLoader.IO
 			return null;
 		}
 
-		public void Load(Mod mod) {
+		protected override void Register() {
 			AddSerializer(this);
-		}
-
-		public void Unload() {
 		}
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/IO/TagSerializer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TagSerializer.cs
@@ -7,7 +7,7 @@ using Terraria.DataStructures;
 
 namespace Terraria.ModLoader.IO
 {
-	public abstract class TagSerializer
+	public abstract class TagSerializer : ILoadable
 	{
 		public abstract Type Type { get; }
 		public abstract Type TagType { get; }
@@ -70,6 +70,13 @@ namespace Terraria.ModLoader.IO
 			}
 
 			return null;
+		}
+
+		public void Load(Mod mod) {
+			AddSerializer(this);
+		}
+
+		public void Unload() {
 		}
 	}
 


### PR DESCRIPTION
### What is the new feature?
TagSerializer implements ILoadable.

### Why should this be part of tModLoader?
It simply grants peace of mind to the average modder. I think that whenever possible with these kind of OOP objects that only get instantiated once, at load time, they should always be automatically handled. Unless they have to explicitly defined, which TagSerializers usually don't have to be, the API should just do it for the user.