### PR TITLE
Fix multiplayer crash by Bestiary PR

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -460,7 +460,8 @@ namespace Terraria.ModLoader
 			bestiaryDatabase.Merge(Main.ItemDropsDB);
 			
 			//Etc
-			Main.BestiaryUI = new UIBestiaryTest(Main.BestiaryDB);
+			if (!Main.dedServ)
+				Main.BestiaryUI = new UIBestiaryTest(Main.BestiaryDB);
 			Main.ItemDropSolver = new ItemDropResolver(itemDropDatabase);
 			Main.BestiaryTracker = new BestiaryUnlocksTracker();
 		}


### PR DESCRIPTION
### What is the bug?
On `1.4_mergedtesting`, starting a multiplayer server makes the server crash with the following error: https://paste.mod.gg/jidabapewa.css
If we follow the stacktrace, we can find that it's crashing because the `SetText` method of `UITextPanel` tries to access `FontAssets.DeathText.Value` and `FontAssets.MouseText.Value`, but because it's a server they are null since they aren't loaded.

### How did you fix the bug?
I changed:
```cs
Main.BestiaryUI = new UIBestiaryTest(Main.BestiaryDB);
```
to:
```cs
if (!Main.dedServ)
	Main.BestiaryUI = new UIBestiaryTest(Main.BestiaryDB);
```

### Are there alternatives to your fix?
maybe
