### PR TITLE
Added armor penetration as a statistic for items and projectiles.

### DIFF
--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -23,6 +23,11 @@ namespace Terraria
 		/// </summary>
 		public DamageClass DamageType { get; set; }
 
+		/// <summary>
+		/// The amount of defense this Item can ignore.
+		/// </summary>
+		public int armorPenetration;
+
 		// Get
 
 		/// <summary> Gets the instance of the specified GlobalItem type. This will throw exceptions on failure. </summary>

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -369,12 +369,13 @@
  				netID = 0;
  				type = 0;
  				stack = 0;
-@@ -44889,14 +_,18 @@
+@@ -44889,14 +_,19 @@
  		public void ResetStats(int Type) {
  			tooltipContext = -1;
  			BestiaryNotes = null;
 +			modItem = null;
 +			globalItems = new GlobalItem[0];
++			armorPenetration = 0;
  			sentry = false;
  			canBePlacedInVanityRegardlessOfConditions = false;
  			DD2Summon = false;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -912,6 +912,15 @@
  				if (buffType[j] == 1) {
  					lavaImmune = true;
  					fireWalk = true;
+@@ -6488,7 +_,7 @@
+ 					manaRegenBonus += 2;
+ 				}
+ 				else if (buffType[j] == 159 && inventory[selectedItem].melee) {
+-					armorPenetration = 12;
++					armorPenetration += 12;
+ 				}
+ 				else if (buffType[j] == 192) {
+ 					pickSpeed -= 0.2f;
 @@ -6716,10 +_,13 @@
  					}
  				}
@@ -2982,7 +2991,7 @@
  				if (Main.netMode != 0)
  					NetMessage.SendPlayerHurt(i, playerDeathReason, num, direction, flag, pvp: true, -1);
  
-@@ -30638,6 +_,11 @@
+@@ -30638,14 +_,24 @@
  							}
  
  							int num4 = Main.DamageVar(num, luck);
@@ -2994,8 +3003,11 @@
  							StatusToNPC(sItem.type, i);
  							if (Main.npc[i].life > 5)
  								OnHit(Main.npc[i].Center.X, Main.npc[i].Center.Y, Main.npc[i]);
-@@ -30646,6 +_,11 @@
- 								num4 += Main.npc[i].checkArmorPenetration(armorPenetration);
+ 
+-							if (armorPenetration > 0)
+-								num4 += Main.npc[i].checkArmorPenetration(armorPenetration);
++							if (armorPenetration + sItem.armorPenetration != 0)
++								num4 += Main.npc[i].checkArmorPenetration(armorPenetration + sItem.armorPenetration);
  
  							int dmgDone = (int)Main.npc[i].StrikeNPC(num4, knockBack, direction, flag);
 +

--- a/patches/tModLoader/Terraria/Projectile.TML.cs
+++ b/patches/tModLoader/Terraria/Projectile.TML.cs
@@ -18,6 +18,11 @@ namespace Terraria
 		/// </summary>
 		public DamageClass DamageType { get; set; }
 
+		/// <summary>
+		/// The amount of defense this Projectile can ignore.
+		/// </summary>
+		public int armorPenetration;
+
 		// Get
 
 		/// <summary> Gets the instance of the specified GlobalProjectile type. This will throw exceptions on failure. </summary>

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -85,7 +85,7 @@
  				for (int j = 0; j < 200; j++) {
  					perIDStaticNPCImmunity[i][j] = 0u;
  				}
-@@ -217,7 +_,31 @@
+@@ -217,7 +_,32 @@
  			}
  		}
  
@@ -113,10 +113,83 @@
  		public void SetDefaults(int Type) {
 +			modProjectile = null;
 +			globalProjectiles = new GlobalProjectile[0];
++			armorPenetration = 0;
 +			nameOverride = null;
  			ownerHitCheckDistance = 1000f;
  			counterweight = false;
  			sentry = false;
+@@ -1811,6 +_,7 @@
+ 				alpha = 255;
+ 				ignoreWater = true;
+ 				magic = true;
++				armorPenetration = 10;
+ 			}
+ 			else if (type == 153) {
+ 				width = 18;
+@@ -2150,6 +_,7 @@
+ 				timeLeft = 600;
+ 				magic = true;
+ 				extraUpdates = 3;
++				armorPenetration = 10;
+ 			}
+ 			else if (type == 190) {
+ 				width = 22;
+@@ -4855,6 +_,7 @@
+ 				ignoreWater = true;
+ 				magic = true;
+ 				light = 0.2f;
++				armorPenetration = 10;
+ 			}
+ 			else if (type == 495) {
+ 				arrow = true;
+@@ -5122,6 +_,7 @@
+ 				extraUpdates = 1;
+ 				usesLocalNPCImmunity = true;
+ 				localNPCHitCooldown = 10;
++				armorPenetration = 25;
+ 			}
+ 			else if (type == 533) {
+ 				netImportant = true;
+@@ -5527,6 +_,7 @@
+ 				melee = true;
+ 				penetrate = -1;
+ 				ownerHitCheck = true;
++				armorPenetration = 20;
+ 			}
+ 			else if (type == 596) {
+ 				width = 8;
+@@ -6610,6 +_,7 @@
+ 				tileCollide = false;
+ 				usesLocalNPCImmunity = true;
+ 				localNPCHitCooldown = 10;
++				armorPenetration = 25;
+ 			}
+ 			else if (type == 728) {
+ 				width = 24;
+@@ -7235,6 +_,7 @@
+ 				timeLeft = 60;
+ 				aiStyle = 169;
+ 				localNPCHitCooldown = 40;
++				armorPenetration = 25;
+ 			}
+ 			else if (type == 865) {
+ 				netImportant = true;
+@@ -7590,6 +_,7 @@
+ 				usesLocalNPCImmunity = true;
+ 				localNPCHitCooldown = -1;
+ 				extraUpdates = 2;
++				armorPenetration = 50;
+ 			}
+ 			else if (type == 918) {
+ 				aiStyle = 178;
+@@ -7612,6 +_,7 @@
+ 				usesLocalNPCImmunity = true;
+ 				coldDamage = true;
+ 				localNPCHitCooldown = 20;
++				armorPenetration = 30;
+ 			}
+ 			else if (type == 919) {
+ 				width = 8;
 @@ -7894,9 +_,8 @@
  				usesLocalNPCImmunity = true;
  				localNPCHitCooldown = 80;
@@ -215,6 +288,26 @@
  							else if (Main.npc[i].trapImmune && trap)
  								flag4 = true;
  							else if (Main.npc[i].immortal && npcProj)
+@@ -9051,9 +_,10 @@
+ 
+ 									float num7 = knockBack;
+ 									bool flag6 = false;
+-									int num8 = Main.player[owner].armorPenetration;
++									int num8 = Main.player[owner].armorPenetration + armorPenetration;
+ 									bool flag7 = !npcProj && !trap;
+ 									switch (type) {
++										/*
+ 										case 864:
+ 											num8 += 25;
+ 											break;
+@@ -9087,6 +_,7 @@
+ 										case 532:
+ 											num8 += 25;
+ 											break;
++										*/
+ 										case 877:
+ 										case 878:
+ 										case 879:
 @@ -9095,7 +_,7 @@
  									}
  


### PR DESCRIPTION
Armor penetration is now saved on items and projectiles as a statistic that can be modified by any given effect, similar to how it's handled for the player. This greatly eases the process of granting armor penetration to projectiles and items, a feature that's now given precedent in vanilla.