### PR TITLE
[1.4] Fix crash with memory statistics tooltip

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/UI/UIMemoryBar.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIMemoryBar.cs
@@ -82,19 +82,14 @@ namespace Terraria.ModLoader.UI
 			}
 
 			if (drawHover && hoverData != null) {
-				if(_hoverPanel.Parent!=Parent) {
-					_hoverPanel.Remove();
-					Parent.Append(_hoverPanel);
-				}
-
-				_hoverPanel.Width.Set(hoverRect.Width + 5, 0);
+				_hoverPanel.Width.Set(hoverRect.Width + 10, 0);
 				_hoverPanel.Height.Set(hoverRect.Height + 5, 0);
-				_hoverPanel.Top.Set(Math.Abs(Parent.GetDimensions().Y - hoverRect.Y) - 10, 0);
-				_hoverPanel.Left.Set(Math.Abs(Parent.GetDimensions().X - hoverRect.X) - 20, 0);
+				_hoverPanel.Top.Set(hoverRect.Y - 10, 0);
+				_hoverPanel.Left.Set(hoverRect.X - 8, 0);
 				_hoverPanel.Recalculate();
 				_hoverPanel.Draw(spriteBatch);
 
-				Utils.DrawBorderStringFourWay(spriteBatch, FontAssets.MouseText.Value, hoverData.Tooltip, hoverRect.X, hoverRect.Y, new Color((int)Main.mouseTextColor, (int)Main.mouseTextColor, (int)Main.mouseTextColor, (int)Main.mouseTextColor), Color.Black, Vector2.Zero, 1f);
+				Utils.DrawBorderStringFourWay(spriteBatch, FontAssets.MouseText.Value, hoverData.Tooltip, hoverRect.X + 5, hoverRect.Y + 2, new Color((int)Main.mouseTextColor, (int)Main.mouseTextColor, (int)Main.mouseTextColor, (int)Main.mouseTextColor), Color.Black, Vector2.Zero, 1f);
 			}
 		}
 


### PR DESCRIPTION
### What is the bug?

Fixes crash when hovering over memory tooltip on the "Mods" page as described in the issue https://github.com/tModLoader/tModLoader/issues/1244

### How did you fix the bug?
Crash seems to be caused by editing render hierarchy during drawing, which raises an exception somewhere down the line. Fix simply removes the part of code that appends `_hoverPanel` into `UIMemoryBar`'s parent element's render tree. This also means that the relative offsetting to `Parent.GetDimensions()` can be removed since `_hoverPanel` is now rendered relative to 0 0. I also changed some of the magic offsets to preserve the original look of the tooltip.

### Are there alternatives to your fix?
I'm pretty new to this project so I can't say that this is the best or correct way to fix the issue