### PR TITLE
Fix duplicate hook in NPCLoader.cs

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -208,16 +208,6 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		private delegate void DelegateSetBestiary(NPC npc, BestiaryDatabase database, BestiaryEntry bestiaryEntry);
-		private static HookList HookSetBestiary = AddHook<DelegateSetBestiary>(g => g.SetBestiary);
-		public static void SetBestiary(NPC npc, BestiaryDatabase database, BestiaryEntry bestiaryEntry) {
-			npc.modNPC?.SetBestiary(database, bestiaryEntry);
-
-			foreach (GlobalNPC g in HookSetBestiary.arr) {
-				g.Instance(npc).SetBestiary(npc, database, bestiaryEntry);
-			}
-		}
-
 		private static HookList HookResetEffects = AddHook<Action<NPC>>(g => g.ResetEffects);
 
 		public static void ResetEffects(NPC npc) {


### PR DESCRIPTION
### What is the bug?
There are errors when compiling tModLoader on the latest commit of `1.4_mergedtesting`, this is because the `SetBestiary` hook was duplicated.
The hook was duplicated in commit https://github.com/tModLoader/tModLoader/commit/a3a1e353820e0f78dde633ba8cbfb3bd4a02fc28

### How did you fix the bug?
Remove the duplicated hook

### Are there alternatives to your fix?
no

Image of duplicate hook:
![image](https://user-images.githubusercontent.com/31808958/102808697-7fec8480-439f-11eb-9400-453e3301d5da.png)

