### PR TITLE
[1.4] Fix crash when opening chests in mutliplayer

### DIFF
--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -189,7 +189,7 @@
  							Main.chest[num260].item[num261].netDefaults(type17);
  							Main.chest[num260].item[num261].Prefix(pre3);
  							Main.chest[num260].item[num261].stack = stack8;
-+							ItemIO.ReceiveModData(Main.chest[num261].item[num261], reader);
++							ItemIO.ReceiveModData(Main.chest[num260].item[num261], reader);
  							Recipe.FindRecipes(canDelayCheck: true);
  						}
  


### PR DESCRIPTION
### What is the bug?
The client crashes when opening a chest in multiplayer.

### How did you fix the bug?
`Main.chest[num261]` was null which seemed like a typo from f33571a. I changed it to 260 then opened a chest successfully.

### Are there alternatives to your fix?
This project is still kind of magic to me, so I don't know.