### PR TITLE
[1.4] CanBurnInLava hook rework (implements #1040)

### DIFF
--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -641,12 +641,22 @@
  			if (Main.netMode == 2 && playerIndexTheItemIsReservedFor != Main.myPlayer) {
  				timeSinceTheItemHasBeenReservedForSomeone++;
  				if (timeSinceTheItemHasBeenReservedForSomeone >= 300) {
-@@ -45395,7 +_,7 @@
+@@ -45376,6 +_,7 @@
+ 		}
+ 
+ 		private void CheckLavaDeath(int i) {
++			bool? canBurnInLava = ItemLoader.CanBurnInLava(this);
+ 			if (type == 267) {
+ 				if (Main.netMode == 1)
+ 					return;
+@@ -45395,7 +_,9 @@
  
  				NetMessage.SendData(21, -1, -1, null, i);
  			}
++			else if (canBurnInLava == false)
++				return;
 -			else if (playerIndexTheItemIsReservedFor == Main.myPlayer && type != 312 && type != 318 && type != 173 && type != 174 && type != 4422 && type != 175 && type != 2701 && rare == 0) {
-+			else if (playerIndexTheItemIsReservedFor == Main.myPlayer && type != 312 && type != 318 && type != 173 && type != 174 && type != 4422 && type != 175 && type != 2701 && rare == 0 || ItemLoader.CanBurnInLava(this)) {
++			else if (canBurnInLava == true || (playerIndexTheItemIsReservedFor == Main.myPlayer && type != 312 && type != 318 && type != 173 && type != 174 && type != 4422 && type != 175 && type != 2701 && rare == 0)) {
  				active = false;
  				type = 0;
  				stack = 0;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -598,10 +598,10 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Returns whether or not this item burns when it is thrown into lava despite item.rare not being 0. Returns false by default.
+		/// Returns whether or not this item will burn in lava regardless of any conditions. Returns null by default (follow vanilla behaviour).
 		/// </summary>
-		public virtual bool CanBurnInLava(Item item) {
-			return false;
+		public virtual bool? CanBurnInLava(Item item) {
+			return null;
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1394,18 +1394,27 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		private static HookList HookCanBurnInLava = AddHook<Func<Item, bool>>(g => g.CanBurnInLava);
+		private static HookList HookCanBurnInLava = AddHook<Func<Item, bool?>>(g => g.CanBurnInLava);
 		/// <summary>
 		/// Calls ModItem.CanBurnInLava.
 		/// </summary>
-		public static bool CanBurnInLava(Item item)
+		public static bool? CanBurnInLava(Item item)
 		{
+			bool? canBurnInLava = null;
 			foreach (var g in HookCanBurnInLava.Enumerate(item.globalItems)) {
-				if (g.CanBurnInLava(item))
-					return true;
+				bool? globalCanBurnInLava = g.CanBurnInLava(item);
+				switch (globalCanBurnInLava) {
+					case null:
+						continue;
+					case false:
+						canBurnInLava = false;
+						continue;
+					case true:
+						return true;
+				}
 			}
 
-			return item.ModItem?.CanBurnInLava() ?? false;
+			return canBurnInLava ?? item.ModItem?.CanBurnInLava();
 		}
 		
 		private static HookList HookPostUpdate = AddHook<Action<Item>>(g => g.PostUpdate);

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1402,8 +1402,7 @@ namespace Terraria.ModLoader
 		{
 			bool? canBurnInLava = null;
 			foreach (var g in HookCanBurnInLava.Enumerate(item.globalItems)) {
-				bool? globalCanBurnInLava = g.CanBurnInLava(item);
-				switch (globalCanBurnInLava) {
+				switch (g.CanBurnInLava(item)) {
 					case null:
 						continue;
 					case false:

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -707,11 +707,10 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Returns whether or not this item burns when it is thrown into lava despite item.rare not being 0. Returns false by default.
+		/// Returns whether or not this item will burn in lava regardless of any conditions. Returns null by default (follow vanilla behaviour).
 		/// </summary>
-		public virtual bool CanBurnInLava()
-		{
-			return false;
+		public virtual bool? CanBurnInLava() {
+			return null;
 		}
 		
 		/// <summary>


### PR DESCRIPTION
### What is the new feature?
Implementation of improvements suggested in #1040. CanBurnInLava hook can now be used to either force an item to burn in lava regardless of any conditions or the opposite. The order of precedence is set such as suggested by @Chicken-Bones in #1040.

### Why should this be part of tModLoader?
This rework allows for a better control of whether the item will burn or not by completely ignoring vanilla rules if needed (the only exception is the Guide Voodoo Doll, as i'm not sure what could be the use case here that don't just break the game). As mentioned in #1040, before it was impossible to make the item not burn by using this hook.

### Are there alternative designs?
While i think the current order of precedence makes sense, other orders are possible. I think there is no single right anwser here, so we should just stick to whatever works in most cases, which seems to apply to current solution. However, other options should still probably be considered.

### Sample usage for the new feature
White rarity item that does not burn in lava.

### ExampleMod updates
As it's a pretty niche feature, i don't think it's that important to create an example for it, but i can do it if it's needed.