### PR TITLE
[1.4] Fix selling back items to NPCs multiplies price by 5 issue

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1247,7 +1247,7 @@
  			if (diff == 1)
  				baseColor = new Microsoft.Xna.Framework.Color((byte)((float)(int)mcColor.R * num2), (byte)((float)(int)mcColor.G * num2), (byte)((float)(int)mcColor.B * num2), mouseTextColor);
  
-@@ -14825,8 +_,9 @@
+@@ -14825,15 +_,19 @@
  				array2[i] = false;
  				array3[i] = false;
  			}
@@ -1258,9 +1258,11 @@
  			float num3 = (float)(int)mouseTextColor / 255f;
  			float num4 = num3;
  			int a = mouseTextColor;
-@@ -14834,6 +_,7 @@
+ 			if (npcShop > 0 && hoverItem.value >= 0 && (hoverItem.type < 71 || hoverItem.type > 74)) {
  				LocalPlayer.GetItemExpectedPrice(hoverItem, out int calcForSelling, out int calcForBuying);
  				int num5 = (hoverItem.isAShopItem || hoverItem.buyOnce) ? calcForBuying : calcForSelling;
++				if (hoverItem.buyOnce && !hoverItem.buy) // tMl: bad(?) fix for visual bug (dividedp price by 5) when bought back item from shop
++					num5 *= 5;
  				if (hoverItem.shopSpecialCurrency != -1) {
 +					tooltipNames[numLines] = "SpecialPrice";
  					CustomCurrencyManager.GetPriceText(hoverItem.shopSpecialCurrency, array, ref numLines, num5);

--- a/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
@@ -192,8 +192,8 @@
 +					*/
 +					Main.mouseItem = inv[slot].Clone();
 +					Main.mouseItem.stack = 1;
-+					if (inv[slot].buyOnce)
-+						Main.mouseItem.value *= 5; // preserve item value for items sold to the shop
++					//if (inv[slot].buyOnce)
++					//	Main.mouseItem.value *= 5; // tMl bug: increased sell back price by 5, enabling infinite money
  
  					Main.mouseItem.stack = 0;
  				}


### PR DESCRIPTION
Issue #1219 

### What is the bug?
Selling back items to NPCs multiplies price by 5. Pointed out by Itorius.
See https://cdn.discordapp.com/attachments/445276626352209920/780078250167894046/fb0EUw9OR9.mp4
(Itorius)

### How did you fix the bug?
I removed a line of code in _ItemSlot.cs_ where the value of an item was multiplied by 5 when sold.
This made a visual bug where the item after being sold and bought once had 1/5 the price in inventory (still sold for the correct price). This might be what the line from _ItemSlot.cs_ was trying to fix. 
I corrected this visual bug in _Main.cs_ by multiplying the item by 5 in the tooltip.

### Are there alternatives to your fix?
There must be a better way to fix this bug without this extra line of code. But this seems to work good.