### PR TITLE
[1.4] Fix ModPlayer CanHitNPC hook not getting called ever

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3034,6 +3034,27 @@
  				if (Main.netMode != 0)
  					NetMessage.SendPlayerHurt(i, playerDeathReason, num, direction, flag, pvp: true, -1);
  
+@@ -30601,11 +_,17 @@
+ 				if (!Main.npc[i].active || Main.npc[i].immune[whoAmI] != 0 || attackCD != 0)
+ 					continue;
+ 
++				bool? modCanHit = PlayerHooks.CanHitNPC(this, sItem, Main.npc[i]);
++
++				if (modCanHit == false) {
++					continue;
++				}
++
+ 				Main.npc[i].position += Main.npc[i].netOffset;
+-				if (!Main.npc[i].dontTakeDamage && CanNPCBeHitByPlayerOrPlayerProjectile(Main.npc[i])) {
++				if (!Main.npc[i].dontTakeDamage && (CanNPCBeHitByPlayerOrPlayerProjectile(Main.npc[i]) || modCanHit == true)) {
+-					if (!Main.npc[i].friendly || (Main.npc[i].type == 22 && killGuide) || (Main.npc[i].type == 54 && killClothier)) {
++					if (!Main.npc[i].friendly || (Main.npc[i].type == 22 && killGuide) || (Main.npc[i].type == 54 && killClothier) || modCanHit == true) {
+ 						Rectangle value = new Rectangle((int)Main.npc[i].position.X, (int)Main.npc[i].position.Y, Main.npc[i].width, Main.npc[i].height);
+-						if (itemRectangle.Intersects(value) && (Main.npc[i].noTileCollide || CanHit(Main.npc[i]))) {
++						if (itemRectangle.Intersects(value) && (Main.npc[i].noTileCollide || CanHit(Main.npc[i]) || modCanHit == true)) {
+ 							int num = originalDamage;
+ 							bool flag = false;
+ 							int weaponCrit = GetWeaponCrit(sItem);
 @@ -30638,6 +_,11 @@
  							}
  


### PR DESCRIPTION
### What is this?
`ModPlayer::CanHitNPC` hook doesn't ever get called from anywhere (there are no calls to `PlayerHooks.CanHitNPC` in the 1.4 code by the looks of it). Add the call into `ItemCheck_MeleeHitNPCs` so that mods can use the hook.

### Considerations
- This implementation adds the call to the very root of `ItemCheck_MeleeHitNPCs` (so it can override all the relevant game logic), which means that the hook will be called very frequently. Do we expect modders to implement heavy logic into this hook?
- This implementation appends the checks into existing if-statements, leading to clutter. Since the change is done via patching, this seems like the way to go. Should refactoring & cleaner code be considered instead?
- This doesn't fix https://github.com/tModLoader/tModLoader/issues/389 , however the hook will now work as stated in the documentation:
```C#
/// <summary>
/// Allows you to determine whether a player can hit the given NPC by swinging a melee weapon. Return true to allow hitting the target, return false to block this player from hitting the target, and return null to use the vanilla code for whether the target can be hit. Returns null by default.
/// </summary>
/// <param name="item"></param>
/// <param name="target"></param>
/// <returns></returns>
public virtual bool? CanHitNPC(Item item, NPC target) {
	return null;
}
```

### Alternatives
There might be alternative places to place the call, but `ItemCheck_MeleeHitNPCs` appeared the most logical place

