### PR TITLE
[1.4] Auto treasure bag droptable registering + NPC setDefaultsToType constructor

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.cs.patch
@@ -29,3 +29,20 @@
  			TrimDuplicateRulesForNegativeIDs();
  		}
  
+@@ -231,6 +_,16 @@
+ 			RegisterBoss_PumpkinMoon();
+ 			RegisterBoss_HallowBoss();
+ 			RegisterBoss_QueenSlime();
++
++			for (int i = NPCID.Count; i < NPCLoader.NPCCount; i++) {
++				//For modded NPCs, automatically register boss bags as a drop rule
++				NPC npc = ContentSamples.NpcsByNetId[i];
++				int bagType = -1;
++				NPCLoader.BossBag(npc, ref bagType);
++
++				if (bagType > -1)
++					RegisterToNPC(i, ItemDropRule.BossBag(bagType));
++			}
+ 		}
+ 
+ 		private void RegisterBoss_QueenSlime() {

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -30,6 +30,19 @@
  		public bool midas;
  		public bool ichor;
  		public bool onFire;
+@@ -284,6 +_,12 @@
+ 		private static int maximumAmountOfTimesLadyBugRainCanStack = 10 * ladyBugRainTime;
+ 		public static int offSetDelayTime = 60;
+ 
++		public NPC() { }
++
++		public NPC(int setDefaultsToType, NPCSpawnParams spawnparams = default(NPCSpawnParams)) {
++			SetDefaults(setDefaultsToType, spawnparams);
++		}
++
+ 		public bool CanTalk {
+ 			get {
+ 				if (isLikeATownNPC && aiStyle == 7 && velocity.Y == 0f)
 @@ -653,7 +_,7 @@
  		public static void UpdateFoundActiveNPCs() {
  			for (int i = 0; i < 200; i++) {
@@ -562,10 +575,11 @@
  					Main.npc[i].active = false;
  					NetMessage.SendData(23, -1, -1, null, i);
  				}
-@@ -59769,6 +_,7 @@
+@@ -59769,6 +_,8 @@
  			if (type == 551)
  				itemType = 3860;
  
++			//Left in for compatibility. It is now in ItemDropDatabase.RegisterBosses
 +			NPCLoader.BossBag(this, ref itemType);
  			DropItemInstanced(position, base.Size, itemType);
  		}


### PR DESCRIPTION
### Description
With 1.4, the old methods of dropping items from NPCs are now obsolete (literally, the `NPC.NPCLootOld()` is not referenced anywhere), with it the way TML added boss bags to the drop logic. 

Added a comment on the obsolete method in case of compatibility, aswell as made it so after vanilla registers all boss loot, TML registers boss bags using the previous 1.3 logic, meaning modders don't have to manually register bags in 1.4 (They sort of had to in 1.3 by checking `Main.expertMode` and calling `NPC.DropBossBags()`).

As an aside, added a convenience constructor for `NPC` (the same way that a previous commit added a new `Item` constructor) that automatically calls SetDefaults with the given type on it.