### PR TITLE
Add call to "GlobalNPC.PostDraw"

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2059,18 +2059,15 @@
  			NPC rCurrentNPC = npc[iNPCIndex];
  			Vector2 screenPos = screenPosition;
  			DrawNPCDirect(spriteBatch, rCurrentNPC, behindTiles, screenPos);
-@@ -16791,6 +_,20 @@
+@@ -16791,6 +_,17 @@
  				}
  			}
  
 +			NPCLoader.DrawEffects(rCurrentNPC, ref npcColor); //TODO: Effects were previously done before drawing, here, but 1.4 moved them to updates in UpdateNPC_BuffApplyVFX(). Should this hook be moved and renamed? --Mirsario
 +			
-+			if (!NPCLoader.PreDraw(rCurrentNPC, spriteBatch, npcColor)) {
-+				NPCLoader.PostDraw(rCurrentNPC, spriteBatch, npcColor);
-+				return;
++			if (NPCLoader.PreDraw(rCurrentNPC, spriteBatch, npcColor)) {
++				DrawNPCDirect_Inner(spriteBatch, rCurrentNPC, behindTiles, screenPos, ref npcColor);
 +			}
-+
-+			DrawNPCDirect_Inner(spriteBatch, rCurrentNPC, behindTiles, screenPos, ref npcColor);
 +
 +			NPCLoader.PostDraw(rCurrentNPC, spriteBatch, npcColor);
 +		}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2073,6 +2073,20 @@
  			npcColor = rCurrentNPC.GetNPCColorTintedByBuffs(npcColor);
  			if (type == 50) {
  				Vector2 zero = Vector2.Zero;
+@@ -19135,10 +_,13 @@
+ 
+ 									if (rCurrentNPC.aiStyle == 7)
+ 										DrawNPCExtras(rCurrentNPC, beforeDraw: false, num37, num36, npcColor, halfSize, spriteEffects, screenPos);
++									// Patch context
+ 
+ 									break;
+ 								}
+ 						}
++
++						NPCLoader.PostDraw(rCurrentNPC, spriteBatch, npcColor);
+ 
+ 						break;
+ 					}
 @@ -20115,12 +_,14 @@
  				}
  

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2059,7 +2059,7 @@
  			NPC rCurrentNPC = npc[iNPCIndex];
  			Vector2 screenPos = screenPosition;
  			DrawNPCDirect(spriteBatch, rCurrentNPC, behindTiles, screenPos);
-@@ -16791,6 +_,13 @@
+@@ -16791,6 +_,20 @@
  				}
  			}
  
@@ -2070,23 +2070,16 @@
 +				return;
 +			}
 +
++			DrawNPCDirect_Inner(spriteBatch, rCurrentNPC, behindTiles, screenPos, ref npcColor);
++
++			NPCLoader.PostDraw(rCurrentNPC, spriteBatch, npcColor);
++		}
++
++		private void DrawNPCDirect_Inner(SpriteBatch mySpriteBatch, NPC rCurrentNPC, bool behindTiles, Vector2 screenPos, ref Color npcColor) {
++			int type = rCurrentNPC.type;
  			npcColor = rCurrentNPC.GetNPCColorTintedByBuffs(npcColor);
  			if (type == 50) {
  				Vector2 zero = Vector2.Zero;
-@@ -19135,10 +_,13 @@
- 
- 									if (rCurrentNPC.aiStyle == 7)
- 										DrawNPCExtras(rCurrentNPC, beforeDraw: false, num37, num36, npcColor, halfSize, spriteEffects, screenPos);
-+									// Patch context
- 
- 									break;
- 								}
- 						}
-+
-+						NPCLoader.PostDraw(rCurrentNPC, spriteBatch, npcColor);
- 
- 						break;
- 					}
 @@ -20115,12 +_,14 @@
  				}
  


### PR DESCRIPTION
### What is the bug?
`GlobalNPC.PostDraw` is only called when `PreDraw` returns false

### How did you fix the bug?
By adding a call to `NPCLoader.PostDraw` inside the `DrawNPCDirect` method. The call was added in the same position as it was in 1.3

### Are there alternatives to your fix?
no

Also, can whoever accepts this merge this PR and #1250 to `1.4_mergedtesting` so that I can finish making `ModdersToolkit` work for that branch.