### PR TITLE
[1.4] Quick Mod Delete

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -338,8 +338,6 @@
 		// Misc
 		"OK": "OK",
 		"Continue": "Continue",
-		"Yes": "Yes",
-		"No": "No",
 		"DeleteModConfirm": "Are you sure you want to delete this mod permanently?",
 		"PatreonSetTooltip": "Thank you for your support!",
 		"WorldGenError": "A problem was encountered during world generation",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -338,6 +338,9 @@
 		// Misc
 		"OK": "OK",
 		"Continue": "Continue",
+		"Yes": "Yes",
+		"No": "No",
+		"DeleteModConfirm": "Are you sure you want to delete this mod permanently?",
 		"PatreonSetTooltip": "Thank you for your support!",
 		"WorldGenError": "A problem was encountered during world generation",
 		"WorldIODataException": "The game encountered a mod data problem for a world.",

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -395,14 +395,7 @@ namespace Terraria.ModLoader.UI
 		}
 
 		private void QuickModDelete(UIMouseEvent evt, UIElement listeningElement) {
-			bool shiftPressed = false;
-			List<Keys> pressedKeys = Main.keyState.GetPressedKeys().ToList();
-			for (int i = 0; i < pressedKeys.Count; i++) {
-				if (pressedKeys[i] == Keys.LeftShift || pressedKeys[i] == Keys.RightShift) {
-					shiftPressed = true;
-					break;
-				}
-			}
+			bool shiftPressed = Main.keyState.PressingShift();
 
 			if (!shiftPressed) {
 				SoundEngine.PlaySound(10, -1, -1, 1);
@@ -426,7 +419,7 @@ namespace Terraria.ModLoader.UI
 				_deleteModDialog.SetPadding(6f);
 				Interface.modsMenu.Append(_deleteModDialog);
 
-				_dialogYesButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.Yes")) {
+				_dialogYesButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("LegacyMenu.104")) {
 					TextColor = Color.White,
 					Width = new StyleDimension(-10f, 1f / 3f),
 					Height = { Pixels = 40 },
@@ -436,7 +429,7 @@ namespace Terraria.ModLoader.UI
 				_dialogYesButton.OnClick += DeleteMod;
 				_deleteModDialog.Append(_dialogYesButton);
 
-				_dialogNoButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.No")) {
+				_dialogNoButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("LegacyMenu.105")) {
 					TextColor = Color.White,
 					Width = new StyleDimension(-10f, 1f / 3f),
 					Height = { Pixels = 40 },

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -15,6 +15,8 @@ using Terraria.Audio;
 using Terraria.GameContent;
 using ReLogic.Content;
 using ReLogic.OS;
+using System.IO;
+using Microsoft.Xna.Framework.Input;
 
 namespace Terraria.ModLoader.UI
 {
@@ -29,6 +31,12 @@ namespace Terraria.ModLoader.UI
 		private UIText _modName;
 		private UIModStateText _uiModStateText;
 		private UIHoverImage _modReferenceIcon;
+		private UIImage _deleteModButton;
+		private UIAutoScaleTextTextPanel<string> _dialogYesButton;
+		private UIAutoScaleTextTextPanel<string> _dialogNoButton;
+		private UIText _dialogText;
+		private UIImage _blockInput;
+		private UIPanel _deleteModDialog;
 		private readonly LocalMod _mod;
 
 		private bool _configChangesRequireReload;
@@ -185,6 +193,17 @@ namespace Terraria.ModLoader.UI
 				if (e.Target.GetType() != typeof(UIModStateText))
 					_uiModStateText.Click(e);
 			};
+
+			if (!_loaded) {
+				_deleteModButton = new UIImage(TextureAssets.Trash) {
+					Width = { Pixels = 36 },
+					Height = { Pixels = 36 },
+					Left = { Pixels = _moreInfoButton.Left.Pixels - (_configButton == null ? 0 : _configButton.Left.Pixels) - 36 - PADDING, Precent = 1 },
+					Top = { Pixels = 42.5f }
+				};
+				_deleteModButton.OnClick += QuickModDelete;
+				Append(_deleteModButton);
+			}
 		}
 
 		// TODO: "Generate Language File Template" button in upcoming "Miscellaneous Tools" menu.
@@ -243,6 +262,9 @@ namespace Terraria.ModLoader.UI
 
 			if (_moreInfoButton?.IsMouseHovering == true) {
 				_tooltip = Language.GetTextValue("tModLoader.ModsMoreInfo");
+			}
+			else if (_deleteModButton?.IsMouseHovering == true) {
+				_tooltip = Language.GetTextValue("UI.Delete");
 			}
 			else if (_modName?.IsMouseHovering == true && _mod?.properties.author.Length > 0) {
 				_tooltip = Language.GetTextValue("tModLoader.ModsByline", _mod.properties.author);
@@ -370,6 +392,83 @@ namespace Terraria.ModLoader.UI
 				case EnabledFilter.DisabledOnly:
 					return !_mod.Enabled;
 			}
+		}
+
+		private void QuickModDelete(UIMouseEvent evt, UIElement listeningElement) {
+			bool shiftPressed = false;
+			List<Keys> pressedKeys = Main.keyState.GetPressedKeys().ToList();
+			for (int i = 0; i < pressedKeys.Count; i++) {
+				if (pressedKeys[i] == Keys.LeftShift || pressedKeys[i] == Keys.RightShift) {
+					shiftPressed = true;
+					break;
+				}
+			}
+
+			if (!shiftPressed) {
+				SoundEngine.PlaySound(10, -1, -1, 1);
+				_blockInput = new UIImage(TextureAssets.Extra[190]) {
+					Width = { Percent = 1 },
+					Height = { Percent = 1 },
+					Color = new Color(0, 0, 0, 0),
+					ScaleToFit = true
+				};
+				_blockInput.OnMouseDown += CloseDialog;
+				Interface.modsMenu.Append(_blockInput);
+
+				_deleteModDialog = new UIPanel() {
+					Width = { Percent = .20f },
+					Height = { Percent = .20f },
+					HAlign = .5f,
+					VAlign = .5f,
+					BackgroundColor = new Color(63, 82, 151),
+					BorderColor = Color.Black
+				};
+				_deleteModDialog.SetPadding(6f);
+				Interface.modsMenu.Append(_deleteModDialog);
+
+				_dialogYesButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.Yes")) {
+					TextColor = Color.White,
+					Width = new StyleDimension(-10f, 1f / 3f),
+					Height = { Pixels = 40 },
+					VAlign = .85f,
+					HAlign = .15f
+				}.WithFadedMouseOver();
+				_dialogYesButton.OnClick += DeleteMod;
+				_deleteModDialog.Append(_dialogYesButton);
+
+				_dialogNoButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.No")) {
+					TextColor = Color.White,
+					Width = new StyleDimension(-10f, 1f / 3f),
+					Height = { Pixels = 40 },
+					VAlign = .85f,
+					HAlign = .85f
+				}.WithFadedMouseOver();
+				_dialogNoButton.OnClick += CloseDialog;
+				_deleteModDialog.Append(_dialogNoButton);
+
+				_dialogText = new UIText(Language.GetTextValue("tModLoader.DeleteModConfirm")) {
+					Width = { Percent = .75f },
+					HAlign = .5f,
+					VAlign = .3f,
+					IsWrapped = true
+				};
+				_deleteModDialog.Append(_dialogText);
+			}
+			else {
+				DeleteMod(evt, listeningElement);
+			}
+		}
+
+		private void CloseDialog(UIMouseEvent evt, UIElement listeningElement) {
+			SoundEngine.PlaySound(SoundID.MenuClose);
+			_blockInput?.Remove();
+			_deleteModDialog?.Remove();
+		}
+
+		private void DeleteMod(UIMouseEvent evt, UIElement listeningElement) {
+			File.Delete(_mod.modFile.path);
+			CloseDialog(evt, listeningElement);
+			Interface.modsMenu.Activate();
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -198,7 +198,7 @@ namespace Terraria.ModLoader.UI
 				_deleteModButton = new UIImage(TextureAssets.Trash) {
 					Width = { Pixels = 36 },
 					Height = { Pixels = 36 },
-					Left = { Pixels = _moreInfoButton.Left.Pixels - (_configButton == null ? 0 : _configButton.Left.Pixels) - 36 - PADDING, Precent = 1 },
+					Left = { Pixels = _moreInfoButton.Left.Pixels - 36 - PADDING, Precent = 1 },
 					Top = { Pixels = 42.5f }
 				};
 				_deleteModButton.OnClick += QuickModDelete;


### PR DESCRIPTION
### What is the new feature?
This feature allows the user to quickly delete disabled mods without having to go into the More Info menu.
### Why should this be part of tModLoader?
Because it's currently hard to quickly delete mods inside tModLoader.
### Are there alternative designs?
Yes, issue #1271 has a similar concept design.
### Sample usage for the new feature
(Pressing L/R Shift skips the dialog box)
https://user-images.githubusercontent.com/30240961/106326907-2d8f6500-6275-11eb-9a59-02f711b5ccf7.mp4

Notes: 
- The trash icon might need to be updated, I simply made use of an already existing asset.
- I couldn't quite manage to center the wrapped text in the dialog box, I'd love some feedback (and help) on it.