### PR TITLE
Fixed DamageClass throwing an exception before the game can even start

### DIFF
--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -17,11 +17,13 @@ namespace Terraria
 
 		private DamageClass _damageClass = DamageClass.Generic;
 		/// <summary>
-		/// The damage type of this Item. Assign to DamageClass.Melee/Ranged/Magic/Summon/Throwing for vanilla classes, or ModContent.GetInstance<T>() for custom damage types.
+		/// The damage type of this Item.
+		/// Assign to DamageClass.Melee/Ranged/Magic/Summon/Throwing for vanilla classes, or ModContent.GetInstance<T>() for custom damage types.
+		/// Set to DamageClass.Generic to not have any one damage class, but still have the weapon be boosted by universal bonuses.
 		/// </summary>
 		public DamageClass DamageType {
 			get => _damageClass;
-			set => _damageClass = value ?? throw new ArgumentException("DamageType cannot be null");
+			set => _damageClass = value;
 		}
 
 		/// <summary> Gets the instance of the specified GlobalItem type. This will throw exceptions on failure. </summary>
@@ -84,6 +86,11 @@ namespace Terraria
 		public static int NewItem(Vector2 position, int Type, int Stack = 1, bool noBroadcast = false, int prefixGiven = 0, bool noGrabDelay = false, bool reverseLookup = false) => 
 			NewItem((int)position.X, (int)position.Y, 0, 0, Type, Stack, noBroadcast, prefixGiven, noGrabDelay, reverseLookup);
 
-		public bool CountsAsClass(DamageClass damageClass) => DamageClassLoader.countsAs[DamageType.Type, damageClass.Type];
+		public bool CountsAsClass(DamageClass damageClass) {
+			if (DamageType != null)
+				return DamageClassLoader.countsAs[DamageType.Type, damageClass.Type];
+
+			return false;
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/Projectile.TML.cs
+++ b/patches/tModLoader/Terraria/Projectile.TML.cs
@@ -12,11 +12,13 @@ namespace Terraria
 
 		private DamageClass _damageClass = DamageClass.Generic;
 		/// <summary>
-		/// The damage type of this Projectile. Assign to DamageClass.Generic/Melee/Ranged/Magic/Summon/Throwing, or ModContent.GetInstance<T>() for custom damage types.
+		/// The damage type of this Projectile.
+		/// Assign to DamageClass.Melee/Ranged/Magic/Summon/Throwing for vanilla classes, or ModContent.GetInstance<T>() for custom damage types.
+		/// Set to DamageClass.Generic to not have any one damage class, but still have the weapon be boosted by universal bonuses.
 		/// </summary>
 		public DamageClass DamageType {
 			get => _damageClass;
-			set => _damageClass = value ?? throw new ArgumentException("DamageType cannot be null");
+			set => _damageClass = value;
 		}
 
 		/// <summary> Gets the instance of the specified GlobalProjectile type. This will throw exceptions on failure. </summary>
@@ -53,6 +55,11 @@ namespace Terraria
 		}
 		*/
 
-		public bool CountsAsClass(DamageClass damageClass) => DamageClassLoader.countsAs[DamageType.Type, damageClass.Type];
+		public bool CountsAsClass(DamageClass damageClass) {
+			if (DamageType != null)
+				return DamageClassLoader.countsAs[DamageType.Type, damageClass.Type];
+
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
Title says it all. Somehow, a null check was added to the DamageClass PR right before it got merged which caused the game to throw an error before even starting properly, preventing all forms of actually opening the game. This PR fixes this.