### PR TITLE
[1.4] Small issue preventing compilation

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -385,7 +385,7 @@
  			mouseBorderColorSlider.Alpha = (float)(int)MouseBorderColor.A / 255f;
 -			if (currentValue != 234)
 +			if (currentValue != 234 || ModLoader.ModLoader.LastLaunchedTModLoaderVersion != ModLoader.ModLoader.version) {
-+				ModLoader.MigrateSettings();
++				ModLoader.ModLoader.MigrateSettings();
  				SaveSettings();
 +			}
  		}


### PR DESCRIPTION
`ModLoader` is namespace, no methods
so change `ModLoader` to `ModLoader.ModLoader`, now compiler happy and you can use methods