### PR TITLE
ItemLoader UseItemFrame Fix Issue#319

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2915,15 +2915,6 @@
  					if ((double)itemAnimation < (double)itemAnimationMax * 0.333)
  						bodyFrame.Y = bodyFrame.Height * 3;
  					else if ((double)itemAnimation < (double)itemAnimationMax * 0.666)
-@@ -25525,7 +_,7 @@
- 								bodyFrame.Y = bodyFrame.Height * 2;
- 						}
- 					}
--				}
-+				}	
- 			}
- 			else if (pulley) {
- 				if (pulleyDir == 2)
 @@ -25550,6 +_,8 @@
  				_ = bodyFrame;
  				reference6.Y = 0;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2905,12 +2905,22 @@
  			if (mount.Active) {
  				legFrameCounter = 0.0;
  				legFrame.Y = legFrame.Height * 6;
-@@ -25526,6 +_,8 @@
+@@ -25444,7 +_,8 @@
+ 				reference5.Y = 0;
+ 			}
+ 			else if (itemAnimation > 0 && inventory[selectedItem].useStyle != 10 && flag4) {
++				if (ItemLoader.UseItemFrame(this.inventory[this.selectedItem], this)) { /* Did custom framing */ } 
+-				if (inventory[selectedItem].useStyle == 1 || inventory[selectedItem].type == 0) {
++				else if (inventory[selectedItem].useStyle == 1 || inventory[selectedItem].type == 0) {
+ 					if ((double)itemAnimation < (double)itemAnimationMax * 0.333)
+ 						bodyFrame.Y = bodyFrame.Height * 3;
+ 					else if ((double)itemAnimation < (double)itemAnimationMax * 0.666)
+@@ -25525,7 +_,7 @@
+ 								bodyFrame.Y = bodyFrame.Height * 2;
  						}
  					}
- 				}
-+				else
-+					ItemLoader.UseItemFrame(this.inventory[this.selectedItem], this); //TODO: does this method need to return bool? Should it run before the rest of the useStyle code?
+-				}
++				}	
  			}
  			else if (pulley) {
  				if (pulleyDir == 2)


### PR DESCRIPTION
### What is the bug?
#319 

### How did you fix the bug?
I moved ItemLoader.UseItemFrame, which already returns a bool, from the end of the if chain to the beginning so it runs first, and thus attempts are now modded -> global -> vanilla instead of vanilla -> modded -> global.
The obvious concern being that this increases the amount of calculations as the global hook list gets called more often, but that's a given in ensuring globals are checked per the issue's decision

### Are there alternatives to your fix?
Don't know. Didn't think much on this as it seems straightforward enough.