### PR TITLE
[1.4] Remove skipped parameter from BossBarLoader.PostDraw

### DIFF
--- a/ExampleMod/Common/GlobalBossBars/ExampleGlobalBossBar.cs
+++ b/ExampleMod/Common/GlobalBossBars/ExampleGlobalBossBar.cs
@@ -20,8 +20,8 @@ namespace ExampleMod.Common.GlobalBossBars
 			return true;
 		}
 
-		public override void PostDraw(bool skipped, SpriteBatch spriteBatch, NPC npc, BossBarDrawParams drawParams) {
-			if (!skipped && npc.type == NPCID.EyeofCthulhu) {
+		public override void PostDraw(SpriteBatch spriteBatch, NPC npc, BossBarDrawParams drawParams) {
+			if (npc.type == NPCID.EyeofCthulhu) {
 				string text = "GlobalBossBar Showcase";
 				var font = FontAssets.MouseText.Value;
 				Vector2 size = font.MeasureString(text);

--- a/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarHelper.cs.patch
@@ -40,7 +40,7 @@
 +				if (!skipped)
 +					BossBarLoader.DrawFancyBar_TML(spriteBatch, drawParams);
 +
-+				BossBarLoader.PostDraw(skipped, spriteBatch, info, drawParams);
++				BossBarLoader.PostDraw(spriteBatch, info, drawParams);
 +
 +				return;
 +			}

--- a/patches/tModLoader/Terraria/ModLoader/BossBarLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BossBarLoader.cs
@@ -195,7 +195,7 @@ namespace Terraria.ModLoader
 			return modify;
 		}
 
-		public static void PostDraw(bool skipped, SpriteBatch spriteBatch, BigProgressBarInfo info, BossBarDrawParams drawParams) {
+		public static void PostDraw(SpriteBatch spriteBatch, BigProgressBarInfo info, BossBarDrawParams drawParams) {
 			int index = info.npcIndexToAimAt;
 			if (index < 0 || index > Main.maxNPCs)
 				return; //Invalid data, abort
@@ -203,10 +203,10 @@ namespace Terraria.ModLoader
 			NPC npc = Main.npc[index];
 
 			if (NpcToBossBar(npc, out ModBossBar bossBar))
-				bossBar.PostDraw(skipped, spriteBatch, npc, drawParams);
+				bossBar.PostDraw(spriteBatch, npc, drawParams);
 
 			foreach (GlobalBossBar globalBossBar in globalBossBars) {
-				globalBossBar.PostDraw(skipped, spriteBatch, npc, drawParams);
+				globalBossBar.PostDraw(spriteBatch, npc, drawParams);
 			}
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalBossBar.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalBossBar.cs
@@ -22,11 +22,10 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Allows you to draw things after the bar has been drawn. skipped is true if you or another mod has skipped drawing the bar (possibly hiding it or in favor of new visuals).
 		/// </summary>
-		/// <param name="skipped"><see langword="true"/> if you or another mod has skipped drawing the bar in PreDraw (possibly hiding it or in favor of new visuals)</param>
 		/// <param name="spriteBatch">The spriteBatch that is drawn on</param>
 		/// <param name="npc">The NPC this bar is focused on</param>
 		/// <param name="drawParams">The draw parameters for the boss bar</param>
-		public virtual void PostDraw(bool skipped, SpriteBatch spriteBatch, NPC npc, BossBarDrawParams drawParams) {
+		public virtual void PostDraw(SpriteBatch spriteBatch, NPC npc, BossBarDrawParams drawParams) {
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModBossBar.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBossBar.cs
@@ -66,11 +66,10 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Allows you to draw things after the bar has been drawn. skipped is true if you or another mod has skipped drawing the bar in PreDraw (possibly hiding it or in favor of new visuals).
 		/// </summary>
-		/// <param name="skipped"><see langword="true"/> if you or another mod has skipped drawing the bar (possibly hiding it or in favor of new visuals)</param>
 		/// <param name="spriteBatch">The spriteBatch that is drawn on</param>
 		/// <param name="npc">The NPC this ModBossBar is focused on</param>
 		/// <param name="drawParams">The draw parameters for the boss bar</param>
-		public virtual void PostDraw(bool skipped, SpriteBatch spriteBatch, NPC npc, BossBarDrawParams drawParams) {
+		public virtual void PostDraw(SpriteBatch spriteBatch, NPC npc, BossBarDrawParams drawParams) {
 		}
 
 		public bool ValidateAndCollectNecessaryInfo(ref BigProgressBarInfo info) {


### PR DESCRIPTION
Follow-up on the PRs #1316 and #1288, the latter one adding a skipped parameter on the `1.4` branch, which this PR removes. Reason: Lack of definitive use cases