### PR TITLE
Player Spawn Biome Check Coordinates Fix

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2974,6 +2974,16 @@
  				dead = false;
  				immuneTime = 0;
  			}
+@@ -26441,6 +_,9 @@
+ 			}
+ 
+ 			if (whoAmI == Main.myPlayer) {
++				// Force updating biomes prior to completing spawn event, avoids any frames of delay on biome updates.
++				UpdateBiomes();
++
+ 				if (context == PlayerSpawnContext.SpawningIntoWorld)
+ 					Main.LocalGolfState.SetScoreTime();
+ 
 @@ -26589,7 +_,7 @@
  			if (whoAmI != Main.myPlayer)
  				return;


### PR DESCRIPTION
### What is the bug?
Currently, the player.spawn calls for return from death and recall items occur after the player biome has already been updated. This leads to at least one frame where the player is in the wrong biome; consequently there are rare occurences of not-yet spawned enemies from the previous biome 'following the player' and spawning in the new biome. 
In 1.4.2, a new method called player.forceUpdateBiomes() will be introduced to fix this vanilla bug.
We will need to add PlayerHooks.UpdateBiomes and related hooks currently in BiomeUpdate() to this new method to guarantee we receive the fix.

### How did you fix the bug?
Can't Yet.