### PR TITLE
Modifiable Menu Buttons Through ModMenu

### DIFF
--- a/ExampleMod/Content/ExampleModMenu.cs
+++ b/ExampleMod/Content/ExampleModMenu.cs
@@ -50,10 +50,9 @@ namespace ExampleMod.Content
 			buttons.First().color = Main.DiscoColor;
 
 			// Use a foreach loop to modify all buttons in the list
-			foreach (MenuButton button in buttons) {
+			foreach (MenuButton button in buttons)
 				// Forcefully set the yOffsetPos of every button to _globalButtonOffset, which is modified through our ExampleButton below
 				button.yOffsetPos = _globalButtonOffset;
-			}
 
 			// Make sure we're on the title screen menu
 			// If we aren't, then return and don't execute the code below

--- a/ExampleMod/Content/ExampleModMenu.cs
+++ b/ExampleMod/Content/ExampleModMenu.cs
@@ -1,16 +1,21 @@
-﻿using Terraria;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using ReLogic.Content;
-using Terraria.ModLoader;
+using System.Collections.Generic;
+using System.Linq;
+using Terraria;
 using Terraria.Audio;
 using Terraria.ID;
+using Terraria.ModLoader;
 
 namespace ExampleMod.Content
 {
 	public class ExampleModMenu : ModMenu
 	{
 		private const string menuAssetPath = "ExampleMod/Assets/Textures/Menu"; // Creates a constant variable representing the texture path, so we don't have to write it out multiple times
+
+		private int _globalButtonOffset;
+		private int _ticksHovered;
 
 		public override Asset<Texture2D> Logo => base.Logo;
 
@@ -31,6 +36,57 @@ namespace ExampleMod.Content
 		public override bool PreDrawLogo(SpriteBatch spriteBatch, ref Vector2 logoDrawCenter, ref float logoRotation, ref float logoScale, ref Color drawColor) {
 			drawColor = Main.DiscoColor; // Changes the draw color of the logo
 			return true;
+		}
+
+		// This hook allows you to modify the buttons on the main menu
+		// These changes only take place if your menu is loaded
+		public override void ModifyMenuButtons(List<MenuButton> buttons) {
+			// If there are no MenuButtons in the list, return, since there's nothing to do
+			if (buttons.Count == 0)
+				return;
+
+			// Color the first button in the list rainbow
+			// This will always be applied no matter what menu mode the user is on (menu modes are not the same as ModMenus)
+			buttons.First().color = Main.DiscoColor;
+
+			// Use a foreach loop to modify all buttons in the list
+			foreach (MenuButton button in buttons) {
+				// Forcefully set the yOffsetPos of every button to _globalButtonOffset, which is modified through our ExampleButton below
+				button.yOffsetPos = _globalButtonOffset;
+			}
+
+			// Make sure we're on the title screen menu
+			// If we aren't, then return and don't execute the code below
+			if (Main.menuMode != MenuID.Title)
+				return;
+
+			MenuButton exampleButton = new MenuButton(Mod, $"{Mod.Name}:ExampleButton", "Example Button!") {
+				color = Color.Goldenrod, // Change the default text color to GoldenRod
+				onHover = ExampleButtonOnHover, // Invoke this method when the button is being hovered on
+				onLeftClick = ExampleButtonOnLeftClick, // Invoke this method when the button is clicked with the left mouse button
+				readonlyText = false, // Make sure the button is interactable
+				unhoverableText = false, // Make sure you can hover over the button
+				scale = 0.5f // Adjust the scale to make it considerably smaller
+			};
+				
+			// Add our newly-created button to the end of the list
+			// This will allow our button to actually appear
+			buttons.Add(exampleButton);
+		}
+
+		private void ExampleButtonOnHover() {
+			// Increment _ticksHovered every tick
+			_ticksHovered++;
+
+			// Every ten ticks this button is hovered on, increment _globalButtonOffset by 1
+			if (_ticksHovered % 10 == 0)
+				_globalButtonOffset++;
+		}
+
+		private void ExampleButtonOnLeftClick() {
+			// When the button is left-clicked, reset _ticksHovered and _globalButtonOffset, resetting buttons to their normal position
+			_ticksHovered = 0;
+			_globalButtonOffset = 0;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2921,14 +2921,36 @@
  
  			if (menuMode == 888) {
  				if (!_blockFancyUIWhileLoading)
-@@ -38839,6 +_,7 @@
+@@ -38837,8 +_,11 @@
+ 					IngameOptions.rightLock = IngameOptions.rightHover;
+ 			}
  
++			// Generate a list of MenuButton instances and modify existing arrays based on the modifications as well.
++			List<MenuButton> buttons = MenuLoader.ModifyMenuButtons(ref num5, ref array, ref array2, ref array3, ref array4, ref array5, ref array6, ref array7, ref array8, ref array9, color, out Color[] buttonColor, out Action[] onClick, out Action[] onHover);
  			bool flag11 = false;
  			for (int num95 = 0; num95 < num5; num95++) {
 +				//patch file: num5, array9, num95
  				if (array9[num95] == null)
  					continue;
  
+@@ -38848,6 +_,8 @@
+ 				for (int num96 = 0; num96 < 5; num96++) {
+ 					Microsoft.Xna.Framework.Color color11 = Microsoft.Xna.Framework.Color.Black;
+ 					if (num96 == 4) {
++						// Skip the color switch since it's handled in MenuLoader.ModifyMenuButtons
++						goto SkipColorSwitch;
+ 						switch (array6[num95]) {
+ 							case 0:
+ 								color11 = color;
+@@ -38870,7 +_,7 @@
+ 								color11 = color;
+ 								break;
+ 						}
+-
++						SkipColorSwitch:
+ 						color11.R = (byte)((255 + color11.R) / 2);
+ 						color11.G = (byte)((255 + color11.G) / 2);
+ 						color11.B = (byte)((255 + color11.B) / 2);
 @@ -38936,6 +_,7 @@
  
  					num104 *= array7[num95];
@@ -2937,6 +2959,29 @@
  						spriteBatch.DrawString(FontAssets.DeathText.Value, array9[num95], new Vector2(num3 + num102 + array5[num95], (float)(num2 + num4 * num95 + num103) + origin.Y * array7[num95] + (float)array4[num95]), color11, 0f, origin, num104, SpriteEffects.None, 0f);
  					else
  						spriteBatch.DrawString(FontAssets.DeathText.Value, array9[num95], new Vector2(num3 + num102 + array5[num95], (float)(num2 + num4 * num95 + num103) + origin.Y * array7[num95] + (float)array4[num95]), color11, 0f, new Vector2(0f, origin.Y), num104, SpriteEffects.None, 0f);
+@@ -38974,6 +_,10 @@
+ 					continue;
+ 
+ 				focusMenu = num95;
++				// Call OnHover *after* focusMenu is set but before readonly and unhoverable buttons are skipped
++				// Modders should check for these themselves if they don't want their code to execute
++				// TODO: OnClick for rightclicks (selectedMenu2)
++				buttons[num95].onHover?.Invoke();
+ 				if (array[num95] || array2[num95]) {
+ 					focusMenu = -1;
+ 					continue;
+@@ -38982,8 +_,10 @@
+ 				if (num45 != focusMenu)
+ 					flag11 = true;
+ 
+-				if (mouseLeftRelease && mouseLeft)
++				if (mouseLeftRelease && mouseLeft) {
+ 					selectedMenu = num95;
++					buttons[num95].onClick?.Invoke();
++				}
+ 
+ 				if (mouseRightRelease && mouseRight)
+ 					selectedMenu2 = num95;
 @@ -39047,10 +_,47 @@
  					if (num107 == 3)
  						num109 = 2;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2942,12 +2942,13 @@
  						switch (array6[num95]) {
  							case 0:
  								color11 = color;
-@@ -38870,7 +_,7 @@
+@@ -38870,7 +_,8 @@
  								color11 = color;
  								break;
  						}
 -
 +						SkipColorSwitch:
++						color11 = buttonColor[num95];
  						color11.R = (byte)((255 + color11.R) / 2);
  						color11.G = (byte)((255 + color11.G) / 2);
  						color11.B = (byte)((255 + color11.B) / 2);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2926,7 +2926,7 @@
  			}
  
 +			// Generate a list of MenuButton instances and modify existing arrays based on the modifications as well.
-+			List<MenuButton> buttons = MenuLoader.ModifyMenuButtons(ref num5, ref array, ref array2, ref array3, ref array4, ref array5, ref array6, ref array7, ref array8, ref array9, color, out Color[] buttonColor, out Action[] onClick, out Action[] onHover);
++			List<MenuButton> buttons = MenuLoader.ModifyMenuButtons(ref num5, ref array, ref array2, ref array3, ref array4, ref array5, ref array6, ref array7, ref array8, ref array9, color, out Color[] buttonColor, out Action[] onLeftClick, out Action[] onRightClick, out Action[] onHover);
  			bool flag11 = false;
  			for (int num95 = 0; num95 < num5; num95++) {
 +				//patch file: num5, array9, num95
@@ -2959,29 +2959,62 @@
  						spriteBatch.DrawString(FontAssets.DeathText.Value, array9[num95], new Vector2(num3 + num102 + array5[num95], (float)(num2 + num4 * num95 + num103) + origin.Y * array7[num95] + (float)array4[num95]), color11, 0f, origin, num104, SpriteEffects.None, 0f);
  					else
  						spriteBatch.DrawString(FontAssets.DeathText.Value, array9[num95], new Vector2(num3 + num102 + array5[num95], (float)(num2 + num4 * num95 + num103) + origin.Y * array7[num95] + (float)array4[num95]), color11, 0f, new Vector2(0f, origin.Y), num104, SpriteEffects.None, 0f);
-@@ -38974,6 +_,10 @@
+@@ -38952,6 +_,9 @@
+ 						continue;
+ 
+ 					focusMenu = num95;
++					// Call OnHover *after* focusMenu is set but before readonly and unhoverable buttons are skipped
++					// Modders should check for these themselves if they don't want their code to execute
++					buttons[num95].onHover?.Invoke();
+ 					if (array[num95] || array2[num95]) {
+ 						focusMenu = -1;
+ 						continue;
+@@ -38960,11 +_,15 @@
+ 					if (num45 != focusMenu)
+ 						flag11 = true;
+ 
+-					if (mouseLeftRelease && mouseLeft)
++					if (mouseLeftRelease && mouseLeft) {
+ 						selectedMenu = num95;
++						buttons[num95].onLeftClick?.Invoke();
++					}
+ 
+-					if (mouseRightRelease && mouseRight)
++					if (mouseRightRelease && mouseRight) {
+ 						selectedMenu2 = num95;
++						buttons[num95].onRightClick?.Invoke();
++					}
+ 
+ 					continue;
+ 				}
+@@ -38974,6 +_,9 @@
  					continue;
  
  				focusMenu = num95;
 +				// Call OnHover *after* focusMenu is set but before readonly and unhoverable buttons are skipped
 +				// Modders should check for these themselves if they don't want their code to execute
-+				// TODO: OnClick for rightclicks (selectedMenu2)
 +				buttons[num95].onHover?.Invoke();
  				if (array[num95] || array2[num95]) {
  					focusMenu = -1;
  					continue;
-@@ -38982,8 +_,10 @@
+@@ -38982,11 +_,15 @@
  				if (num45 != focusMenu)
  					flag11 = true;
  
 -				if (mouseLeftRelease && mouseLeft)
 +				if (mouseLeftRelease && mouseLeft) {
  					selectedMenu = num95;
-+					buttons[num95].onClick?.Invoke();
++					buttons[num95].onLeftClick?.Invoke();
 +				}
  
- 				if (mouseRightRelease && mouseRight)
+-				if (mouseRightRelease && mouseRight)
++				if (mouseRightRelease && mouseRight) {
  					selectedMenu2 = num95;
++					buttons[num95].onRightClick?.Invoke();
++				}
+ 			}
+ 
+ 			if (flag11 && num45 != focusMenu)
 @@ -39047,10 +_,47 @@
  					if (num107 == 3)
  						num109 = 2;

--- a/patches/tModLoader/Terraria/ModLoader/MenuButton.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MenuButton.cs
@@ -20,9 +20,14 @@ namespace Terraria.ModLoader
 		public string Name { get; }
 
 		/// <summary>
-		/// Allows you to tell the button what to do when it is clicked.
+		/// Allows you to tell the button what to do when it is left-clicked.
 		/// </summary>
-		public Action onClick;
+		public Action onLeftClick;
+
+		/// <summary>
+		/// Allows you to tell the button what to do when it is right-clicked;
+		/// </summary>
+		public Action onRightClick;
 
 		/// <summary>
 		/// Allows you to tell the button what to do when it's being hovered on.

--- a/patches/tModLoader/Terraria/ModLoader/MenuButton.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MenuButton.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+
+namespace Terraria.ModLoader
+{
+	/// <summary>
+	/// This class serves as a way to store information about menu buttons on the main menu. <br />
+	/// You will create and manipulate objects of this class if you use the <see cref="ModMenu.ModifyMenuBottons"/> hook.
+	/// </summary>
+	public class MenuButton
+	{
+		/// <summary>
+		/// The name of the mod that added this menu button. For vanilla buttons, the mod name will be "Terraria".
+		/// </summary>
+		public string Mod { get; }
+
+		/// <summary>
+		/// The name of this menu button, which is used to help identify its function.
+		/// </summary>
+		public string Name { get; }
+
+		/// <summary>
+		/// Allows you to tell the button what to do when it is clicked.
+		/// </summary>
+		public Action onClick;
+
+		/// <summary>
+		/// Allows you to tell the button what to do when it's being hovered on.
+		/// </summary>
+		public Action onHover;
+
+		/// <summary>
+		/// The text this menu button displays.
+		/// </summary>
+		public string text;
+
+		/// <summary>
+		/// The button's scale.
+		/// </summary>
+		public float scale = 1f;
+
+		/// <summary>
+		/// Offset position on the y-axis.
+		/// </summary>
+		public int yOffsetPos = 0;
+
+		/// <summary>
+		/// Offset position on the x-axis.
+		/// </summary>
+		public int xOffsetPos = 0;
+
+		/// <summary>
+		/// If set to true, this text will be colored to white and the player will be unable to click on or hover over the button.
+		/// </summary>
+		public bool readonlyText = true;
+
+		/// <summary>
+		/// Similar to <see cref="readonlyText"/>, but just disallows clicking and hovering while still keeping the menu button color the same.
+		/// </summary>
+		public bool unhoverableText = true;
+
+		/// <summary>
+		/// The color of the button text.
+		/// </summary>
+		public Color color = Color.White;
+
+		// internal fields used for vanilla code
+		internal bool loweredAlpha = false;
+		internal bool noCenterOffset = false;
+		internal byte colorByte = 0;
+
+		public MenuButton(Mod mod, string name, string text) {
+			Mod = mod.Name;
+			Name = name;
+			this.text = text;
+		}
+
+		internal MenuButton(string name, string text) {
+			Mod = "Terraria";
+			Name = name;
+			this.text = text;
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
@@ -147,9 +147,14 @@ namespace Terraria.ModLoader
 				if (text[i] == null)
 					continue;
 
+				string buttonText = text[i]; // Can't use ref params in lambdas
+
+				// Find the respective localization key for a button
+				// Fallback to <MenuMode>_<NumberInArray>Button if, for some reason, no value is found
+				string buttonName = LanguageManager.Instance._localizedTexts.Values.FirstOrDefault(x => x.Value == buttonText)?.Key ?? $"{Main.menuMode}_{i}Button";
+
 				// Create a vanilla menu button instance
-				// TODO: Reverse-lookup the translation dictionary to use the translation key as the name
-				MenuButton button = new MenuButton($"{Main.menuMode}_{i}Button", text[i]);
+				MenuButton button = new MenuButton(buttonName, text[i]);
 
 				// Copy all data over to the newly-created MenuButton instance
 				button.color = GetColorFromByte(button.colorByte = color[i], defaultColor); // Find the button's color based on the vanilla color byte

--- a/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria.Audio;
@@ -136,6 +137,90 @@ namespace Terraria.ModLoader
 			if (Main.menuMode == 0) {
 				ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.MouseText.Value, text, new Vector2(switchTextRect.X, switchTextRect.Y),
 					switchTextRect.Contains(Main.mouseX, Main.mouseY) ? Main.OurFavoriteColor : new Color(120, 120, 120, 76), 0, Vector2.Zero, Vector2.One);
+			}
+		}
+
+		internal static List<MenuButton> ModifyMenuButtons(ref int numButtons, ref bool[] readonlyText, ref bool[] unhoverableText, ref bool[] loweredAlpha, ref int[] yOffsetPos, ref int[] xOffsetPos, ref byte[] color, ref float[] scale, ref bool[] noCenterOffset, ref string[] text, Color defaultColor, out Color[] buttonColor, out Action[] onClick, out Action[] onHover) {
+			List<MenuButton> buttons = new List<MenuButton>();
+
+			for (int i = 0; i < numButtons; i++) {
+				if (text[i] == null)
+					continue;
+
+				// Create a vanilla menu button instance
+				// TODO: Reverse-lookup the translation dictionary to use the translation key as the name
+				MenuButton button = new MenuButton($"{Main.menuMode}_{i}Button", text[i]);
+
+				// Copy all data over to the newly-created MenuButton instance
+				button.color = GetColorFromByte(button.colorByte = color[i], defaultColor); // Find the button's color based on the vanilla color byte
+				button.loweredAlpha = loweredAlpha[i];
+				button.noCenterOffset = noCenterOffset[i];
+				button.readonlyText = readonlyText[i];
+				button.scale = scale[i];
+				button.text = text[i];
+				button.unhoverableText = unhoverableText[i];
+				button.xOffsetPos = xOffsetPos[i];
+				button.yOffsetPos = yOffsetPos[i];
+				buttons.Add(button);
+			}
+
+			// Modify buttons based on the currently-selected menu
+			currentMenu.ModifyMenuButtons(buttons);
+
+			// Resize and repopulate arrays with the new data
+			numButtons = buttons.Count;
+			readonlyText = new bool[numButtons];
+			unhoverableText = new bool[numButtons];
+			loweredAlpha = new bool[numButtons];
+			yOffsetPos = new int[numButtons];
+			xOffsetPos = new int[numButtons];
+			color = new byte[numButtons];
+			buttonColor = new Color[numButtons];
+			scale = new float[numButtons];
+			noCenterOffset = new bool[numButtons];
+			text = new string[numButtons];
+			onClick = new Action[numButtons];
+			onHover = new Action[numButtons];
+			for (int i = 0; i < numButtons; i++) {
+				readonlyText[i] = buttons[i].readonlyText;
+				unhoverableText[i] = buttons[i].readonlyText;
+				loweredAlpha[i] = buttons[i].loweredAlpha;
+				yOffsetPos[i] = buttons[i].yOffsetPos;
+				xOffsetPos[i] = buttons[i].xOffsetPos;
+				color[i] = buttons[i].colorByte;
+				buttonColor[i] = buttons[i].color;
+				scale[i] = buttons[i].scale;
+				noCenterOffset[i] = buttons[i].noCenterOffset;
+				text[i] = buttons[i].text;
+				onClick[i] = buttons[i].onClick;
+				onHover[i] = buttons[i].onHover;
+			}
+
+			return buttons;
+		}
+
+		/// <summary>
+		/// Returns a <see cref="Color"/> identical whatever color vanilla would use. <br />
+		/// This replaces the code vanilla uses for getting <see cref="MenuButton"/> colors.
+		/// </summary>
+		private static Color GetColorFromByte(byte color, Color defaultColor) {
+			switch (color) {
+				default:
+					return defaultColor;
+
+				case 1:
+					return Main.mcColor;
+
+				case 2:
+					return Main.hcColor;
+
+				case 3:
+					return Main.highVersionColor;
+
+				case 4:
+				case 5:
+				case 6:
+					return Main.errorColor;
 			}
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
@@ -140,7 +140,7 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		internal static List<MenuButton> ModifyMenuButtons(ref int numButtons, ref bool[] readonlyText, ref bool[] unhoverableText, ref bool[] loweredAlpha, ref int[] yOffsetPos, ref int[] xOffsetPos, ref byte[] color, ref float[] scale, ref bool[] noCenterOffset, ref string[] text, Color defaultColor, out Color[] buttonColor, out Action[] onClick, out Action[] onHover) {
+		internal static List<MenuButton> ModifyMenuButtons(ref int numButtons, ref bool[] readonlyText, ref bool[] unhoverableText, ref bool[] loweredAlpha, ref int[] yOffsetPos, ref int[] xOffsetPos, ref byte[] color, ref float[] scale, ref bool[] noCenterOffset, ref string[] text, Color defaultColor, out Color[] buttonColor, out Action[] onLeftClick, out Action[] onRightClick, out Action[] onHover) {
 			List<MenuButton> buttons = new List<MenuButton>();
 
 			for (int i = 0; i < numButtons; i++) {
@@ -179,7 +179,8 @@ namespace Terraria.ModLoader
 			scale = new float[numButtons];
 			noCenterOffset = new bool[numButtons];
 			text = new string[numButtons];
-			onClick = new Action[numButtons];
+			onLeftClick = new Action[numButtons];
+			onRightClick = new Action[numButtons];
 			onHover = new Action[numButtons];
 			for (int i = 0; i < numButtons; i++) {
 				readonlyText[i] = buttons[i].readonlyText;
@@ -192,7 +193,8 @@ namespace Terraria.ModLoader
 				scale[i] = buttons[i].scale;
 				noCenterOffset[i] = buttons[i].noCenterOffset;
 				text[i] = buttons[i].text;
-				onClick[i] = buttons[i].onClick;
+				onLeftClick[i] = buttons[i].onLeftClick;
+				onRightClick[i] = buttons[i].onRightClick;
 				onHover[i] = buttons[i].onHover;
 			}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModMenu.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMenu.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using ReLogic.Content;
+using System.Collections.Generic;
 using Terraria.GameContent;
 using Terraria.UI;
 
@@ -85,6 +86,12 @@ namespace Terraria.ModLoader
 		/// Called just after the logo is drawn, and gives the values of some of the parameters of the logo draw code.
 		/// </summary>
 		public virtual void PostDrawLogo(SpriteBatch spriteBatch, Vector2 logoDrawCenter, float logoRotation, float logoScale, Color drawColor) {
+		}
+
+		/// <summary>
+		/// Allows you to modify the buttons displayed on the main menu. These changes are only applied if your menu is selected.
+		/// </summary>
+		public virtual void ModifyMenuButtons(List<MenuButton> buttons) {
 		}
 	}
 }


### PR DESCRIPTION
### What is the new feature?
This PR introduces the ability to modify the buttons on the main menu through `ModMenu`. Menu buttons will only be modified by the currently selected ModMenu, removing any chance of conflicts between mods.

### Why should this be part of tModLoader?
This should be part of tML since `ModMenu` already gives you the ability to incorporate vustom drawcode and other neat stuff. This PR simply builds on that by allowing people to modify the menu buttons easily as well, giving modders more freedom.

### Are there alternative designs?
The only real alternative design is making it not part of `ModMenu`, but instead `Mod`/`ModSystem`. (See my old PR: #1222)

### Sample usage for the new feature
See `ExampleModMenu.cs`.

### ExampleMod updates
Added an example usage of this new feature to `ExampleModMenu`, which makes the first button always rainbow and adds a new button to the main menu with a modified size and color that adjusts the offset of other buttons when hovered and resets it when clicked.

Example in action: https://gyazo.com/90ae03812a0eba465f23651f9d28ecf0.mp4

