### PR TITLE
[1.4] Fix crash with world generation (PlaceBoulderTrapSpot)

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Biomes/DeadMansChestBiome.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Biomes/DeadMansChestBiome.cs.patch
@@ -1,0 +1,11 @@
+--- src/Terraria/Terraria/GameContent/Biomes/DeadMansChestBiome.cs
++++ src/tModLoader/Terraria/GameContent/Biomes/DeadMansChestBiome.cs
+@@ -200,7 +_,7 @@
+ 		}
+ 
+ 		private void PlaceBoulderTrapSpot(Point position, int yPush) {
+-			int[] array = new int[624];
++			int[] array = new int[Main.tileSolid.Length];
+ 			for (int i = position.X; i < position.X + 2; i++) {
+ 				for (int j = position.Y - 4; j <= position.Y; j++) {
+ 					Tile tile = Main.tile[i, j];

--- a/patches/tModLoader/Terraria/GameContent/Biomes/DeadMansChestBiome.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Biomes/DeadMansChestBiome.cs.patch
@@ -1,11 +1,19 @@
 --- src/Terraria/Terraria/GameContent/Biomes/DeadMansChestBiome.cs
 +++ src/tModLoader/Terraria/GameContent/Biomes/DeadMansChestBiome.cs
+@@ -2,6 +_,7 @@
+ using Newtonsoft.Json;
+ using System.Collections.Generic;
+ using Terraria.ID;
++using Terraria.ModLoader;
+ using Terraria.Utilities;
+ using Terraria.WorldBuilding;
+ 
 @@ -200,7 +_,7 @@
  		}
  
  		private void PlaceBoulderTrapSpot(Point position, int yPush) {
 -			int[] array = new int[624];
-+			int[] array = new int[Main.tileSolid.Length];
++			int[] array = new int[TileLoader.TileCount];
  			for (int i = position.X; i < position.X + 2; i++) {
  				for (int j = position.Y - 4; j <= position.Y; j++) {
  					Tile tile = Main.tile[i, j];


### PR DESCRIPTION
### What is the bug?
There is a rare crash during world generation due to an out-of-bounds array index exception. 

### How to reproduce?
1. Build ExampleMod for 1.4 (you might need to change `new Before(...` to `new BeforeParent(...` in ExamplePlayerDrawLayer.cs)
2. Enable ExampleMod (this will bump the length of `Main.tileSolid` and other tile arrays to 640)
3. Create a `Medium` sized `Journey` world with `Crimson` and seed `678930300`
4. The game should crash in `Micro Biomes` world generation phase

### How did you fix the bug?
Instead of 624 fixed sized array, borrow the correct size from `Main.tileSolid`. There doesn't appear to be a constant for the tile count so this seemed like the most straight forward way. This fix simply makes `PlaceBoulderTrapSpot` agnostic to what the maximum number of tile types in the game is.

### Are there alternatives to your fix?
If there is an up-to-date constant or some other way to get the max number of tile types, perhaps that could be used instead of borrowing the number directly from `Main.tileSolid`?


### Relevant crashlog
```
[12:34:16] [37/ERROR] [tML]: A problem was encountered during world generation
Micro Biomes
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Terraria.GameContent.Biomes.DeadMansChestBiome.PlaceBoulderTrapSpot(Point position, Int32 yPush) in tModLoader\Terraria\GameContent\Biomes\DeadMansChestBiome.cs:line 208
   at Terraria.GameContent.Biomes.DeadMansChestBiome.FindBoulderTrapSpot(Point position) in tModLoader\Terraria\GameContent\Biomes\DeadMansChestBiome.cs:line 199
   at Terraria.GameContent.Biomes.DeadMansChestBiome.FindBoulderTrapSpots(Point position) in tModLoader\Terraria\GameContent\Biomes\DeadMansChestBiome.cs:line 155
   at Terraria.GameContent.Biomes.DeadMansChestBiome.GetPossibleChestsToTrapify(StructureMap structures) in tModLoader\Terraria\GameContent\Biomes\DeadMansChestBiome.cs:line 337
   at Terraria.WorldGen.<>c__DisplayClass343_0.<GenerateWorld>b__102(GenerationProgress progress, GameConfiguration passConfig) in tModLoader\Terraria\WorldGen.cs:line 11401
   at Terraria.GameContent.Generation.PassLegacy.ApplyPass(GenerationProgress progress, GameConfiguration configuration) in tModLoader\Terraria\GameContent\Generation\PassLegacy.cs:line 226
   at Terraria.WorldBuilding.GenPass.Apply(GenerationProgress progress, GameConfiguration configuration) in tModLoader\Terraria\WorldBuilding\GenPass.cs:line 24
   at Terraria.WorldBuilding.WorldGenerator.GenerateWorld(GenerationProgress progress) in tModLoader\Terraria\WorldBuilding\WorldGenerator.cs:line 47
[12:34:16] [37/ERROR] [Terraria]: A problem was encountered during world generation
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Terraria.WorldBuilding.WorldGenerator.GenerateWorld(GenerationProgress progress) in tModLoader\Terraria\WorldBuilding\WorldGenerator.cs:line 61
   at Terraria.WorldGen.GenerateWorld(Int32 seed, GenerationProgress customProgressObject) in tModLoader\Terraria\WorldGen.cs:line 11878
   at Terraria.WorldGen.do_worldGenCallBack(Object threadContext) in tModLoader\Terraria\WorldGen.cs:line 2299
   at Terraria.WorldGen.worldGenCallback(Object threadContext) in tModLoader\Terraria\WorldGen.cs:line 2289
```
