### PR TITLE
Enable autoloading on ModLoaderMod for default content

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1417,7 +1417,7 @@
 -					int damage = item.damage;
 +					LocalizedText tip;
 +					if (item.DamageType != null) {
-+						tip = new LocalizedText("", item.DamageType.DisplayName);
++						tip = new LocalizedText("", " "+item.DamageType.DisplayName);
 +					}
 +					else {
 +						tip = Lang.tip[55]; // No damage class

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1342,7 +1342,7 @@
  						if (diff == 1)
  							black = new Microsoft.Xna.Framework.Color((byte)((float)(int)mcColor.R * num4), (byte)((float)(int)mcColor.G * num4), (byte)((float)(int)mcColor.B * num4), a);
  
-@@ -15033,95 +_,113 @@
+@@ -15033,95 +_,111 @@
  
  						if (hoverItem.expert || rare == -12)
  							black = new Microsoft.Xna.Framework.Color((byte)((float)DiscoR * num4), (byte)((float)DiscoG * num4), (byte)((float)DiscoB * num4), a);
@@ -1417,9 +1417,7 @@
 -					int damage = item.damage;
 +					LocalizedText tip;
 +					if (item.DamageType != null) {
-+						bool classIsVanilla = item.DamageType.index < DamageClassLoader.DefaultDamageClassCount;
-+						//'damage' portion is still required on modded ClassNames for the sake of possibility of accurate translations, but the space isn't.
-+						tip = new LocalizedText("", $"{(classIsVanilla ? string.Empty : " ")}{item.DamageType.DisplayName}");
++						tip = new LocalizedText("", item.DamageType.DisplayName);
 +					}
 +					else {
 +						tip = Lang.tip[55]; // No damage class

--- a/patches/tModLoader/Terraria/ModLoader/DamageClass.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DamageClass.cs
@@ -4,11 +4,11 @@ namespace Terraria.ModLoader
 {
 	public abstract class DamageClass : ModType
 	{
-		public static Melee Melee { get; private set; } = new Melee();
-		public static Ranged Ranged { get; private set; } = new Ranged();
-		public static Magic Magic { get; private set; } = new Magic();
-		public static Summon Summon { get; private set; } = new Summon();
-		public static Throwing Throwing { get; private set; } = new Throwing();
+		public static Melee Melee => ModContent.GetInstance<Melee>();
+		public static Ranged Ranged => ModContent.GetInstance<Ranged>();
+		public static Magic Magic => ModContent.GetInstance<Magic>();
+		public static Summon Summon => ModContent.GetInstance<Summon>();
+		public static Throwing Throwing => ModContent.GetInstance<Throwing>();
 
 		internal int index;
 
@@ -19,14 +19,6 @@ namespace Terraria.ModLoader
 		public string DisplayName => DisplayNameInternal;
 
 		internal protected virtual string DisplayNameInternal => ClassName.GetTranslation(Language.ActiveCulture);
-
-		public override void Load() {
-			Melee.index = 0;
-			Ranged.index = 1;
-			Magic.index = 2;
-			Summon.index = 3;
-			Throwing.index = 4;
-		}
 
 		protected override void Register() {
 			index = DamageClassLoader.Add(this);

--- a/patches/tModLoader/Terraria/ModLoader/DamageClassLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DamageClassLoader.cs
@@ -6,15 +6,7 @@ namespace Terraria.ModLoader
 	{
 		public static int DamageClassCount => DamageClasses.Count;
 
-		internal static readonly List<DamageClass> DamageClasses = new List<DamageClass>() {
-			DamageClass.Melee,
-			DamageClass.Ranged,
-			DamageClass.Magic,
-			DamageClass.Summon,
-			DamageClass.Throwing
-		};
-
-		internal static readonly int DefaultDamageClassCount = DamageClasses.Count;
+		internal static readonly List<DamageClass> DamageClasses = new List<DamageClass>();
 
 		internal static int Add(DamageClass damageClass) {
 			DamageClasses.Add(damageClass);
@@ -22,7 +14,7 @@ namespace Terraria.ModLoader
 		}
 
 		internal static void Unload() {
-			DamageClasses.RemoveRange(DefaultDamageClassCount, DamageClasses.Count - DefaultDamageClassCount);
+			DamageClasses.Clear();
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Default/AprilFools.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/AprilFools.cs
@@ -3,7 +3,7 @@ using Terraria.ID;
 
 namespace Terraria.ModLoader.Default
 {
-	public class AprilFools : ModItem
+	public class AprilFools : ModLoaderModItem
 	{
 		public override string Texture => "Terraria/Item_3389";
 

--- a/patches/tModLoader/Terraria/ModLoader/Default/DefaultModMenus.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/DefaultModMenus.cs
@@ -7,6 +7,7 @@ namespace Terraria.ModLoader.Default
 	/// <summary>
 	/// This is the default modmenu - the one that tML uses and the default one upon entering the game for the first time.
 	/// </summary>
+	[Autoload(false)]
 	internal class MenutML : ModMenu
 	{
 		public override string DisplayName => "tModLoader";
@@ -15,6 +16,7 @@ namespace Terraria.ModLoader.Default
 	/// <summary>
 	/// The Journey's End theme converted into a ModMenu, so that it better fits with the new system.
 	/// </summary>
+	[Autoload(false)]
 	internal class MenuJourneysEnd : ModMenu
 	{
 		public override string DisplayName => "Journey's End";
@@ -25,6 +27,7 @@ namespace Terraria.ModLoader.Default
 	/// <summary>
 	/// The Terraria 1.3.5.3 theme converted into a ModMenu, so that it better fits with the new system.
 	/// </summary>
+	[Autoload(false)]
 	internal class MenuOldVanilla : ModMenu
 	{
 		public override bool IsAvailable => Main.instance.playOldTile;

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/DeveloperItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/DeveloperItem.cs
@@ -1,28 +1,18 @@
 ﻿using Microsoft.Xna.Framework;
-using System;
 using System.Collections.Generic;
 
 namespace Terraria.ModLoader.Default.Developer
 {
-	internal abstract class DeveloperItem : ModItem
+	internal abstract class DeveloperItem : ModLoaderModItem
 	{
-		public override string Name => $"{SetName}_{ItemEquipType}";
-
 		public virtual string TooltipBrief { get; }
-		public abstract string SetName { get; }
-		public abstract EquipType ItemEquipType { get; }
 		public virtual string SetSuffix => "'s";
 
-		protected string EquipTypeSuffix
-			=> Enum.GetName(typeof(EquipType), ItemEquipType);
-
-		public override string Texture => $"ModLoader/Developer.{SetName}_{EquipTypeSuffix}";
+		public string InternalSetName => GetType().Name.Split('_')[0];
 
 		public override void SetStaticDefaults() {
-			string displayName =
-				EquipTypeSuffix != null
-				? $"{SetName}{SetSuffix} {EquipTypeSuffix}"
-				: "ITEM NAME ERROR";
+			var displayName = Name.Replace('_', ' ');
+			displayName.Insert(displayName.IndexOf(' '), SetSuffix);
 			DisplayName.SetDefault(displayName);
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/AndromedonItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/AndromedonItem.cs
@@ -10,14 +10,13 @@ namespace Terraria.ModLoader.Default.Developer.Jofairden
 	internal abstract class AndromedonItem : DeveloperItem
 	{
 		public override string TooltipBrief => "Jofairden's ";
-		public sealed override string SetName => "PowerRanger";
 		public const int ShaderNumSegments = 8;
 		public const int ShaderDrawOffset = 2;
 
 		private static int? ShaderId;
 
 		public sealed override void SetStaticDefaults() {
-			DisplayName.SetDefault($"Andromedon {EquipTypeSuffix}");
+			DisplayName.SetDefault($"Andromedon {Name.Split('_')[1]}");
 			Tooltip.SetDefault("The power of the Andromedon flows within you");
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/PowerRanger_Body.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/PowerRanger_Body.cs
@@ -3,10 +3,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Terraria.ModLoader.Default.Developer.Jofairden
 {
+	[AutoloadEquip(EquipType.Body)]
 	internal class PowerRanger_Body : AndromedonItem
 	{
-		public override EquipType ItemEquipType => EquipType.Body;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(34, 22);

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/PowerRanger_Head.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/PowerRanger_Head.cs
@@ -3,19 +3,18 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Terraria.ModLoader.Default.Developer.Jofairden
 {
+	[AutoloadEquip(EquipType.Head)]
 	internal class PowerRanger_Head : AndromedonItem
 	{
-		public override EquipType ItemEquipType => EquipType.Head;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(18, 20);
 		}
 
 		public override bool IsVanitySet(int head, int body, int legs) {
-			return head == Mod.GetEquipSlot($"{SetName}_{EquipType.Head}", EquipType.Head)
-				   && body == Mod.GetEquipSlot($"{SetName}_{EquipType.Body}", EquipType.Body)
-				   && legs == Mod.GetEquipSlot($"{SetName}_{EquipType.Legs}", EquipType.Legs);
+			return head == Mod.GetEquipSlot(nameof(PowerRanger_Head), EquipType.Head)
+				   && body == Mod.GetEquipSlot(nameof(PowerRanger_Body), EquipType.Body)
+				   && legs == Mod.GetEquipSlot(nameof(PowerRanger_Legs), EquipType.Legs);
 		}
 
 		public override void UpdateVanitySet(Player player) {

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/PowerRanger_Legs.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/PowerRanger_Legs.cs
@@ -3,10 +3,9 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Terraria.ModLoader.Default.Developer.Jofairden
 {
+	[AutoloadEquip(EquipType.Legs)]
 	internal class PowerRanger_Legs : AndromedonItem
 	{
-		public override EquipType ItemEquipType => EquipType.Legs;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(22, 18);

--- a/patches/tModLoader/Terraria/ModLoader/Default/ModLoaderMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/ModLoaderMod.cs
@@ -3,22 +3,16 @@ using ReLogic.Content;
 using ReLogic.Content.Sources;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using Terraria.ModLoader.Assets;
 using Terraria.ModLoader.Default.Developer;
-using Terraria.ModLoader.Default.Developer.Jofairden;
 using Terraria.ModLoader.Default.Patreon;
 
 namespace Terraria.ModLoader.Default
 {
 	internal class ModLoaderMod : Mod
 	{
-		internal static ModLoaderMod Instance;
-
-		// If new types arise (probably not), change the format:
-		// head, body, legs, wings, <new>
 		private static PatreonItem[][] PatronSets;
 		private static DeveloperItem[][] DeveloperSets;
 		private const int ChanceToGetPatreonArmor = 20;
@@ -30,8 +24,8 @@ namespace Terraria.ModLoader.Default
 		internal ModLoaderMod() {
 			Side = ModSide.NoSync;
 			DisplayName = "tModLoader";
+			Code = Assembly.GetExecutingAssembly();
 		}
-
 
 		public override void SetupAssetRepository(IList<IContentSource> sources, AssetReaderCollection assetReaderCollection, IList<Type> delayedLoadTypes)
 		{
@@ -40,30 +34,11 @@ namespace Terraria.ModLoader.Default
 		}
 
 		public override void Load() {
-			Instance = this;
-
-			/*if (!Main.dedServ) {
-				AddTexture("UnloadedItem", ReadTexture("UnloadedItem"));
-				AddTexture("StartBag", ReadTexture("StartBag"));
-				AddTexture("UnloadedTile", ReadTexture("UnloadedTile"));
-			}*/
-			
-			AddContent<UnloadedItem>();
-			AddContent<UnloadedGlobalItem>();
-			AddContent<StartBag>();
-			AddContent<AprilFools>();
 			AddContent(new UnloadedTile());
 			AddContent(new UnloadedTile("PendingUnloadedTile"));
-			AddContent<UnloadedTileEntity>();
-			AddContent<UnloadedPlayer>();
-			AddContent<UnloadedWorld>();
-			AddContent<UnloadedTilesWorld>();
-			AddContent<HelpCommand>();
-			AddContent<ModlistCommand>();
-			/*AddPatronSets();
-			AddPlayer("PatronModPlayer", new PatronModPlayer());
-			AddDeveloperSets();
-			AddPlayer("DeveloperPlayer", new DeveloperPlayer());*/
+
+			PatronSets = GetContent<PatreonItem>().GroupBy(t => t.InternalSetName).Select(set => set.ToArray()).ToArray();
+			DeveloperSets = GetContent<DeveloperItem>().GroupBy(t => t.InternalSetName).Select(set => set.ToArray()).ToArray();
 		}
 
 		public override void Unload() {
@@ -71,64 +46,7 @@ namespace Terraria.ModLoader.Default
 			DeveloperSets = null;
 		}
 
-		private void AddPatronSets() {
-			PatronSets = new[] {
-				new PatreonItem[] { new toplayz_Head(), new toplayz_Body(), new toplayz_Legs() },
-				new PatreonItem[] { new KittyKitCatCat_Head(), new KittyKitCatCat_Body(), new KittyKitCatCat_Legs() },
-				new PatreonItem[] { new Polyblank_Head(), new Polyblank_Body(), new Polyblank_Legs() },
-				new PatreonItem[] { new dinidini_Head(), new dinidini_Body(), new dinidini_Legs(), new dinidini_Wings() },
-				new PatreonItem[] { new Remeus_Head(), new Remeus_Body(), new Remeus_Legs() },
-				new PatreonItem[] { new Saethar_Head(), new Saethar_Body(), new Saethar_Legs(), new Saethar_Wings() },
-				new PatreonItem[] { new Orian_Head(), new Orian_Body(), new Orian_Legs() },
-				new PatreonItem[] { new Glory_Head(), new Glory_Body(), new Glory_Legs() },
-				new PatreonItem[] { new POCKETS_Head(), new POCKETS_Body(), new POCKETS_Legs(), new POCKETS_Wings() },
-			};
-
-			foreach (var patronItem in PatronSets.SelectMany(x => x)) {
-				AddItemAndEquipType(patronItem, patronItem.ItemEquipType);
-			}
-		}
-
-		private void AddDeveloperSets() {
-			DeveloperSets = new[] {
-				new DeveloperItem[] { new PowerRanger_Head(), new PowerRanger_Body(), new PowerRanger_Legs() }
-			};
-
-			foreach (var developerItem in DeveloperSets.SelectMany(x => x)) {
-				AddItemAndEquipType(developerItem, developerItem.ItemEquipType);
-			}
-		}
-
-		// Adds the given patreon item to ModLoader, and handles loading its assets automatically
-		private void AddItemAndEquipType(ModItem item, EquipType equipType) {
-			// If a client, we need to add several textures
-			/*if (!Main.dedServ) {
-				AddTexture($"{prefix}.{name}_{equipType}", ReadTexture($"{prefix}.{name}_{equipType}"));
-				AddTexture($"{prefix}.{name}_{equipType}_{equipType}", ReadTexture($"{prefix}.{name}_{equipType}_{equipType}"));
-				if (equipType == EquipType.Body) // If a body, add the arms texture
-				{
-					AddTexture($"{prefix}.{name}_{equipType}_Arms", ReadTexture($"{prefix}.{name}_{equipType}_Arms"));
-				}
-			}*/
-
-			// Adds the item to ModLoader, as well as the normal assets
-			AddContent(item);
-			// AddEquipTexture adds the arms and female body assets automatically, if EquipType is Body
-			AddEquipTexture(item, equipType, item.Texture + '_' + equipType);
-		}
-
-		internal static Texture2D ReadTexture(string file) {
-			Assembly assembly = Assembly.GetExecutingAssembly();
-			// if someone set the type or name wrong, the stream will be null.
-			Stream stream = assembly.GetManifestResourceStream("Terraria.ModLoader.Default." + file + ".png");
-
-			// [sanity check, makes it easier to know what's wrong]
-			if (stream == null) {
-				throw new ArgumentException("Given EquipType for PatreonItem or name is not valid. It is possible either does not match up with the classname. If you added a new EquipType, modify GetEquipTypeSuffix() and AddPatreonItemAndEquipType() first.");
-			}
-
-			return Texture2D.FromStream(Main.instance.GraphicsDevice, stream);
-		}
+		internal static Texture2D ReadTexture(string file) => ModContent.GetInstance<ModLoaderMod>().GetTexture(file).Value;
 
 		internal static bool TryGettingPatreonOrDevArmor(Player player) {
 			if (Main.rand.NextBool(ChanceToGetPatreonArmor)) {

--- a/patches/tModLoader/Terraria/ModLoader/Default/ModLoaderModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/ModLoaderModItem.cs
@@ -1,0 +1,9 @@
+﻿namespace Terraria.ModLoader.Default
+{
+	public abstract class ModLoaderModItem : ModItem
+	{
+		// wish we could just use slashes everywhere, and use the standardised paths here too, but this will do for now - CB
+		// Need to change how AssemblyResourcesContentSource works, and it's a pain to map forward and back with slashes and not stuff up extensions
+		public override string Texture => "ModLoader/"+base.Texture.Substring("Terraria.ModLoader.Default.".Length).Replace('/', '.');
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/Default/NetHandler.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/NetHandler.cs
@@ -13,7 +13,7 @@ namespace Terraria.ModLoader.Default
 		}
 
 		protected ModPacket GetPacket(byte packetType, int fromWho) {
-			var p = ModLoaderMod.Instance.GetPacket();
+			var p = ModContent.GetInstance<ModLoaderMod>().GetPacket();
 			p.Write(HandlerType);
 			p.Write(packetType);
 			if (Main.netMode == NetmodeID.Server) {

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Dinidini.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Dinidini.cs
@@ -1,10 +1,8 @@
 ﻿namespace Terraria.ModLoader.Default.Patreon
 {
+	[AutoloadEquip(EquipType.Head)]
 	internal class dinidini_Head : PatreonItem
 	{
-		public override string SetName => "dinidini";
-		public override EquipType ItemEquipType => EquipType.Head;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.width = 28;
@@ -12,11 +10,9 @@
 		}
 	}
 
+	[AutoloadEquip(EquipType.Body)]
 	internal class dinidini_Body : PatreonItem
 	{
-		public override string SetName => "dinidini";
-		public override EquipType ItemEquipType => EquipType.Body;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.width = 28;
@@ -24,11 +20,9 @@
 		}
 	}
 
+	[AutoloadEquip(EquipType.Legs)]
 	internal class dinidini_Legs : PatreonItem
 	{
-		public override string SetName => "dinidini";
-		public override EquipType ItemEquipType => EquipType.Legs;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.width = 22;
@@ -36,11 +30,9 @@
 		}
 	}
 
+	[AutoloadEquip(EquipType.Wings)]
 	internal class dinidini_Wings : PatreonItem
 	{
-		public override string SetName => "dinidini";
-		public override EquipType ItemEquipType => EquipType.Wings;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.vanity = false;

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Glory.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Glory.cs
@@ -2,33 +2,27 @@ using Microsoft.Xna.Framework;
 
 namespace Terraria.ModLoader.Default.Patreon
 {
+	[AutoloadEquip(EquipType.Head)]
 	internal class Glory_Head : PatreonItem
 	{
-		public override string SetName => "Glory";
-		public override EquipType ItemEquipType => EquipType.Head;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(30, 32);
 		}
 	}
 
+	[AutoloadEquip(EquipType.Body)]
 	internal class Glory_Body : PatreonItem
 	{
-		public override string SetName => "Glory";
-		public override EquipType ItemEquipType => EquipType.Body;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(34, 24);
 		}
 	}
 
+	[AutoloadEquip(EquipType.Legs)]
 	internal class Glory_Legs : PatreonItem
 	{
-		public override string SetName => "Glory";
-		public override EquipType ItemEquipType => EquipType.Legs;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(22, 18);

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/KittyKitCatCat.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/KittyKitCatCat.cs
@@ -1,10 +1,8 @@
 ﻿namespace Terraria.ModLoader.Default.Patreon
 {
+	[AutoloadEquip(EquipType.Head)]
 	internal class KittyKitCatCat_Head : PatreonItem
 	{
-		public override string SetName => "KittyKitCatCat";
-		public override EquipType ItemEquipType => EquipType.Head;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.width = 34;
@@ -12,11 +10,9 @@
 		}
 	}
 
+	[AutoloadEquip(EquipType.Body)]
 	internal class KittyKitCatCat_Body : PatreonItem
 	{
-		public override string SetName => "KittyKitCatCat";
-		public override EquipType ItemEquipType => EquipType.Body;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.width = 42;
@@ -24,11 +20,9 @@
 		}
 	}
 
+	[AutoloadEquip(EquipType.Legs)]
 	internal class KittyKitCatCat_Legs : PatreonItem
 	{
-		public override string SetName => "KittyKitCatCat";
-		public override EquipType ItemEquipType => EquipType.Legs;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.width = 22;

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Orian.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Orian.cs
@@ -1,14 +1,12 @@
 namespace Terraria.ModLoader.Default.Patreon
 {
+	[AutoloadEquip(EquipType.Head)]
 	internal class Orian_Head : PatreonItem
 	{
-		public override string SetName => "Orian";
-		public override EquipType ItemEquipType => EquipType.Head;
-
 		public override bool IsVanitySet(int head, int body, int legs) {
-			return head == Mod.GetEquipSlot($"{SetName}_{EquipType.Head}", EquipType.Head)
-				   && body == Mod.GetEquipSlot($"{SetName}_{EquipType.Body}", EquipType.Body)
-				   && legs == Mod.GetEquipSlot($"{SetName}_{EquipType.Legs}", EquipType.Legs);
+			return head == Mod.GetEquipSlot(nameof(Orian_Head), EquipType.Head)
+				   && body == Mod.GetEquipSlot(nameof(Orian_Body), EquipType.Body)
+				   && legs == Mod.GetEquipSlot(nameof(Orian_Legs), EquipType.Legs);
 		}
 
 		public override void UpdateVanitySet(Player player) {
@@ -22,11 +20,9 @@ namespace Terraria.ModLoader.Default.Patreon
 		}
 	}
 
+	[AutoloadEquip(EquipType.Body)]
 	internal class Orian_Body : PatreonItem
 	{
-		public override string SetName => "Orian";
-		public override EquipType ItemEquipType => EquipType.Body;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.width = 30;
@@ -34,11 +30,9 @@ namespace Terraria.ModLoader.Default.Patreon
 		}
 	}
 
+	[AutoloadEquip(EquipType.Legs)]
 	internal class Orian_Legs : PatreonItem
 	{
-		public override string SetName => "Orian";
-		public override EquipType ItemEquipType => EquipType.Legs;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.width = 22;

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/POCKETS.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/POCKETS.cs
@@ -2,44 +2,36 @@ using Microsoft.Xna.Framework;
 
 namespace Terraria.ModLoader.Default.Patreon
 {
+	[AutoloadEquip(EquipType.Head)]
 	internal class POCKETS_Head : PatreonItem
 	{
-		public override string SetName => "POCKETS";
-		public override EquipType ItemEquipType => EquipType.Head;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(34);
 		}
 	}
 
+	[AutoloadEquip(EquipType.Body)]
 	internal class POCKETS_Body : PatreonItem
 	{
-		public override string SetName => "POCKETS";
-		public override EquipType ItemEquipType => EquipType.Body;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(30, 18);
 		}
 	}
 
+	[AutoloadEquip(EquipType.Legs)]
 	internal class POCKETS_Legs : PatreonItem
 	{
-		public override string SetName => "POCKETS";
-		public override EquipType ItemEquipType => EquipType.Legs;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(22, 18);
 		}
 	}
 
+	[AutoloadEquip(EquipType.Wings)]
 	internal class POCKETS_Wings : PatreonItem
 	{
-		public override string SetName => "POCKETS";
-		public override EquipType ItemEquipType => EquipType.Wings;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.vanity = false;

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/PatreonItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/PatreonItem.cs
@@ -1,29 +1,18 @@
 ﻿using Microsoft.Xna.Framework;
-using System;
 using System.Collections.Generic;
 using Terraria.Localization;
 
 namespace Terraria.ModLoader.Default.Patreon
 {
-	internal abstract class PatreonItem : ModItem
+	internal abstract class PatreonItem : ModLoaderModItem
 	{
-		public override string Name => $"{SetName}_{ItemEquipType}";
-
-		// Make sure the name and classname prefix match exactly.
-		public abstract string SetName { get; }
-		public abstract EquipType ItemEquipType { get; }
 		public virtual string SetSuffix => "'s";
 
-		protected string EquipTypeSuffix
-			=> Enum.GetName(typeof(EquipType), ItemEquipType);
-
-		public override string Texture => $"ModLoader/Patreon.{SetName}_{EquipTypeSuffix}";
+		public string InternalSetName => GetType().Name.Split('_')[0];
 
 		public override void SetStaticDefaults() {
-			string displayName =
-				EquipTypeSuffix != null
-					? $"{SetName}{SetSuffix} {EquipTypeSuffix}"
-					: "ITEM NAME ERROR";
+			var displayName = Name.Replace('_', ' ');
+			displayName.Insert(displayName.IndexOf(' '), SetSuffix);
 			DisplayName.SetDefault(displayName);
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Polyblank.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Polyblank.cs
@@ -1,10 +1,8 @@
 ﻿namespace Terraria.ModLoader.Default.Patreon
 {
+	[AutoloadEquip(EquipType.Head)]
 	internal class Polyblank_Head : PatreonItem
 	{
-		public override string SetName => "Polyblank";
-		public override EquipType ItemEquipType => EquipType.Head;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.width = 24;
@@ -12,11 +10,9 @@
 		}
 	}
 
+	[AutoloadEquip(EquipType.Body)]
 	internal class Polyblank_Body : PatreonItem
 	{
-		public override string SetName => "Polyblank";
-		public override EquipType ItemEquipType => EquipType.Body;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.width = 30;
@@ -24,11 +20,9 @@
 		}
 	}
 
+	[AutoloadEquip(EquipType.Legs)]
 	internal class Polyblank_Legs : PatreonItem
 	{
-		public override string SetName => "Polyblank";
-		public override EquipType ItemEquipType => EquipType.Legs;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.width = 22;

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Remeus.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Remeus.cs
@@ -2,33 +2,27 @@ using Microsoft.Xna.Framework;
 
 namespace Terraria.ModLoader.Default.Patreon
 {
+	[AutoloadEquip(EquipType.Head)]
 	internal class Remeus_Head : PatreonItem
 	{
-		public override string SetName => "Remeus";
-		public override EquipType ItemEquipType => EquipType.Head;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(34);
 		}
 	}
 
+	[AutoloadEquip(EquipType.Body)]
 	internal class Remeus_Body : PatreonItem
 	{
-		public override string SetName => "Remeus";
-		public override EquipType ItemEquipType => EquipType.Body;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(30, 18);
 		}
 	}
 
+	[AutoloadEquip(EquipType.Legs)]
 	internal class Remeus_Legs : PatreonItem
 	{
-		public override string SetName => "Remeus";
-		public override EquipType ItemEquipType => EquipType.Legs;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(22, 18);

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Saethar.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Saethar.cs
@@ -2,44 +2,36 @@ using Microsoft.Xna.Framework;
 
 namespace Terraria.ModLoader.Default.Patreon
 {
+	[AutoloadEquip(EquipType.Head)]
 	internal class Saethar_Head : PatreonItem
 	{
-		public override string SetName => "Saethar";
-		public override EquipType ItemEquipType => EquipType.Head;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(34);
 		}
 	}
 
+	[AutoloadEquip(EquipType.Body)]
 	internal class Saethar_Body : PatreonItem
 	{
-		public override string SetName => "Saethar";
-		public override EquipType ItemEquipType => EquipType.Body;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(30, 18);
 		}
 	}
 
+	[AutoloadEquip(EquipType.Legs)]
 	internal class Saethar_Legs : PatreonItem
 	{
-		public override string SetName => "Saethar";
-		public override EquipType ItemEquipType => EquipType.Legs;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(22, 18);
 		}
 	}
 
+	[AutoloadEquip(EquipType.Wings)]
 	internal class Saethar_Wings : PatreonItem
 	{
-		public override string SetName => "Saethar";
-		public override EquipType ItemEquipType => EquipType.Wings;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.vanity = false;
@@ -51,6 +43,5 @@ namespace Terraria.ModLoader.Default.Patreon
 		public override void UpdateAccessory(Player player, bool hideVisual) {
 			player.wingTimeMax = 150;
 		}
-
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Squid.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Squid.cs
@@ -2,33 +2,27 @@ using Microsoft.Xna.Framework;
 
 namespace Terraria.ModLoader.Default.Patreon
 {
+	[AutoloadEquip(EquipType.Head)]
 	internal class Squid_Head : PatreonItem
 	{
-		public override string SetName => "Squid";
-		public override EquipType ItemEquipType => EquipType.Head;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(26);
 		}
 	}
 
+	[AutoloadEquip(EquipType.Body)]
 	internal class Squid_Body : PatreonItem
 	{
-		public override string SetName => "Squid";
-		public override EquipType ItemEquipType => EquipType.Body;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(34, 26);
 		}
 	}
 
+	[AutoloadEquip(EquipType.Legs)]
 	internal class Squid_Legs : PatreonItem
 	{
-		public override string SetName => "Squid";
-		public override EquipType ItemEquipType => EquipType.Legs;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.Size = new Vector2(22, 18);

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/toplayz.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/toplayz.cs
@@ -1,10 +1,8 @@
 ﻿namespace Terraria.ModLoader.Default.Patreon
 {
+	[AutoloadEquip(EquipType.Head)]
 	internal class toplayz_Head : PatreonItem
 	{
-		public override string SetName => "toplayz";
-		public override EquipType ItemEquipType => EquipType.Head;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.width = 28;
@@ -12,11 +10,9 @@
 		}
 	}
 
+	[AutoloadEquip(EquipType.Body)]
 	internal class toplayz_Body : PatreonItem
 	{
-		public override string SetName => "toplayz";
-		public override EquipType ItemEquipType => EquipType.Body;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.width = 30;
@@ -24,11 +20,9 @@
 		}
 	}
 
+	[AutoloadEquip(EquipType.Legs)]
 	internal class toplayz_Legs : PatreonItem
 	{
-		public override string SetName => "toplayz";
-		public override EquipType ItemEquipType => EquipType.Legs;
-
 		public override void SetDefaults() {
 			base.SetDefaults();
 			item.width = 22;

--- a/patches/tModLoader/Terraria/ModLoader/Default/StartBag.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/StartBag.cs
@@ -4,11 +4,9 @@ using Terraria.ModLoader.IO;
 
 namespace Terraria.ModLoader.Default
 {
-	public class StartBag : ModItem
+	public class StartBag : ModLoaderModItem
 	{
 		private List<Item> items = new List<Item>();
-
-		public override string Texture => "ModLoader/StartBag";
 
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("{$tModLoader.StartBagItemName}");

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedItem.cs
@@ -5,13 +5,11 @@ using Terraria.ModLoader.IO;
 
 namespace Terraria.ModLoader.Default
 {
-	public class UnloadedItem : ModItem
+	public class UnloadedItem : ModLoaderModItem
 	{
 		private string modName;
 		private string itemName;
 		private TagCompound data;
-
-		public override string Texture => "ModLoader/UnloadedItem";
 
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("{$tModLoader.UnloadedItemItemName}");

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedTile.cs
@@ -1,5 +1,6 @@
 namespace Terraria.ModLoader.Default
 {
+	[Autoload(false)] // need two named versions
 	public class UnloadedTile : ModTile
 	{
 		public override string Name{get;}

--- a/patches/tModLoader/Terraria/ModLoader/GlobalBuff.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalBuff.cs
@@ -7,7 +7,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class allows you to modify the behavior of any buff in the game.
 	/// </summary>
-	public class GlobalBuff:ModType
+	public abstract class GlobalBuff : ModType
 	{
 		protected sealed override void Register() {
 			ModTypeLookup<GlobalBuff>.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -12,7 +12,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class allows you to modify and use hooks for all items, including vanilla items. Create an instance of an overriding class then call Mod.AddGlobalItem to use this.
 	/// </summary>
-	public class GlobalItem:ModType
+	public abstract class GlobalItem : ModType
 	{
 		internal int index;
 		internal int instanceIndex;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -8,7 +8,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class allows you to modify and use hooks for all NPCs, including vanilla mobs. Create an instance of an overriding class then call Mod.AddGlobalNPC to use this.
 	/// </summary>
-	public class GlobalNPC:ModType
+	public abstract class GlobalNPC : ModType
 	{
 		internal int index;
 		internal int instanceIndex;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -8,7 +8,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class allows you to modify and use hooks for all projectiles, including vanilla projectiles. Create an instance of an overriding class then call Mod.AddGlobalProjectile to use this.
 	/// </summary>
-	public class GlobalProjectile:ModType
+	public abstract class GlobalProjectile : ModType
 	{
 		internal int index;
 		internal int instanceIndex;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalRecipe.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalRecipe.cs
@@ -3,7 +3,7 @@
 	/// <summary>
 	/// This class provides hooks that control all recipes in the game.
 	/// </summary>
-	public class GlobalRecipe:ModType
+	public abstract class GlobalRecipe : ModType
 	{
 		protected sealed override void Register() {
 			ModTypeLookup<GlobalRecipe>.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -7,7 +7,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class allows you to modify the behavior of any tile in the game. Create an instance of an overriding class then call Mod.AddGlobalTile to use this.
 	/// </summary>
-	public class GlobalTile:ModType
+	public abstract class GlobalTile : ModType
 	{
 		/// <summary>
 		/// A convenient method for adding an integer to the end of an array. This can be used with the arrays in TileID.Sets.RoomNeeds.

--- a/patches/tModLoader/Terraria/ModLoader/GlobalWall.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalWall.cs
@@ -5,7 +5,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class allows you to modify the behavior of any wall in the game (although admittedly walls don't have much behavior). Create an instance of an overriding class then call Mod.AddGlobalWall to use this.
 	/// </summary>
-	public class GlobalWall:ModType
+	public abstract class GlobalWall : ModType
 	{
 		protected sealed override void Register() {
 			ModTypeLookup<GlobalWall>.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
@@ -17,7 +17,7 @@ namespace Terraria.ModLoader
 		public static int GoreCount { get; private set; } = GoreID.Count;
 
 		/// <summary> Registers a new gore with the provided texture. </summary>
-		public static void AddGoreFromTexture<T>(Mod mod, string texture) where T : ModGore, new() {
+		public static void AddGoreFromTexture<TGore>(Mod mod, string texture) where TGore : ModGore, new() {
 			if (mod == null)
 				throw new ArgumentNullException(nameof(mod));
 
@@ -27,12 +27,10 @@ namespace Terraria.ModLoader
 			if (!mod.loading)
 				throw new Exception(Language.GetTextValue("tModLoader.LoadErrorNotLoading"));
 
-			var modGore = Activator.CreateInstance<T>();
-
-			modGore.nameOverride = Path.GetFileNameWithoutExtension(texture);
-			modGore.textureOverride = texture;
-
-			mod.AddContent(modGore);
+			mod.AddContent(new TGore {
+				nameOverride = Path.GetFileNameWithoutExtension(texture),
+				textureOverride = texture
+			});
 		}
 
 		//Called by ModGore.Register
@@ -49,7 +47,7 @@ namespace Terraria.ModLoader
 				string textureKey = $"{mod.Name}/{texturePath}";
 
 				if (!mod.TryFind<ModGore>($"{mod.Name}/{Path.GetFileName(texturePath)}", out _)) //ModGore gores will already be loaded at this point.
-					AddGoreFromTexture<ModGore>(mod, textureKey);
+					AddGoreFromTexture<SimpleModGore>(mod, textureKey);
 			}
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/IO/TagSerializer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TagSerializer.cs
@@ -27,15 +27,6 @@ namespace Terraria.ModLoader.IO
 		internal static void Reload() {
 			serializers.Clear();
 			typeNameCache.Clear();
-			AddSerializer(new BoolTagSerializer());
-			AddSerializer(new UShortTagSerializer());
-			AddSerializer(new UIntTagSerializer());
-			AddSerializer(new ULongTagSerializer());
-			AddSerializer(new Vector2TagSerializer());
-			AddSerializer(new Vector3TagSerializer());
-			AddSerializer(new ColorSerializer());
-			AddSerializer(new Point16Serializer());
-			AddSerializer(new RectangleSerializer());
 		}
 
 		public static bool TryGetSerializer(Type type, out TagSerializer serializer) {

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -94,9 +94,10 @@ namespace Terraria.ModLoader
 
 			Type modType = GetType();
 			foreach (Type type in Code.GetTypes().OrderBy(type => type.FullName, StringComparer.InvariantCulture)) {
-				if (type == modType){continue;}
-				if (type.IsAbstract){continue;}
-				if (type.GetConstructor(new Type[0]) == null){continue;}//don't autoload things with no default constructor
+				if (type == modType) continue;
+				if (type.IsAbstract) continue;
+				if (type.ContainsGenericParameters) continue;
+				if (type.GetConstructor(new Type[0]) == null) continue;//don't autoload things with no default constructor
 
 				if (type.IsSubclassOf(typeof(ModSound))) {
 					modSounds.Add(type);
@@ -215,6 +216,9 @@ namespace Terraria.ModLoader
 		/// Loads .lang files
 		/// </summary>
 		private void AutoloadLocalization() {
+			if (File == null)
+				return;
+
 			var modTranslationDictionary = new Dictionary<string, ModTranslation>();
 			foreach (var translationFile in File.Where(entry => Path.GetExtension(entry.Name) == ".lang")) {
 				// .lang files need to be UTF8 encoded.

--- a/patches/tModLoader/Terraria/ModLoader/ModBackgroundStyle.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBackgroundStyle.cs
@@ -99,7 +99,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class serves to collect functions that operate on any kind of background style, without being specific to one single background style.
 	/// </summary>
-	public class GlobalBgStyle:ModType
+	public abstract class GlobalBgStyle : ModType
 	{
 		protected override sealed void Register() {
 			ModTypeLookup<GlobalBgStyle>.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/ModBuff.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBuff.cs
@@ -7,7 +7,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class serves as a place for you to define a new buff and how that buff behaves.
 	/// </summary>
-	public class ModBuff:ModTexturedType
+	public abstract class ModBuff : ModTexturedType
 	{
 		/// <summary>
 		/// The buff id of this buff.

--- a/patches/tModLoader/Terraria/ModLoader/ModCommand.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModCommand.cs
@@ -39,7 +39,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class represents a chat or console command. Use the CommandType to specify the scope of the command.
 	/// </summary>
-	public abstract class ModCommand:ModType
+	public abstract class ModCommand : ModType
 	{
 		/// <summary>The desired text to trigger this command.</summary>
 		public abstract string Command { get; }

--- a/patches/tModLoader/Terraria/ModLoader/ModDust.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModDust.cs
@@ -11,7 +11,7 @@ namespace Terraria.ModLoader
 	/// This class represents a type of dust that is added by a mod. Only one instance of this class will ever exist for each type of dust you add.
 	/// </summary>
 	[Autoload(Side = ModSide.Client)]
-	public class ModDust:ModTexturedType
+	public abstract class ModDust : ModTexturedType
 	{
 		private static int nextDust = DustID.Count;
 		internal static readonly IList<ModDust> dusts = new List<ModDust>();

--- a/patches/tModLoader/Terraria/ModLoader/ModGore.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModGore.cs
@@ -5,7 +5,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class allows you to customize the behavior of a custom gore.
 	/// </summary>
-	public class ModGore : ModTexturedType
+	public abstract class ModGore : ModTexturedType
 	{
 		/// <summary> Allows you to copy the Update behavior of a different type of gore. This defaults to 0, which means no behavior is copied. </summary>
 		public int updateType = -1;

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -17,7 +17,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class serves as a place for you to place all your properties and hooks for each item. Create instances of ModItem (preferably overriding this class) to pass as parameters to Mod.AddItem.
 	/// </summary>
-	public class ModItem:ModTexturedType
+	public abstract class ModItem : ModTexturedType
 	{
 		//add modItem property to Terraria.Item (internal set)
 		//set modItem to null at beginning of Terraria.Item.ResetStats		

--- a/patches/tModLoader/Terraria/ModLoader/ModMountData.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMountData.cs
@@ -12,7 +12,7 @@ namespace Terraria.ModLoader
 	/// Only one instance of ModMountData will exist for each mount, so storing player specific data on the ModMountData is not good. 
 	/// Modders can use player.mount._mountSpecificData or a ModPlayer class to store player specific data relating to a mount. Use SetMount to assign these fields.
 	/// </summary>
-	public class ModMountData:ModTexturedType
+	public abstract class ModMountData : ModTexturedType
 	{
 		/// <summary>
 		/// The vanilla MountData object that is controlled by this ModMountData.

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -13,7 +13,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class serves as a place for you to place all your properties and hooks for each NPC. Create instances of ModNPC (preferably overriding this class) to pass as parameters to Mod.AddNPC.
 	/// </summary>
-	public class ModNPC:ModTexturedType
+	public abstract class ModNPC : ModTexturedType
 	{
 		//add modNPC property to Terraria.NPC (internal set)
 		//set modNPC to null at beginning of Terraria.NPC.SetDefaults

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -14,7 +14,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// A ModPlayer instance represents an extension of a Player instance. You can store fields in the ModPlayer classes, much like how the Player class abuses field usage, to keep track of mod-specific information on the player that a ModPlayer instance represents. It also contains hooks to insert your code into the Player class.
 	/// </summary>
-	public class ModPlayer:ModType
+	public abstract class ModPlayer : ModType
 	{
 		/// <summary>
 		/// The Player instance that this ModPlayer instance is attached to.

--- a/patches/tModLoader/Terraria/ModLoader/ModPrefix.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPrefix.cs
@@ -7,7 +7,7 @@ using Terraria.Utilities;
 
 namespace Terraria.ModLoader
 {
-	public abstract class ModPrefix:ModType
+	public abstract class ModPrefix : ModType
 	{
 		private static byte nextPrefix = PrefixID.Count;
 

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -12,7 +12,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class serves as a place for you to place all your properties and hooks for each projectile. Create instances of ModProjectile (preferably overriding this class) to pass as parameters to Mod.AddProjectile.
 	/// </summary>
-	public class ModProjectile : ModTexturedType
+	public abstract class ModProjectile : ModTexturedType
 	{
 		//add modProjectile property to Terraria.Projectile (internal set)
 		//set modProjectile to null at beginning of Terraria.Projectile.SetDefaults

--- a/patches/tModLoader/Terraria/ModLoader/ModTexturedType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTexturedType.cs
@@ -3,7 +3,7 @@
 	/// <summary>
 	/// The base type for most modded things with textures.
 	/// </summary>
-	public abstract class ModTexturedType:ModType
+	public abstract class ModTexturedType : ModType
 	{
 		/// <summary>
 		/// The file name of this type's texture file in the mod loader's file space.

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -12,7 +12,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class represents a type of tile that can be added by a mod. Only one instance of this class will ever exist for each type of tile that is added. Any hooks that are called will be called by the instance corresponding to the tile type. This is to prevent the game from using a massive amount of memory storing tile instances.
 	/// </summary>
-	public class ModTile:ModTexturedType
+	public abstract class ModTile : ModTexturedType
 	{
 		/// <summary>
 		/// The internal ID of this type of tile.

--- a/patches/tModLoader/Terraria/ModLoader/ModWall.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWall.cs
@@ -11,7 +11,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class represents a type of wall that can be added by a mod. Only one instance of this class will ever exist for each type of wall that is added. Any hooks that are called will be called by the instance corresponding to the wall type.
 	/// </summary>
-	public class ModWall:ModTexturedType
+	public abstract class ModWall : ModTexturedType
 	{
 		/// <summary>
 		/// The internal ID of this type of wall.

--- a/patches/tModLoader/Terraria/ModLoader/ModWaterStyle.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWaterStyle.cs
@@ -7,7 +7,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// Represents a style of water that gets drawn, based on factors such as the background. This is used to determine the color of the water, as well as other things as determined by the hooks below.
 	/// </summary>
-	public abstract class ModWaterStyle:ModTexturedType
+	public abstract class ModWaterStyle : ModTexturedType
 	{
 		/// <summary>
 		/// The ID of the water style.
@@ -70,7 +70,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// Represents a style of waterfalls that gets drawn. This is mostly used to determine the color of the waterfall.
 	/// </summary>
-	public class ModWaterfallStyle:ModTexturedType
+	public abstract class ModWaterfallStyle : ModTexturedType
 	{
 		/// <summary>
 		/// The ID of this waterfall style.

--- a/patches/tModLoader/Terraria/ModLoader/ModWorld.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWorld.cs
@@ -8,7 +8,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// A ModWorld instance represents an extension of a World. You can store fields in the ModWorld classes to keep track of mod-specific information on the world. It also contains hooks to insert your code into the world generation process.
 	/// </summary>
-	public class ModWorld:ModType
+	public abstract class ModWorld : ModType
 	{
 		protected sealed override void Register() {
 			ModTypeLookup<ModWorld>.Register(this);

--- a/patches/tModLoader/Terraria/ModLoader/SimpleModGore.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SimpleModGore.cs
@@ -1,0 +1,7 @@
+﻿namespace Terraria.ModLoader
+{	
+	[Autoload(false)]
+	public class SimpleModGore : ModGore
+	{
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
+++ b/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
@@ -4,26 +4,26 @@ namespace Terraria.ModLoader
 {
 	public class Melee : DamageClass
 	{
-		internal protected override string DisplayNameInternal => Language.GetTextValue("LegacyTooltip.2");
+		internal protected override string DisplayNameInternal => " "+Language.GetTextValue("LegacyTooltip.2");
 	}
 
 	public class Ranged : DamageClass
 	{
-		internal protected override string DisplayNameInternal => Language.GetTextValue("LegacyTooltip.3");
+		internal protected override string DisplayNameInternal => " " + Language.GetTextValue("LegacyTooltip.3");
 	}
 
 	public class Magic : DamageClass
 	{
-		internal protected override string DisplayNameInternal => Language.GetTextValue("LegacyTooltip.4");
+		internal protected override string DisplayNameInternal => " " + Language.GetTextValue("LegacyTooltip.4");
 	}
 
 	public class Summon : DamageClass
 	{
-		internal protected override string DisplayNameInternal => Language.GetTextValue("LegacyTooltip.53");
+		internal protected override string DisplayNameInternal => " " + Language.GetTextValue("LegacyTooltip.53");
 	}
 
 	public class Throwing : DamageClass
 	{
-		internal protected override string DisplayNameInternal => Language.GetTextValue("LegacyTooltip.58");
+		internal protected override string DisplayNameInternal => " " + Language.GetTextValue("LegacyTooltip.58");
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
+++ b/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
@@ -4,26 +4,26 @@ namespace Terraria.ModLoader
 {
 	public class Melee : DamageClass
 	{
-		internal protected override string DisplayNameInternal => " "+Language.GetTextValue("LegacyTooltip.2");
+		internal protected override string DisplayNameInternal => Language.GetTextValue("LegacyTooltip.2").Substring(1);
 	}
 
 	public class Ranged : DamageClass
 	{
-		internal protected override string DisplayNameInternal => " " + Language.GetTextValue("LegacyTooltip.3");
+		internal protected override string DisplayNameInternal => Language.GetTextValue("LegacyTooltip.3").Substring(1);
 	}
 
 	public class Magic : DamageClass
 	{
-		internal protected override string DisplayNameInternal => " " + Language.GetTextValue("LegacyTooltip.4");
+		internal protected override string DisplayNameInternal => Language.GetTextValue("LegacyTooltip.4").Substring(1);
 	}
 
 	public class Summon : DamageClass
 	{
-		internal protected override string DisplayNameInternal => " " + Language.GetTextValue("LegacyTooltip.53");
+		internal protected override string DisplayNameInternal => Language.GetTextValue("LegacyTooltip.53").Substring(1);
 	}
 
 	public class Throwing : DamageClass
 	{
-		internal protected override string DisplayNameInternal => " " + Language.GetTextValue("LegacyTooltip.58");
+		internal protected override string DisplayNameInternal => Language.GetTextValue("LegacyTooltip.58").Substring(1);
 	}
 }


### PR DESCRIPTION
Also restores the dev/patreon sets.

This cleans up the code fairly well in quite a few places. Haven't tested past loading into the world, due to lack of cheat sheet.

The texture paths are annoying because we have to use '.' instead of '/' with `AssemblyResourcesContentSource`

`DamageClass` static instance properties are now getters for `ModContent.GetInstance`. The JIT should compile it down to just a direct fetch from the correct address, same as a static variable access. Pattern should work the same as any other damage class.

Had to make every ModX class abstract (they should be anyway), and add `SimpleModGore`