### PR TITLE
Added a hook to prevent items from stacking in the world

### DIFF
--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -676,6 +676,16 @@
  				base.velocity.Y += gravity;
  				if (base.velocity.Y > maxFallSpeed)
  					base.velocity.Y = maxFallSpeed;
+@@ -45614,6 +_,9 @@
+ 					num2 *= 2;
+ 
+ 				if (num < (float)num2) {
++					if (!ItemLoader.CanStackInWorld(this, item))
++						continue;
++
+ 					position = (position + item.position) / 2f;
+ 					velocity = (velocity + item.velocity) / 2f;
+ 					int num3 = item.stack;
 @@ -45935,6 +_,9 @@
  		}
  

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -481,10 +481,11 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to prevent vanilla items from stacking in the world
+		/// Allows you to prevent vanilla items from stacking in the world.
+		/// This is only called when two items of the same type attempt to stack.
 		/// </summary>
-		/// <param name="item1">The first item attempting to stack</param>
-		/// <param name="item2">The second item attempting to stack</param>
+		/// <param name="item1">The item that is attempting to stack</param>
+		/// <param name="item2">The item that the other item is attempting to stack with</param>
 		/// <returns>Whether or not the items are allowed to stack</returns>
 		public virtual bool CanStackInWorld(Item item1, Item item2) {
 			return true;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -481,6 +481,16 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to prevent vanilla items from stacking in the world
+		/// </summary>
+		/// <param name="item1">The first item attempting to stack</param>
+		/// <param name="item2">The second item attempting to stack</param>
+		/// <returns>Whether or not the items are allowed to stack</returns>
+		public virtual bool CanStackInWorld(Item item1, Item item2) {
+			return true;
+		}
+
+		/// <summary>
 		/// Returns if the normal reforge pricing is applied. 
 		/// If true or false is returned and the price is altered, the price will equal the altered price.
 		/// The passed reforge price equals the item.value. Vanilla pricing will apply 20% discount if applicable and then price the reforge at a third of that value.

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1117,6 +1117,21 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		private static HookList HookCanStackInWorld = AddHook<Func<Item, Item, bool>>(g => g.CanStackInWorld);
+		//in Terraria.Item.CombineWithNearbyItems after num comparison
+		// if(!ItemLoader.CanStackInWorld(this, item)) { continue; }
+		/// <summary>
+		/// Calls all GlobalItem.CanStackInWorld hooks until one returns false then ModItem.CanStackInWorld. Returns whether any of the hooks returned false.
+		/// </summary>
+		public static bool CanStackInWorld(Item item1, Item item2) {
+			foreach (var g in HookCanStackInWorld.Enumerate(globalItemsArray)) {
+				if (!g.CanStackInWorld(item1, item2))
+					return false;
+			}
+
+			return item1.ModItem?.CanStackInWorld(item2) ?? true;
+		}
+
 		private delegate bool DelegateReforgePrice(Item item, ref int reforgePrice, ref bool canApplyDiscount);
 		private static HookList HookReforgePrice = AddHook<DelegateReforgePrice>(g => g.ReforgePrice);
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -581,6 +581,15 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to decide if this item is allowed to stack with another of its type in the world
+		/// </summary>
+		/// <param name="item2">The item this is trying to stack with</param>
+		/// <returns>Whether or not the item is allowed to stack</returns>
+		public virtual bool CanStackInWorld(Item item2) {
+			return true;
+		}
+
+		/// <summary>
 		/// Returns if the normal reforge pricing is applied. 
 		/// If true or false is returned and the price is altered, the price will equal the altered price.
 		/// The passed reforge price equals the item.value. Vanilla pricing will apply 20% discount if applicable and then price the reforge at a third of that value.

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -581,7 +581,8 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to decide if this item is allowed to stack with another of its type in the world
+		/// Allows you to decide if this item is allowed to stack with another of its type in the world.
+		/// This is only called when attempting to stack with an item of the same type.
 		/// </summary>
 		/// <param name="item2">The item this is trying to stack with</param>
 		/// <returns>Whether or not the item is allowed to stack</returns>


### PR DESCRIPTION
### What is the new feature?
This PR adds a hook for ModItem which returns a boolean which allows the modder to allow items to stack in the inventory but not in the world.
There is an issue for this PR: #1106 
### Why should this be part of tModLoader?
Because it will allow mods to create unique in world item interactions based on certain criteria. (See issue)
### Are there alternative designs?
See issue
### Sample usage for the new feature
```C#
using Terraria.ModLoader;

public class ExampleItem : ModItem
{

	...

	public override bool CanStackInWorld(Item item2) {
		return false; //Prevents the item from stacking in the world but still allows it to stack in the inventory 
	}

}

```
### ExampleMod updates
<!-- If you also updated ExampleMod for your new feature, let us know here -->
None
<!--
We recommend using one of our pull request templates if you want your PR taken seriously.

You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.
If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:

Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->
