### PR TITLE
[Changes Requested][1.3] Resolve multiplayer frame drops in 1.3 version, matching PR 1272 of 1.4

### DIFF
--- a/patches/tModLoader/Terraria/Netplay.cs.patch
+++ b/patches/tModLoader/Terraria/Netplay.cs.patch
@@ -123,7 +123,6 @@
  							NetMessage.SendData(8, -1, -1, null, Main.player[Main.myPlayer].SpawnX, Main.player[Main.myPlayer].SpawnY);
  						}
  
-
 @@ -307,6 +_,7 @@
  					num = Connection.State;
  				}

--- a/patches/tModLoader/Terraria/Netplay.cs.patch
+++ b/patches/tModLoader/Terraria/Netplay.cs.patch
@@ -123,15 +123,7 @@
  							NetMessage.SendData(8, -1, -1, null, Main.player[Main.myPlayer].SpawnX, Main.player[Main.myPlayer].SpawnY);
  						}
  
-@@ -296,8 +_,6 @@
- 								Main.statusText = Connection.StatusText + ": " + (int)((float)Connection.StatusCount / (float)Connection.StatusMax * 100f) + "%";
- 							}
- 						}
--
--						Thread.Sleep(1);
- 					}
- 					else if (Connection.IsActive) {
- 						Main.statusText = Language.GetTextValue("Net.LostConnection");
+
 @@ -307,6 +_,7 @@
  					num = Connection.State;
  				}


### PR DESCRIPTION
Resolves longstanding issue of multiplayer frame drops.
Patch 1.3 per the following change: https://github.com/tModLoader/tModLoader/pull/1272/commits/31713772a7d5c2c8534199581cfc4dd994c985f5
As part of: https://github.com/tModLoader/tModLoader/pull/1272

*My opinion* is we should patch this on 1.3 as well, while 1.4 is still being developed.