### PR TITLE
More improvements related to the flow of time

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Ambience/AmbienceServer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Ambience/AmbienceServer.cs.patch
@@ -1,0 +1,11 @@
+--- src/Terraria/Terraria/GameContent/Ambience/AmbienceServer.cs
++++ src/tModLoader/Terraria/GameContent/Ambience/AmbienceServer.cs
+@@ -18,7 +_,7 @@
+ 		private const int MAXIMUM_SECONDS_BETWEEN_SPAWNS = 120;
+ 		private readonly Dictionary<SkyEntityType, Func<bool>> _spawnConditions = new Dictionary<SkyEntityType, Func<bool>>();
+ 		private readonly Dictionary<SkyEntityType, Func<Player, bool>> _secondarySpawnConditionsPerPlayer = new Dictionary<SkyEntityType, Func<Player, bool>>();
+-		private int _updatesUntilNextAttempt;
++		private double _updatesUntilNextAttempt;
+ 		private List<AmbienceSpawnInfo> _forcedSpawns = new List<AmbienceSpawnInfo>();
+ 
+ 		private static bool IsSunnyDay() {

--- a/patches/tModLoader/Terraria/GameContent/Ambience/AmbienceServer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Ambience/AmbienceServer.cs.patch
@@ -9,3 +9,12 @@
  		private List<AmbienceSpawnInfo> _forcedSpawns = new List<AmbienceSpawnInfo>();
  
  		private static bool IsSunnyDay() {
+@@ -81,7 +_,7 @@
+ 		public void Update() {
+ 			SpawnForcedEntities();
+ 			if (_updatesUntilNextAttempt > 0) {
+-				_updatesUntilNextAttempt -= Main.dayRate;
++				_updatesUntilNextAttempt -= Main.desiredWorldEventsUpdateRate;
+ 				return;
+ 			}
+ 

--- a/patches/tModLoader/Terraria/GameContent/Events/CultistRitual.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Events/CultistRitual.cs.patch
@@ -1,0 +1,13 @@
+--- src/Terraria/Terraria/GameContent/Events/CultistRitual.cs
++++ src/tModLoader/Terraria/GameContent/Events/CultistRitual.cs
+@@ -9,8 +_,8 @@
+ 		public const int respawnDelay = 43200;
+ 		private const int timePerCultist = 3600;
+ 		private const int recheckStart = 600;
+-		public static int delay;
++		public static double delay;
+-		public static int recheck;
++		public static double recheck;
+ 
+ 		public static void UpdateTime() {
+ 			if (Main.netMode == 1)

--- a/patches/tModLoader/Terraria/GameContent/Events/CultistRitual.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Events/CultistRitual.cs.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/GameContent/Events/CultistRitual.cs
 +++ src/tModLoader/Terraria/GameContent/Events/CultistRitual.cs
-@@ -9,8 +_,8 @@
+@@ -9,18 +_,18 @@
  		public const int respawnDelay = 43200;
  		private const int timePerCultist = 3600;
  		private const int recheckStart = 600;
@@ -11,3 +11,15 @@
  
  		public static void UpdateTime() {
  			if (Main.netMode == 1)
+ 				return;
+ 
+-			delay -= Main.dayRate;
++			delay -= Main.desiredWorldEventsUpdateRate;
+ 			if (delay < 0)
+ 				delay = 0;
+ 
+-			recheck -= Main.dayRate;
++			recheck -= Main.desiredWorldEventsUpdateRate;
+ 			if (recheck < 0)
+ 				recheck = 0;
+ 

--- a/patches/tModLoader/Terraria/GameContent/Events/MysticLogFairiesEvent.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Events/MysticLogFairiesEvent.cs.patch
@@ -1,0 +1,11 @@
+--- src/Terraria/Terraria/GameContent/Events/MysticLogFairiesEvent.cs
++++ src/tModLoader/Terraria/GameContent/Events/MysticLogFairiesEvent.cs
+@@ -8,7 +_,7 @@
+ 	public class MysticLogFairiesEvent
+ 	{
+ 		private bool _canSpawnFairies;
+-		private int _delayUntilNextAttempt;
++		private double _delayUntilNextAttempt;
+ 		private const int DELAY_BETWEEN_ATTEMPTS = 60;
+ 		private List<Point> _stumpCoords = new List<Point>();
+ 

--- a/patches/tModLoader/Terraria/GameContent/Events/MysticLogFairiesEvent.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Events/MysticLogFairiesEvent.cs.patch
@@ -34,7 +34,7 @@
  				if (_delayUntilNextAttempt == 0) {
  					_delayUntilNextAttempt = 60;
  					TrySpawningFairies();
-@@ -60,10 +_,16 @@
+@@ -60,10 +_,17 @@
  
  			int oneOverSpawnChance = GetOneOverSpawnChance();
  			bool flag = false;
@@ -49,6 +49,7 @@
 -					flag = true;
 +						flag = true;
 -					break;
++						_timePass -= Math.Floor(_timePass);
 +						break;
 +					}
 +					_timePass -= 1;

--- a/patches/tModLoader/Terraria/GameContent/Events/MysticLogFairiesEvent.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Events/MysticLogFairiesEvent.cs.patch
@@ -34,25 +34,20 @@
  				if (_delayUntilNextAttempt == 0) {
  					_delayUntilNextAttempt = 60;
  					TrySpawningFairies();
-@@ -60,10 +_,17 @@
+@@ -60,12 +_,15 @@
  
  			int oneOverSpawnChance = GetOneOverSpawnChance();
  			bool flag = false;
 +
 +			_timePass += Main.desiredWorldEventsUpdateRate;
-+			if (_timePass >= 1) {
-+				double _timePassReference = _timePass;
 -			for (int i = 0; i < Main.dayRate; i++) {
-+				for (int i = 0; i < (int)_timePassReference; i++) {
--				if (Main.rand.Next(oneOverSpawnChance) == 0) {
-+					if (Main.rand.Next(oneOverSpawnChance) == 0) {
--					flag = true;
-+						flag = true;
--					break;
-+						_timePass -= Math.Floor(_timePass);
-+						break;
-+					}
-+					_timePass -= 1;
++			for (int i = 1; i < (int)_timePass; i++) {
+ 				if (Main.rand.Next(oneOverSpawnChance) == 0) {
+ 					flag = true;
+ 					break;
  				}
  			}
++			_timePass %= 1.0;
  
+ 			if (!flag)
+ 				return;

--- a/patches/tModLoader/Terraria/GameContent/Events/MysticLogFairiesEvent.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Events/MysticLogFairiesEvent.cs.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/GameContent/Events/MysticLogFairiesEvent.cs
 +++ src/tModLoader/Terraria/GameContent/Events/MysticLogFairiesEvent.cs
-@@ -8,7 +_,7 @@
+@@ -8,14 +_,16 @@
  	public class MysticLogFairiesEvent
  	{
  		private bool _canSpawnFairies;
@@ -8,4 +8,50 @@
 +		private double _delayUntilNextAttempt;
  		private const int DELAY_BETWEEN_ATTEMPTS = 60;
  		private List<Point> _stumpCoords = new List<Point>();
++		private double _timePass;
+ 
+ 		public void WorldClear() {
+ 			_canSpawnFairies = false;
+ 			_delayUntilNextAttempt = 0;
+ 			_stumpCoords.Clear();
++			_timePass = 0.0;
+ 		}
+ 
+ 		public void StartWorld() {
+@@ -27,13 +_,14 @@
+ 			if (Main.netMode != 1) {
+ 				_canSpawnFairies = true;
+ 				_delayUntilNextAttempt = 0;
++				_timePass = 0.0;
+ 				ScanWholeOverworldForLogs();
+ 			}
+ 		}
+ 
+ 		public void UpdateTime() {
+ 			if (Main.netMode != 1 && _canSpawnFairies && IsAGoodTime()) {
+-				_delayUntilNextAttempt = Math.Max(0, _delayUntilNextAttempt - Main.dayRate);
++				_delayUntilNextAttempt = Math.Max(0, _delayUntilNextAttempt - Main.desiredWorldEventsUpdateRate);
+ 				if (_delayUntilNextAttempt == 0) {
+ 					_delayUntilNextAttempt = 60;
+ 					TrySpawningFairies();
+@@ -60,10 +_,16 @@
+ 
+ 			int oneOverSpawnChance = GetOneOverSpawnChance();
+ 			bool flag = false;
++
++			_timePass += Main.desiredWorldEventsUpdateRate;
++			if (_timePass >= 1) {
++				double _timePassReference = _timePass;
+-			for (int i = 0; i < Main.dayRate; i++) {
++				for (int i = 0; i < _timePassReference; i++) {
+-				if (Main.rand.Next(oneOverSpawnChance) == 0) {
++					if (Main.rand.Next(oneOverSpawnChance) == 0) {
+-					flag = true;
++						flag = true;
+-					break;
++						break;
++					}
++					_timePass -= 1;
+ 				}
+ 			}
  

--- a/patches/tModLoader/Terraria/GameContent/Events/MysticLogFairiesEvent.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Events/MysticLogFairiesEvent.cs.patch
@@ -43,7 +43,7 @@
 +			if (_timePass >= 1) {
 +				double _timePassReference = _timePass;
 -			for (int i = 0; i < Main.dayRate; i++) {
-+				for (int i = 0; i < _timePassReference; i++) {
++				for (int i = 0; i < (int)_timePassReference; i++) {
 -				if (Main.rand.Next(oneOverSpawnChance) == 0) {
 +					if (Main.rand.Next(oneOverSpawnChance) == 0) {
 -					flag = true;

--- a/patches/tModLoader/Terraria/GameContent/Events/Sandstorm.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Events/Sandstorm.cs.patch
@@ -1,0 +1,11 @@
+--- src/Terraria/Terraria/GameContent/Events/Sandstorm.cs
++++ src/tModLoader/Terraria/GameContent/Events/Sandstorm.cs
+@@ -10,7 +_,7 @@
+ 		private const int SANDSTORM_DURATION_MINIMUM = 28800;
+ 		private const int SANDSTORM_DURATION_MAXIMUM = 86400;
+ 		public static bool Happening;
+-		public static int TimeLeft;
++		public static double TimeLeft;
+ 		public static float Severity;
+ 		public static float IntendedSeverity;
+ 		private static bool _effectsUp;

--- a/patches/tModLoader/Terraria/GameContent/Events/Sandstorm.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Events/Sandstorm.cs.patch
@@ -19,21 +19,17 @@
  		}
  
  		public static void UpdateTime() {
-@@ -41,9 +_,14 @@
+@@ -41,10 +_,12 @@
  					int num = 21600;
  					num = ((!Main.hardMode) ? (num * 3) : (num * 2));
  					if (HasSufficientWind()) {
 +						timePass += Main.desiredWorldEventsUpdateRate;
-+						if (timePass >= 1) {
-+							double timePassReference = timePass;
 -						for (int i = 0; i < Main.dayRate; i++) {
-+							for (int i = 0; i < (int)timePassReference; i++) {
--							if (Main.rand.Next(num) == 0)
-+								if (Main.rand.Next(num) == 0)
--								StartSandstorm();
-+									StartSandstorm();
-+								timePass -= 1.0;
-+							}
++						for (int i = 1; i < (int)timePass; i++) {
+ 							if (Main.rand.Next(num) == 0)
+ 								StartSandstorm();
  						}
++						timePass %= 1.0;
  					}
  				}
+ 

--- a/patches/tModLoader/Terraria/GameContent/Events/Sandstorm.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Events/Sandstorm.cs.patch
@@ -27,7 +27,7 @@
 +						if (timePass >= 1) {
 +							double timePassReference = timePass;
 -						for (int i = 0; i < Main.dayRate; i++) {
-+							for (int i = 0; i < timePassReference; i++) {
++							for (int i = 0; i < (int)timePassReference; i++) {
 -							if (Main.rand.Next(num) == 0)
 +								if (Main.rand.Next(num) == 0)
 -								StartSandstorm();

--- a/patches/tModLoader/Terraria/GameContent/Events/Sandstorm.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Events/Sandstorm.cs.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/GameContent/Events/Sandstorm.cs
 +++ src/tModLoader/Terraria/GameContent/Events/Sandstorm.cs
-@@ -10,7 +_,7 @@
+@@ -10,15 +_,17 @@
  		private const int SANDSTORM_DURATION_MINIMUM = 28800;
  		private const int SANDSTORM_DURATION_MAXIMUM = 86400;
  		public static bool Happening;
@@ -9,3 +9,31 @@
  		public static float Severity;
  		public static float IntendedSeverity;
  		private static bool _effectsUp;
++		private static double timePass;
+ 
+ 		private static bool HasSufficientWind() => Math.Abs(Main.windSpeedCurrent) >= 0.6f;
+ 
+ 		public static void WorldClear() {
+ 			Happening = false;
++			timePass = 0.0;
+ 		}
+ 
+ 		public static void UpdateTime() {
+@@ -41,9 +_,14 @@
+ 					int num = 21600;
+ 					num = ((!Main.hardMode) ? (num * 3) : (num * 2));
+ 					if (HasSufficientWind()) {
++						timePass += Main.desiredWorldEventsUpdateRate;
++						if (timePass >= 1) {
++							double timePassReference = timePass;
+-						for (int i = 0; i < Main.dayRate; i++) {
++							for (int i = 0; i < timePassReference; i++) {
+-							if (Main.rand.Next(num) == 0)
++								if (Main.rand.Next(num) == 0)
+-								StartSandstorm();
++									StartSandstorm();
++								timePass -= 1.0;
++							}
+ 						}
+ 					}
+ 				}

--- a/patches/tModLoader/Terraria/Graphics/Effects/SkyManager.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Effects/SkyManager.cs.patch
@@ -8,7 +8,7 @@
  
  		public void Reset() {
  			foreach (CustomSky value in _effects.Values) {
-@@ -16,14 +_,22 @@
+@@ -16,14 +_,18 @@
  			}
  
  			_activeSkies.Clear();
@@ -24,24 +24,20 @@
 +				num = 0;
 +			*/
  
--			for (int i = 0; i < num; i++) {
 +			_timePass += Main.desiredWorldEventsUpdateRate;
-+			if (_timePass < 1)
-+				return;
-+
-+			double _timePassReference = _timePass;
-+			for (int i = 0; i < (int)_timePassReference; i++) {
+-			for (int i = 0; i < num; i++) {
++			for (int i = 1; i < (int)_timePass; i++) {
  				LinkedListNode<CustomSky> linkedListNode = _activeSkies.First;
  				while (linkedListNode != null) {
  					CustomSky value = linkedListNode.Value;
-@@ -34,6 +_,7 @@
- 
+@@ -35,6 +_,7 @@
  					linkedListNode = next;
  				}
-+				_timePass -= 1.0;
  			}
++			_timePass %= 1.0;
  		}
  
+ 		public void Draw(SpriteBatch spriteBatch) {
 @@ -87,6 +_,13 @@
  			}
  

--- a/patches/tModLoader/Terraria/Graphics/Effects/SkyManager.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Effects/SkyManager.cs.patch
@@ -1,18 +1,47 @@
 --- src/Terraria/Terraria/Graphics/Effects/SkyManager.cs
 +++ src/tModLoader/Terraria/Graphics/Effects/SkyManager.cs
-@@ -19,9 +_,9 @@
+@@ -9,6 +_,7 @@
+ 		public static SkyManager Instance = new SkyManager();
+ 		private float _lastDepth;
+ 		private LinkedList<CustomSky> _activeSkies = new LinkedList<CustomSky>();
++		private double _timePass;
+ 
+ 		public void Reset() {
+ 			foreach (CustomSky value in _effects.Values) {
+@@ -16,14 +_,22 @@
+ 			}
+ 
+ 			_activeSkies.Clear();
++			_timePass = 0.0;
  		}
  
  		public void Update(GameTime gameTime) {
--			int num = Main.dayRate;
-+			double num = Main.dayRate;
++			/*
+ 			int num = Main.dayRate;
 -			if (num < 1)
 +			if (num < 0)
 -				num = 1;
 +				num = 0;
++			*/
  
- 			for (int i = 0; i < num; i++) {
+-			for (int i = 0; i < num; i++) {
++			_timePass += Main.desiredWorldEventsUpdateRate;
++			if (_timePass < 1)
++				return;
++
++			double _timePassReference = _timePass;
++			for (int i = 0; i < _timePassReference; i++) {
  				LinkedListNode<CustomSky> linkedListNode = _activeSkies.First;
+ 				while (linkedListNode != null) {
+ 					CustomSky value = linkedListNode.Value;
+@@ -34,6 +_,7 @@
+ 
+ 					linkedListNode = next;
+ 				}
++				_timePass -= 1.0;
+ 			}
+ 		}
+ 
 @@ -87,6 +_,13 @@
  			}
  

--- a/patches/tModLoader/Terraria/Graphics/Effects/SkyManager.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Effects/SkyManager.cs.patch
@@ -30,7 +30,7 @@
 +				return;
 +
 +			double _timePassReference = _timePass;
-+			for (int i = 0; i < _timePassReference; i++) {
++			for (int i = 0; i < (int)_timePassReference; i++) {
  				LinkedListNode<CustomSky> linkedListNode = _activeSkies.First;
  				while (linkedListNode != null) {
  					CustomSky value = linkedListNode.Value;

--- a/patches/tModLoader/Terraria/Graphics/Effects/SkyManager.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Effects/SkyManager.cs.patch
@@ -1,15 +1,29 @@
 --- src/Terraria/Terraria/Graphics/Effects/SkyManager.cs
 +++ src/tModLoader/Terraria/Graphics/Effects/SkyManager.cs
-@@ -88,5 +_,12 @@
+@@ -19,9 +_,9 @@
+ 		}
+ 
+ 		public void Update(GameTime gameTime) {
+-			int num = Main.dayRate;
++			double num = Main.dayRate;
+-			if (num < 1)
++			if (num < 0)
+-				num = 1;
++				num = 0;
+ 
+ 			for (int i = 0; i < num; i++) {
+ 				LinkedListNode<CustomSky> linkedListNode = _activeSkies.First;
+@@ -87,6 +_,13 @@
+ 			}
  
  			return MathHelper.Clamp(num, 0f, 1f);
- 		}
++		}
 +
 +		internal void DeactivateAll() {
 +			foreach (string key in _effects.Keys) {
 +				if (this[key].IsActive())
 +					this[key].Deactivate(new object[0]);
 +			}
-+		}
+ 		}
  	}
  }

--- a/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
+++ b/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
@@ -10,6 +10,40 @@
  
  namespace Terraria.IO
  {
+@@ -23,12 +_,12 @@
+ 		private static double _tempTime = Main.time;
+ 		private static bool _tempRaining;
+ 		private static float _tempMaxRain;
+-		private static int _tempRainTime;
++		private static double _tempRainTime;
+ 		private static bool _tempDayTime = Main.dayTime;
+ 		private static bool _tempBloodMoon = Main.bloodMoon;
+ 		private static bool _tempEclipse = Main.eclipse;
+ 		private static int _tempMoonPhase = Main.moonPhase;
+-		private static int _tempCultistDelay = CultistRitual.delay;
++		private static double _tempCultistDelay = CultistRitual.delay;
+ 		private static int _versionNumber;
+ 		private static bool _isWorldOnCloud;
+ 		private static bool _tempPartyGenuine;
+@@ -41,15 +_,15 @@
+ 		private static int? _cachedMoonPhase;
+ 		private static bool? _cachedBloodMoon;
+ 		private static bool? _cachedEclipse;
+-		private static int? _cachedCultistDelay;
++		private static double? _cachedCultistDelay;
+ 		private static bool? _cachedPartyGenuine;
+ 		private static bool? _cachedPartyManual;
+ 		private static int? _cachedPartyDaysOnCooldown;
+ 		private static readonly List<int> CachedCelebratingNPCs = new List<int>();
+ 		private static bool? _cachedSandstormHappening;
+ 		private static bool _tempSandstormHappening;
+-		private static int? _cachedSandstormTimeLeft;
++		private static double? _cachedSandstormTimeLeft;
+-		private static int _tempSandstormTimeLeft;
++		private static double _tempSandstormTimeLeft;
+ 		private static float? _cachedSandstormSeverity;
+ 		private static float _tempSandstormSeverity;
+ 		private static float? _cachedSandstormIntendedSeverity;
 @@ -303,6 +_,7 @@
  			Main.checkXMas();
  			Main.checkHalloween();

--- a/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
+++ b/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
@@ -10,40 +10,32 @@
  
  namespace Terraria.IO
  {
-@@ -23,12 +_,12 @@
- 		private static double _tempTime = Main.time;
- 		private static bool _tempRaining;
- 		private static float _tempMaxRain;
--		private static int _tempRainTime;
-+		private static double _tempRainTime;
- 		private static bool _tempDayTime = Main.dayTime;
+@@ -28,7 +_,7 @@
  		private static bool _tempBloodMoon = Main.bloodMoon;
  		private static bool _tempEclipse = Main.eclipse;
  		private static int _tempMoonPhase = Main.moonPhase;
 -		private static int _tempCultistDelay = CultistRitual.delay;
-+		private static double _tempCultistDelay = CultistRitual.delay;
++		private static int _tempCultistDelay = (int)CultistRitual.delay;
  		private static int _versionNumber;
  		private static bool _isWorldOnCloud;
  		private static bool _tempPartyGenuine;
-@@ -41,15 +_,15 @@
- 		private static int? _cachedMoonPhase;
- 		private static bool? _cachedBloodMoon;
- 		private static bool? _cachedEclipse;
--		private static int? _cachedCultistDelay;
-+		private static double? _cachedCultistDelay;
- 		private static bool? _cachedPartyGenuine;
- 		private static bool? _cachedPartyManual;
- 		private static int? _cachedPartyDaysOnCooldown;
- 		private static readonly List<int> CachedCelebratingNPCs = new List<int>();
- 		private static bool? _cachedSandstormHappening;
- 		private static bool _tempSandstormHappening;
--		private static int? _cachedSandstormTimeLeft;
-+		private static double? _cachedSandstormTimeLeft;
--		private static int _tempSandstormTimeLeft;
-+		private static double _tempSandstormTimeLeft;
- 		private static float? _cachedSandstormSeverity;
- 		private static float _tempSandstormSeverity;
- 		private static float? _cachedSandstormIntendedSeverity;
+@@ -73,14 +_,14 @@
+ 			_cachedMoonPhase = Main.moonPhase;
+ 			_cachedBloodMoon = Main.bloodMoon;
+ 			_cachedEclipse = Main.eclipse;
+-			_cachedCultistDelay = CultistRitual.delay;
++			_cachedCultistDelay = (int)CultistRitual.delay;
+ 			_cachedPartyGenuine = BirthdayParty.GenuineParty;
+ 			_cachedPartyManual = BirthdayParty.ManualParty;
+ 			_cachedPartyDaysOnCooldown = BirthdayParty.PartyDaysOnCooldown;
+ 			CachedCelebratingNPCs.Clear();
+ 			CachedCelebratingNPCs.AddRange(BirthdayParty.CelebratingNPCs);
+ 			_cachedSandstormHappening = Sandstorm.Happening;
+-			_cachedSandstormTimeLeft = Sandstorm.TimeLeft;
++			_cachedSandstormTimeLeft = (int)Sandstorm.TimeLeft;
+ 			_cachedSandstormSeverity = Sandstorm.Severity;
+ 			_cachedSandstormIntendedSeverity = Sandstorm.IntendedSeverity;
+ 			_cachedLanternNightCooldown = LanternNight.LanternNightsOnCooldown;
 @@ -303,6 +_,7 @@
  			Main.checkXMas();
  			Main.checkHalloween();
@@ -79,6 +71,37 @@
  		}
  
  		private static void DoRollingBackups(string backupWorldWritePath) {
+@@ -603,18 +_,18 @@
+ 			_tempMoonPhase = Main.moonPhase;
+ 			_tempBloodMoon = Main.bloodMoon;
+ 			_tempEclipse = Main.eclipse;
+-			_tempCultistDelay = CultistRitual.delay;
++			_tempCultistDelay = (int)CultistRitual.delay;
+ 			_tempPartyManual = BirthdayParty.ManualParty;
+ 			_tempPartyGenuine = BirthdayParty.GenuineParty;
+ 			_tempPartyCooldown = BirthdayParty.PartyDaysOnCooldown;
+ 			TempPartyCelebratingNPCs.Clear();
+ 			TempPartyCelebratingNPCs.AddRange(BirthdayParty.CelebratingNPCs);
+ 			_tempSandstormHappening = Sandstorm.Happening;
+-			_tempSandstormTimeLeft = Sandstorm.TimeLeft;
++			_tempSandstormTimeLeft = (int)Sandstorm.TimeLeft;
+ 			_tempSandstormSeverity = Sandstorm.Severity;
+ 			_tempSandstormIntendedSeverity = Sandstorm.IntendedSeverity;
+ 			_tempRaining = Main.raining;
+-			_tempRainTime = Main.rainTime;
++			_tempRainTime = (int)Main.rainTime;
+ 			_tempMaxRain = Main.maxRaining;
+ 			_tempLanternNightCooldown = LanternNight.LanternNightsOnCooldown;
+ 			_tempLanternNightGenuine = LanternNight.GenuineLanterns;
+@@ -640,7 +_,7 @@
+ 			_tempSandstormSeverity = _cachedSandstormSeverity.Value;
+ 			_tempSandstormIntendedSeverity = _cachedSandstormIntendedSeverity.Value;
+ 			_tempRaining = Main.raining;
+-			_tempRainTime = Main.rainTime;
++			_tempRainTime = (int)Main.rainTime;
+ 			_tempMaxRain = Main.maxRaining;
+ 			_tempLanternNightCooldown = _cachedLanternNightCooldown.Value;
+ 			_tempLanternNightGenuine = _cachedLanternNightGenuine.Value;
 @@ -877,7 +_,11 @@
  			}
  
@@ -151,33 +174,6 @@
  					writer.Write(nPC2.active);
  					writer.Write(nPC2.netID);
  					writer.WriteVector2(nPC2.position);
-@@ -1426,7 +_,7 @@
- 				Main.sundialCooldown = reader.ReadByte();
- 
- 			_tempRaining = reader.ReadBoolean();
--			_tempRainTime = reader.ReadInt32();
-+			_tempRainTime = reader.ReadDouble();
- 			_tempMaxRain = reader.ReadSingle();
- 			WorldGen.SavedOreTiers.Cobalt = reader.ReadInt32();
- 			WorldGen.SavedOreTiers.Mythril = reader.ReadInt32();
-@@ -1482,7 +_,7 @@
- 			if (versionNumber < 108)
- 				_tempCultistDelay = 86400;
- 			else
--				_tempCultistDelay = reader.ReadInt32();
-+				_tempCultistDelay = reader.ReadDouble();
- 
- 			if (versionNumber < 109)
- 				return;
-@@ -1561,7 +_,7 @@
- 			}
- 			else {
- 				_tempSandstormHappening = reader.ReadBoolean();
--				_tempSandstormTimeLeft = reader.ReadInt32();
-+				_tempSandstormTimeLeft = reader.ReadDouble();
- 				_tempSandstormSeverity = reader.ReadSingle();
- 				_tempSandstormIntendedSeverity = reader.ReadSingle();
- 			}
 @@ -1867,7 +_,7 @@
  				int num3 = reader.ReadInt32();
  				Tile tile = Main.tile[num2, num3];

--- a/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
+++ b/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
@@ -151,6 +151,33 @@
  					writer.Write(nPC2.active);
  					writer.Write(nPC2.netID);
  					writer.WriteVector2(nPC2.position);
+@@ -1426,7 +_,7 @@
+ 				Main.sundialCooldown = reader.ReadByte();
+ 
+ 			_tempRaining = reader.ReadBoolean();
+-			_tempRainTime = reader.ReadInt32();
++			_tempRainTime = reader.ReadDouble();
+ 			_tempMaxRain = reader.ReadSingle();
+ 			WorldGen.SavedOreTiers.Cobalt = reader.ReadInt32();
+ 			WorldGen.SavedOreTiers.Mythril = reader.ReadInt32();
+@@ -1482,7 +_,7 @@
+ 			if (versionNumber < 108)
+ 				_tempCultistDelay = 86400;
+ 			else
+-				_tempCultistDelay = reader.ReadInt32();
++				_tempCultistDelay = reader.ReadDouble();
+ 
+ 			if (versionNumber < 109)
+ 				return;
+@@ -1561,7 +_,7 @@
+ 			}
+ 			else {
+ 				_tempSandstormHappening = reader.ReadBoolean();
+-				_tempSandstormTimeLeft = reader.ReadInt32();
++				_tempSandstormTimeLeft = reader.ReadDouble();
+ 				_tempSandstormSeverity = reader.ReadSingle();
+ 				_tempSandstormIntendedSeverity = reader.ReadSingle();
+ 			}
 @@ -1867,7 +_,7 @@
  				int num3 = reader.ReadInt32();
  				Tile tile = Main.tile[num2, num3];

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -23,6 +23,7 @@ namespace Terraria
 		public static bool hidePlayerCraftingMenu;
 		public static bool showServerConsole;
 		public static bool Support8K = true; // provides an option to disable 8k (but leave 4k)
+		public static double desiredWorldEventsUpdateRate;
 
 		internal static TMLContentManager AlternateContentManager;
 

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -24,6 +24,7 @@ namespace Terraria
 		public static bool showServerConsole;
 		public static bool Support8K = true; // provides an option to disable 8k (but leave 4k)
 		public static double desiredWorldEventsUpdateRate;
+		public static double timePass;
 
 		internal static TMLContentManager AlternateContentManager;
 

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -52,15 +52,17 @@
  		public static FileMetadata WorldFileMetadata;
  		public static FileMetadata MapFileMetadata;
  		public static PingMapLayer Pings = new PingMapLayer();
-@@ -509,7 +_,7 @@
+@@ -509,8 +_,8 @@
  		public static bool showSplash = true;
  		public static bool ignoreErrors = true;
  		public static string defaultIP = "";
 -		public static int dayRate = 1;
 +		public static double dayRate = 1;
- 		public static int desiredWorldTilesUpdateRate = 1;
+-		public static int desiredWorldTilesUpdateRate = 1;
++		public static double desiredWorldTilesUpdateRate = 1;
  		public static int maxScreenW = 1920;
  		public static int maxScreenH = 1200;
+ 		public static int minScreenW = 800;
 @@ -541,7 +_,7 @@
  		public static int instantBGTransitionCounter = 2;
  		public static int bgDelay;
@@ -758,22 +760,29 @@
  		}
  
  		public static void Sundialing() {
-@@ -4733,7 +_,7 @@
+@@ -4733,7 +_,8 @@
  			if (fastForwardTime) {
  				dayRate = 60;
  				desiredWorldTilesUpdateRate = 1;
 -				return;
++				desiredWorldEventsUpdateRate = 60;
 +				goto endVanillaMethod;
  			}
  
  			bool enabled = CreativePowerManager.Instance.GetPower<CreativePowers.FreezeTime>().Enabled;
-@@ -4752,6 +_,9 @@
+@@ -4748,10 +_,15 @@
+ 
+ 			dayRate = num;
+ 			desiredWorldTilesUpdateRate = num;
++			desiredWorldEventsUpdateRate = num;
+ 			if (gameMenu) {
  				dayRate = 1;
  				desiredWorldTilesUpdateRate = 1;
++				desiredWorldEventsUpdateRate = 1;
  			}
 +
 +			endVanillaMethod:
-+			SystemHooks.ModifyTimeRate(ref dayRate, ref desiredWorldTilesUpdateRate);
++			SystemHooks.ModifyTimeRate(ref dayRate, ref desiredWorldTilesUpdateRate, ref desiredWorldEventsUpdateRate);
  		}
  
  		public Main() {
@@ -3568,6 +3577,15 @@
  					num6 *= 4;
  					if (rand.Next(num6) == 0) {
  						int num7 = 0;
+@@ -49815,7 +_,7 @@
+ 		}
+ 
+ 		private static void UpdateTime_SpawnTownNPCs() {
+-			int worldUpdateRate = WorldGen.GetWorldUpdateRate();
++			double worldUpdateRate = WorldGen.GetWorldUpdateRate();
+ 			if (netMode == 1 || worldUpdateRate <= 0)
+ 				return;
+ 
 @@ -49830,7 +_,7 @@
  					num++;
  			}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1056,15 +1056,6 @@
  			else if ((double)player[myPlayer].position.Y >= worldSurface * 16.0 + (double)(screenHeight / 2) && !WorldGen.oceanDepths((int)(screenPosition.X + (float)(screenWidth / 2)) / 16, (int)(screenPosition.Y + (float)(screenHeight / 2)) / 16)) {
  				if (player[myPlayer].ZoneHallow) {
  					newMusic = 11;
-@@ -9868,7 +_,7 @@
- 			if (cloudBGActive > 0f)
- 				cloudBGActive = 0f;
- 
--			if (cloudBGActive == 0f && rand.Next((int)((float)(num2 * 12 / ((dayRate == 0) ? 1 : dayRate)) / num3)) == 0) {
-+			if (cloudBGActive == 0f && rand.Next((int)((float)(num2 * 12 / ((dayRate == 0) ? 1E-38 : dayRate)) / num3)) == 0) {
- 				cloudBGActive = rand.Next(num2 * 3, num * 2);
- 				if (netMode == 2)
- 					NetMessage.SendData(7);
 @@ -12221,11 +_,16 @@
  		}
  
@@ -1127,7 +1118,7 @@
  				gamePaused = true;
  				return;
  			}
-@@ -12640,10 +_,19 @@
+@@ -12640,10 +_,16 @@
  			if (netMode != 1)
  				updateCloudLayer();
  
@@ -1135,14 +1126,11 @@
 +				goto skipWeatherUpdates;
 +
 +			timePass += dayRate;
-+			if (timePass < 1)
-+				goto skipWeatherUpdates;
-+			double timePassReference = timePass;
 -			for (int i = 0; i < dayRate; i++) {
-+			for (int i = 0; i < (int)timePassReference; i++) {
++			for (int i = 0; i < (int)timePass; i++) {
  				UpdateWeather(gameTime);
-+				timePass -= 1.0;
  			}
++			timePass %= 1.0;
  
 +			skipWeatherUpdates:
  			if ((timeForVisualEffects += 1.0) >= 216000.0)
@@ -3248,15 +3236,17 @@
  		}
  
  		private void DoDraw(GameTime gameTime) {
-@@ -47097,9 +_,9 @@
+@@ -47097,9 +_,14 @@
  			if (gameMenu || netMode == 2)
  				bgTopY = -200;
  
--			int num3 = dayRate;
++			/*
+ 			int num3 = dayRate;
+ 			if (num3 < 1)
+ 				num3 = 1;
++			*/
 +			double num3 = dayRate;
--			if (num3 < 1)
 +			if (num3 < 0)
--				num3 = 1;
 +				num3 = 0;
  
  			float num4 = 0.0005f * (float)num3;
@@ -3525,15 +3515,20 @@
  			if (invasionType <= 0)
  				return;
  
-@@ -48991,9 +_,9 @@
+@@ -48991,9 +_,14 @@
  			if (invasionX == (double)spawnTileX)
  				return;
  
++			/*
 -			float num = dayRate;
-+			double num = dayRate;
++			int num = dayRate;
 -			if (num < 1f)
-+			if (num < 0)
++			if (num < 1)
 -				num = 1f;
++				num = 1;
++			*/
++			double num = dayRate;
++			if (num < 0)
 +				num = 0;
  
  			if (invasionX > (double)spawnTileX) {
@@ -3582,7 +3577,7 @@
 -					int num2 = 86400;
 +					double num2 = 86400;
 -					num2 /= ((dayRate == 0) ? 1 : dayRate);
-+					num2 /= (dayRate == 0) ? 1E-38 : dayRate;
++					num2 /= (dayRate == 0) ? 1 : dayRate;
  					if (!CreativePowerManager.Instance.GetPower<CreativePowers.FreezeRainPower>().Enabled && dayRate != 0) {
  						if (rand.Next((int)((double)num2 * 5.75)) == 0)
  							StartRain();
@@ -3596,20 +3591,22 @@
  
  					if (!raining && !NPC.BusyWithAnyInvasionOfSorts()) {
 -						int num3 = (int)(1728000.0 / (double)dayRate);
-+						int num3 = (int)(1728000.0 / (double)((dayRate == 0) ? 1E-38 : dayRate));
++						int num3 = (int)(1728000.0 / (double)((dayRate == 0) ? 1 : dayRate));
  						if (!NPC.downedSlimeKing)
  							num3 /= 2;
  
-@@ -49454,11 +_,11 @@
+@@ -49454,11 +_,16 @@
  						WorldGen.UnspawnTravelNPC();
  				}
  				else if (!fastForwardTime && dayTime && time < 27000.0) {
--					int num5 = dayRate;
++					/*
+ 					int num5 = dayRate;
+ 					if (num5 < 1)
+ 						num5 = 1;
++					*/
 +					double num5 = dayRate;
--					if (num5 < 1)
-+					if (num5 < 1E-38)
--						num5 = 1;
-+						num5 = 1E-38;
++					if (num5 == 0)
++						num5 = 1;
  
 -					int num6 = (int)(27000.0 / (double)num5);
 +					int num6 = (int)(27000.0 / num5);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -770,7 +770,7 @@
  			}
  
  			bool enabled = CreativePowerManager.Instance.GetPower<CreativePowers.FreezeTime>().Enabled;
-@@ -4748,10 +_,15 @@
+@@ -4748,10 +_,17 @@
  
  			dayRate = num;
  			desiredWorldTilesUpdateRate = num;
@@ -783,6 +783,8 @@
 +
 +			endVanillaMethod:
 +			SystemHooks.ModifyTimeRate(ref dayRate, ref desiredWorldTilesUpdateRate, ref desiredWorldEventsUpdateRate);
++			if (dayRate > 86400)
++				dayRate = 86400;
  		}
  
  		public Main() {
@@ -1054,6 +1056,15 @@
  			else if ((double)player[myPlayer].position.Y >= worldSurface * 16.0 + (double)(screenHeight / 2) && !WorldGen.oceanDepths((int)(screenPosition.X + (float)(screenWidth / 2)) / 16, (int)(screenPosition.Y + (float)(screenHeight / 2)) / 16)) {
  				if (player[myPlayer].ZoneHallow) {
  					newMusic = 11;
+@@ -9868,7 +_,7 @@
+ 			if (cloudBGActive > 0f)
+ 				cloudBGActive = 0f;
+ 
+-			if (cloudBGActive == 0f && rand.Next((int)((float)(num2 * 12 / ((dayRate == 0) ? 1 : dayRate)) / num3)) == 0) {
++			if (cloudBGActive == 0f && rand.Next((int)((float)(num2 * 12 / ((dayRate == 0) ? 1E-38 : dayRate)) / num3)) == 0) {
+ 				cloudBGActive = rand.Next(num2 * 3, num * 2);
+ 				if (netMode == 2)
+ 					NetMessage.SendData(7);
 @@ -12221,11 +_,16 @@
  		}
  
@@ -1116,6 +1127,27 @@
  				gamePaused = true;
  				return;
  			}
+@@ -12640,10 +_,19 @@
+ 			if (netMode != 1)
+ 				updateCloudLayer();
+ 
++			if (dayRate <= 0)
++				goto skipWeatherUpdates;
++
++			timePass += dayRate;
++			if (timePass < 1)
++				goto skipWeatherUpdates;
++			double timePassReference = timePass;
+-			for (int i = 0; i < dayRate; i++) {
++			for (int i = 0; i < (int)timePassReference; i++) {
+ 				UpdateWeather(gameTime);
++				timePass -= 1.0;
+ 			}
+ 
++			skipWeatherUpdates:
+ 			if ((timeForVisualEffects += 1.0) >= 216000.0)
+ 				timeForVisualEffects = 0.0;
+ 
 @@ -12661,6 +_,7 @@
  				Sandstorm.EmitDust();
  			}
@@ -3531,7 +3563,7 @@
  			ChangeRain();
  			raining = true;
  		}
-@@ -49356,24 +_,24 @@
+@@ -49356,29 +_,29 @@
  						else {
  							rainTime -= dayRate;
  							if (dayRate > 0) {
@@ -3549,7 +3581,8 @@
  				else if (!slimeRain && !LanternNight.LanternsUp && !LanternNight.NextNightIsLanternNight) {
 -					int num2 = 86400;
 +					double num2 = 86400;
- 					num2 /= ((dayRate == 0) ? 1 : dayRate);
+-					num2 /= ((dayRate == 0) ? 1 : dayRate);
++					num2 /= (dayRate == 0) ? 1E-38 : dayRate;
  					if (!CreativePowerManager.Instance.GetPower<CreativePowers.FreezeRainPower>().Enabled && dayRate != 0) {
  						if (rand.Next((int)((double)num2 * 5.75)) == 0)
  							StartRain();
@@ -3561,6 +3594,12 @@
  							StartRain();
  					}
  
+ 					if (!raining && !NPC.BusyWithAnyInvasionOfSorts()) {
+-						int num3 = (int)(1728000.0 / (double)dayRate);
++						int num3 = (int)(1728000.0 / (double)((dayRate == 0) ? 1E-38 : dayRate));
+ 						if (!NPC.downedSlimeKing)
+ 							num3 /= 2;
+ 
 @@ -49454,11 +_,11 @@
  						WorldGen.UnspawnTravelNPC();
  				}
@@ -3568,9 +3607,9 @@
 -					int num5 = dayRate;
 +					double num5 = dayRate;
 -					if (num5 < 1)
-+					if (num5 < 0)
++					if (num5 < 1E-38)
 -						num5 = 1;
-+						num5 = 0;
++						num5 = 1E-38;
  
 -					int num6 = (int)(27000.0 / (double)num5);
 +					int num6 = (int)(27000.0 / num5);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -52,6 +52,15 @@
  		public static FileMetadata WorldFileMetadata;
  		public static FileMetadata MapFileMetadata;
  		public static PingMapLayer Pings = new PingMapLayer();
+@@ -509,7 +_,7 @@
+ 		public static bool showSplash = true;
+ 		public static bool ignoreErrors = true;
+ 		public static string defaultIP = "";
+-		public static int dayRate = 1;
++		public static double dayRate = 1;
+ 		public static int desiredWorldTilesUpdateRate = 1;
+ 		public static int maxScreenW = 1920;
+ 		public static int maxScreenH = 1200;
 @@ -541,7 +_,7 @@
  		public static int instantBGTransitionCounter = 2;
  		public static int bgDelay;
@@ -135,6 +144,15 @@
  		public static string worldName = "";
  		public static int worldID;
  		public static int background;
+@@ -784,7 +_,7 @@
+ 		public static float cloudAlpha;
+ 		public static float maxRaining;
+ 		public static float oldMaxRaining;
+-		public static int rainTime;
++		public static double rainTime;
+ 		public static bool raining;
+ 		public static bool eclipse;
+ 		public static float eclipseLight;
 @@ -825,7 +_,11 @@
  		public static float invAlpha = 1f;
  		public static float invDir = 1f;
@@ -226,7 +244,7 @@
  		private static bool _settingsButtonIsPushedToSide;
  		private static bool _MouseOversCanClear;
  		private static Vector2 _itemIconCacheScreenPosition;
-@@ -2093,13 +_,13 @@
+@@ -2093,19 +_,19 @@
  		};
  		private static float backgroundLayerTransitionSpeed = 0.05f;
  		public static float atmo;
@@ -246,6 +264,13 @@
  		private float cTop;
  		private bool _isDrawingOrUpdating;
  		public static List<INeedRenderTargetContent> ContentThatNeedsRenderTargets = new List<INeedRenderTargetContent>();
+ 		private static string _oldNetplayStatusText;
+ 		private static TextSnippet[] _netplayStatusTextSnippets;
+-		public static int ladyBugRainBoost = 0;
++		public static double ladyBugRainBoost = 0;
+ 		private static bool _canShowMeteorFall;
+ 
+ 		public static Vector2 ViewPosition => screenPosition + GameViewMatrix.Translation;
 @@ -2257,7 +_,7 @@
  
  		public static int npcShop {
@@ -3182,6 +3207,19 @@
  		}
  
  		private void DoDraw(GameTime gameTime) {
+@@ -47097,9 +_,9 @@
+ 			if (gameMenu || netMode == 2)
+ 				bgTopY = -200;
+ 
+-			int num3 = dayRate;
++			double num3 = dayRate;
+-			if (num3 < 1)
++			if (num3 < 0)
+-				num3 = 1;
++				num3 = 0;
+ 
+ 			float num4 = 0.0005f * (float)num3;
+ 			if (gameMenu)
 @@ -47167,8 +_,8 @@
  			UpdateAtmosphereTransparencyToSkyColor();
  			base.GraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Black);
@@ -3382,6 +3420,19 @@
  			Microsoft.Xna.Framework.Rectangle value3 = dayTime ? new Microsoft.Xna.Framework.Rectangle((int)((double)num3 - (double)TextureAssets.Sun.Width() * 0.5 * (double)num5), (int)((double)num4 - (double)TextureAssets.Sun.Height() * 0.5 * (double)num5 + (double)sunModY), (int)((float)TextureAssets.Sun.Width() * num5), (int)((float)TextureAssets.Sun.Width() * num5)) : new Microsoft.Xna.Framework.Rectangle((int)((double)num6 - (double)TextureAssets.Moon[num].Width() * 0.5 * (double)num8), (int)((double)num7 - (double)TextureAssets.Moon[num].Width() * 0.5 * (double)num8 + (double)moonModY), (int)((float)TextureAssets.Moon[num].Width() * num8), (int)((float)TextureAssets.Moon[num].Width() * num8));
  			value3.Offset((int)sceneArea.SceneLocalScreenPositionOffset.X, (int)sceneArea.SceneLocalScreenPositionOffset.Y);
  			Microsoft.Xna.Framework.Rectangle rectangle = new Microsoft.Xna.Framework.Rectangle(mouseX, mouseY, 1, 1);
+@@ -48010,10 +_,10 @@
+ 				Vector2 origin = value.Size() / 2f;
+ 				if (star.falling) {
+ 					star.fadeIn = 0f;
+-					int num7 = star.fallTime;
++					double num7 = star.fallTime;
+ 					float num8 = 30f;
+ 					if ((float)num7 > num8)
+-						num7 = (int)num8;
++						num7 = (double)num8;
+ 
+ 					for (int j = 1; j < num7; j++) {
+ 						Vector2 value2 = star.fallSpeed * j * 0.4f;
 @@ -48036,6 +_,8 @@
  			tileColor.G = (byte)((colorOfTheSkies.R + colorOfTheSkies.G + colorOfTheSkies.B + colorOfTheSkies.G * 7) / 10);
  			tileColor.B = (byte)((colorOfTheSkies.R + colorOfTheSkies.G + colorOfTheSkies.B + colorOfTheSkies.B * 7) / 10);
@@ -3433,6 +3484,19 @@
  			if (invasionType <= 0)
  				return;
  
+@@ -48991,9 +_,9 @@
+ 			if (invasionX == (double)spawnTileX)
+ 				return;
+ 
+-			float num = dayRate;
++			double num = dayRate;
+-			if (num < 1f)
++			if (num < 0)
+-				num = 1f;
++				num = 0;
+ 
+ 			if (invasionX > (double)spawnTileX) {
+ 				invasionX -= num;
 @@ -49199,6 +_,15 @@
  			}
  		}
@@ -3449,6 +3513,61 @@
  		public static void NewText(string newText, byte R = byte.MaxValue, byte G = byte.MaxValue, byte B = byte.MaxValue) {
  			chatMonitor.NewText(newText, R, G, B);
  			SoundEngine.PlaySound(12);
+@@ -49250,7 +_,7 @@
+ 			if (rand.Next(5) == 0)
+ 				num4 += 0.2f;
+ 
+-			rainTime = (int)((float)num3 * num4);
++			rainTime = (double)((float)num3 * num4);
+ 			ChangeRain();
+ 			raining = true;
+ 		}
+@@ -49356,24 +_,24 @@
+ 						else {
+ 							rainTime -= dayRate;
+ 							if (dayRate > 0) {
+-								int num = 86400 / dayRate / 24;
++								double num = 86400 / dayRate / 24;
+ 								if (rainTime <= 0)
+ 									StopRain();
+-								else if (rand.Next(num * 2) == 0)
++								else if (rand.Next((int)(num * 2)) == 0)
+ 									ChangeRain();
+ 							}
+ 						}
+ 					}
+ 				}
+ 				else if (!slimeRain && !LanternNight.LanternsUp && !LanternNight.NextNightIsLanternNight) {
+-					int num2 = 86400;
++					double num2 = 86400;
+ 					num2 /= ((dayRate == 0) ? 1 : dayRate);
+ 					if (!CreativePowerManager.Instance.GetPower<CreativePowers.FreezeRainPower>().Enabled && dayRate != 0) {
+ 						if (rand.Next((int)((double)num2 * 5.75)) == 0)
+ 							StartRain();
+-						else if (cloudBGActive >= 1f && rand.Next((int)((double)num2 * 4.25)) == 0)
++						else if (cloudBGActive >= 1f && rand.Next((int)(num2 * 4.25)) == 0)
+ 							StartRain();
+-						else if (ladyBugRainBoost > 0 && rand.Next(num2) == 0)
++						else if (ladyBugRainBoost > 0 && rand.Next((int)num2) == 0)
+ 							StartRain();
+ 					}
+ 
+@@ -49454,11 +_,11 @@
+ 						WorldGen.UnspawnTravelNPC();
+ 				}
+ 				else if (!fastForwardTime && dayTime && time < 27000.0) {
+-					int num5 = dayRate;
++					double num5 = dayRate;
+-					if (num5 < 1)
++					if (num5 < 0)
+-						num5 = 1;
++						num5 = 0;
+ 
+-					int num6 = (int)(27000.0 / (double)num5);
++					int num6 = (int)(27000.0 / num5);
+ 					num6 *= 4;
+ 					if (rand.Next(num6) == 0) {
+ 						int num7 = 0;
 @@ -49830,7 +_,7 @@
  					num++;
  			}

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -30,7 +30,8 @@ namespace Terraria.ModLoader.IO
 				["killCounts"] = SaveNPCKillCounts(),
 				["anglerQuest"] = SaveAnglerQuest(),
 				["townManager"] = SaveTownManager(),
-				["modData"] = SaveModData()
+				["modData"] = SaveModData(),
+				["alteredVanilla"] = SaveAlteredVanillaFields()
 			};
 
 			var stream = new MemoryStream();
@@ -75,6 +76,7 @@ namespace Terraria.ModLoader.IO
 				customDataFail = e;
 				throw;
 			}
+			LoadAlteredVanillaFields(tag.GetCompound("alteredVanilla"));
 		}
 
 		internal static List<TagCompound> SaveChests() {

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -2,6 +2,7 @@ using Microsoft.Xna.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Terraria.GameContent.Events;
 using Terraria.ID;
 using Terraria.ModLoader.Default;
 using Terraria.ModLoader.Exceptions;
@@ -289,6 +290,20 @@ namespace Terraria.ModLoader.IO
 					ModContent.GetInstance<UnloadedSystem>().data.Add(tag);
 				}
 			}
+		}
+
+		internal static TagCompound SaveAlteredVanillaFields() {
+			return new TagCompound {
+				["timeCultists"] = CultistRitual.delay,
+				["timeRain"] = Main.rainTime,
+				["timeSandstorm"] = Sandstorm.TimeLeft
+			};
+		}
+
+		internal static void LoadAlteredVanillaFields(TagCompound compound) {
+			CultistRitual.delay = compound.GetDouble("timeCultists");
+			Main.rainTime = compound.GetDouble("timeRain");
+			Sandstorm.TimeLeft = compound.GetDouble("timeSandstorm");
 		}
 
 		public static void SendModData(BinaryWriter writer) {

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -220,10 +220,11 @@ namespace Terraria.ModLoader
 		public virtual void PostDrawTiles() { }
 
 		/// <summary>
-		/// Called after all other time calculations. Can be used to modify the speed at which time should progress per tick in seconds, along with the rate at which the world should update with it.
+		/// Called after all other time calculations.
+		/// Can be used to modify the speed at which time should progress per tick (measured in in-game minutes per real-life second), along with the rate at which the world should update with it (measured in ticks per frame).
 		/// You may want to consider Main.fastForwardTime and CreativePowerManager.Instance.GetPower<CreativePowers.FreezeTime>().Enabled here.
 		/// </summary>
-		public virtual void ModifyTimeRate(ref int timeRate, ref int tileUpdateRate) { }
+		public virtual void ModifyTimeRate(ref double timeRate, ref int tileUpdateRate) { }
 
 		/// <summary>
 		/// Allows you to save custom data for this system in the current world. Useful for things like saving world specific flags. For example, if your mod adds a boss and you want certain NPC to only spawn once it has been defeated, this is where you would store the information that that boss has been defeated in this world. Returns null by default.

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -221,10 +221,14 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Called after all other time calculations.
-		/// Can be used to modify the speed at which time should progress per tick (measured in in-game minutes per real-life second), along with the rate at which the world should update with it (measured in ticks per frame).
+		/// Can be used to modify the speed at which time should progress per second, along with the rate at which the world should update with it (normally equivalent to timeRate).
+		/// All fields are measured in in-game minutes per real-life second (min/sec).
 		/// You may want to consider Main.fastForwardTime and CreativePowerManager.Instance.GetPower<CreativePowers.FreezeTime>().Enabled here.
 		/// </summary>
-		public virtual void ModifyTimeRate(ref double timeRate, ref int tileUpdateRate) { }
+		/// <param name="timeRate">The speed at which time flows in min/sec.</param>
+		/// <param name="tileUpdateRate">The speed at which tiles in the world update in min/sec.</param>
+		/// <param name="eventUpdateRate">The speed at which various events in the world (weather changes, fallen star/fairy spans, etc.) update in min/sec.</param>
+		public virtual void ModifyTimeRate(ref double timeRate, ref double tileUpdateRate, ref double eventUpdateRate) { }
 
 		/// <summary>
 		/// Allows you to save custom data for this system in the current world. Useful for things like saving world specific flags. For example, if your mod adds a boss and you want certain NPC to only spawn once it has been defeated, this is where you would store the information that that boss has been defeated in this world. Returns null by default.

--- a/patches/tModLoader/Terraria/ModLoader/SystemHooks.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemHooks.HookLists.cs
@@ -55,7 +55,7 @@ namespace Terraria.ModLoader
 
 		private delegate void DelegatePostDrawFullscreenMap(ref string mouseText);
 
-		private delegate void DelegateModifyTimeRate(ref double timeRate, ref int tileUpdateRate);
+		private delegate void DelegateModifyTimeRate(ref double timeRate, ref double tileUpdateRate, ref double eventUpdateRate);
 
 		private delegate void DelegateModifyWorldGenTasks(List<GenPass> passes, ref float totalWeight);
 

--- a/patches/tModLoader/Terraria/ModLoader/SystemHooks.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemHooks.HookLists.cs
@@ -55,7 +55,7 @@ namespace Terraria.ModLoader
 
 		private delegate void DelegatePostDrawFullscreenMap(ref string mouseText);
 
-		private delegate void DelegateModifyTimeRate(ref int timeRate, ref int tileUpdateRate);
+		private delegate void DelegateModifyTimeRate(ref double timeRate, ref int tileUpdateRate);
 
 		private delegate void DelegateModifyWorldGenTasks(List<GenPass> passes, ref float totalWeight);
 

--- a/patches/tModLoader/Terraria/ModLoader/SystemHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemHooks.cs
@@ -289,7 +289,7 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public static void ModifyTimeRate(ref int timeRate, ref int tileUpdateRate) {
+		public static void ModifyTimeRate(ref double timeRate, ref int tileUpdateRate) {
 			foreach (var system in HookModifyTimeRate.arr) {
 				system.ModifyTimeRate(ref timeRate, ref tileUpdateRate);
 			}

--- a/patches/tModLoader/Terraria/ModLoader/SystemHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemHooks.cs
@@ -289,9 +289,9 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public static void ModifyTimeRate(ref double timeRate, ref int tileUpdateRate) {
+		public static void ModifyTimeRate(ref double timeRate, ref double tileUpdateRate, ref double eventUpdateRate) {
 			foreach (var system in HookModifyTimeRate.arr) {
-				system.ModifyTimeRate(ref timeRate, ref tileUpdateRate);
+				system.ModifyTimeRate(ref timeRate, ref tileUpdateRate, ref eventUpdateRate);
 			}
 		}
 

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -48,7 +48,17 @@
  		public OverheadMessage chatOverhead;
  		public SelectionRadial DpadRadial = new SelectionRadial();
  		public SelectionRadial CircularRadial = new SelectionRadial(SelectionRadial.SelectionMode.RadialCircular);
-@@ -438,7 +_,7 @@
+@@ -430,15 +_,15 @@
+ 		private static SlotId _insideBlizzardSound = SlotId.Invalid;
+ 		public string name = "";
+ 		public int taxMoney;
+-		public int taxTimer;
++		public double taxTimer;
+-		public static int taxRate = 3600;
++		public static double taxRate = 3600;
+ 		public static int crystalLeafDamage = 100;
+ 		public static int crystalLeafKB = 10;
+ 		public float basiliskCharge;
  		public Vector2 lastDeathPostion;
  		public DateTime lastDeathTime;
  		public bool showLastDeath;
@@ -129,6 +139,15 @@
  		public static int defaultItemGrabRange = 42;
  		private static float itemGrabSpeed = 0.45f;
  		private static float itemGrabSpeedMax = 4f;
+@@ -1351,7 +_,7 @@
+ 		private int[] unlitTorchY = new int[maxTorchAttacks];
+ 		private static int[] _torchAttackPosX = new int[400];
+ 		private static int[] _torchAttackPosY = new int[400];
+-		public int ladyBugLuckTimeLeft;
++		public double ladyBugLuckTimeLeft;
+ 		public float luck;
+ 		public float luckMinimumCap = -0.7f;
+ 		public float luckMaximumCap = 1f;
 @@ -2051,11 +_,13 @@
  		}
  

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -588,6 +588,15 @@
  				if (num3 < 24f)
  					Kill();
  
+@@ -32590,7 +_,7 @@
+ 				return;
+ 			}
+ 
+-			ai[0] += Main.dayRate;
++			ai[0] += (float)Main.dayRate;
+ 			if (localAI[0] == 0f && Main.netMode != 2) {
+ 				localAI[0] = 1f;
+ 				if ((double)Main.LocalPlayer.position.Y < Main.worldSurface * 16.0)
 @@ -32896,7 +_,7 @@
  						if (tileSafely2.active() && Main.tileSolid[tileSafely2.type] && !Main.tileSolidTop[tileSafely2.type])
  							continue;

--- a/patches/tModLoader/Terraria/Star.cs.patch
+++ b/patches/tModLoader/Terraria/Star.cs.patch
@@ -1,0 +1,20 @@
+--- src/Terraria/Terraria/Star.cs
++++ src/tModLoader/Terraria/Star.cs
+@@ -16,7 +_,7 @@
+ 		public bool falling;
+ 		public bool hidden;
+ 		public Vector2 fallSpeed;
+-		public int fallTime;
++		public double fallTime;
+ 		public static bool dayCheck = false;
+ 		public static float starfallBoost = 1f;
+ 		public static int starFallCount = 0;
+@@ -122,7 +_,7 @@
+ 		public void Update() {
+ 			if (falling && !hidden) {
+ 				fallTime += Main.dayRate;
+-				position += fallSpeed * (Main.dayRate + 99) / 100f;
++				position += fallSpeed * (float)(Main.dayRate + 99) / 100f;
+ 				if (position.Y > 1500f)
+ 					hidden = true;
+ 

--- a/patches/tModLoader/Terraria/Star.cs.patch
+++ b/patches/tModLoader/Terraria/Star.cs.patch
@@ -9,12 +9,23 @@
  		public static bool dayCheck = false;
  		public static float starfallBoost = 1f;
  		public static int starFallCount = 0;
-@@ -122,7 +_,7 @@
+@@ -121,8 +_,8 @@
+ 
  		public void Update() {
  			if (falling && !hidden) {
- 				fallTime += Main.dayRate;
+-				fallTime += Main.dayRate;
++				fallTime += Main.desiredWorldEventsUpdateRate;
 -				position += fallSpeed * (Main.dayRate + 99) / 100f;
-+				position += fallSpeed * (float)(Main.dayRate + 99) / 100f;
++				position += fallSpeed * (float)(Main.desiredWorldEventsUpdateRate + 99) / 100f;
  				if (position.Y > 1500f)
  					hidden = true;
  
+@@ -147,7 +_,7 @@
+ 			}
+ 
+ 			if (fadeIn > 0f) {
+-				float num = 6.1728395E-05f * (float)Main.dayRate;
++				float num = 6.1728395E-05f * (float)Main.desiredWorldEventsUpdateRate;
+ 				fadeIn -= num;
+ 				if (fadeIn < 0f)
+ 					fadeIn = 0f;

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1564,16 +1564,16 @@
  			if (Main.dayTime)
  				return;
  
--			for (int l = 0; l < Main.dayRate; l++) {
--				float num6 = Main.maxTilesX / 4200;
 +			timePass += Main.desiredWorldEventsUpdateRate;
 +			if (timePass < 1)
 +				return;
 +
 +			double timePassReference = timePass;
-+			for (int l = 0; l < timePassReference; l++) {
+-			for (int l = 0; l < Main.dayRate; l++) {
++			for (int l = 0; l < (int)timePassReference; l++) {
 +				timePass -= 1.0;
-+				float num6 = Main.maxTilesX / 4200f; // Selfish fix for falling stars on extra small worlds
+-				float num6 = Main.maxTilesX / 4200;
++				float num6 = Main.maxTilesX / 4200f;
  				num6 *= Star.starfallBoost;
  				if (!((float)Main.rand.Next(8000) < 10f * num6))
  					continue;

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -23,6 +23,14 @@
  		public static int tLeft;
  		public static int tRight;
  		public static int tTop;
+@@ -894,6 +_,7 @@
+ 		private static bool fossilBreak = false;
+ 		private const bool BUBBLES_SOLID_STATE_FOR_HOUSING = true;
+ 		private static bool skipFramingDuringGen = false;
++		private static double timePass = 0.0; // tML
+ 
+ 		public static UnifiedRandom genRand {
+ 			get {
 @@ -1214,7 +_,7 @@
  			}
  
@@ -1543,15 +1551,43 @@
  			AllowedToSpreadInfections = true;
  			CreativePowers.StopBiomeSpreadPower power = CreativePowerManager.Instance.GetPower<CreativePowers.StopBiomeSpreadPower>();
  			if (power != null && power.GetIsUnlocked())
-@@ -45669,7 +_,7 @@
+@@ -45623,7 +_,7 @@
+ 				Liquid.skipCount = 0;
+ 			}
+ 
+-			int worldUpdateRate = GetWorldUpdateRate();
++			double worldUpdateRate = GetWorldUpdateRate();
+ 			if (worldUpdateRate == 0)
  				return;
  
- 			for (int l = 0; l < Main.dayRate; l++) {
+@@ -45668,8 +_,14 @@
+ 			if (Main.dayTime)
+ 				return;
+ 
+-			for (int l = 0; l < Main.dayRate; l++) {
 -				float num6 = Main.maxTilesX / 4200;
++			timePass += Main.desiredWorldEventsUpdateRate;
++			if (timePass < 1)
++				return;
++
++			double timePassReference = timePass;
++			for (int l = 0; l < timePassReference; l++) {
++				timePass -= 1.0;
 +				float num6 = Main.maxTilesX / 4200f; // Selfish fix for falling stars on extra small worlds
  				num6 *= Star.starfallBoost;
  				if (!((float)Main.rand.Next(8000) < 10f * num6))
  					continue;
+@@ -45702,8 +_,8 @@
+ 			}
+ 		}
+ 
+-		public static int GetWorldUpdateRate() {
++		public static double GetWorldUpdateRate() {
+-			int result = Math.Min(Main.desiredWorldTilesUpdateRate, 24);
++			double result = Math.Min(Main.desiredWorldTilesUpdateRate, 24);
+ 			if (CreativePowerManager.Instance.GetPower<CreativePowers.FreezeTime>().Enabled)
+ 				result = 0;
+ 
 @@ -45711,6 +_,8 @@
  		}
  

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1560,25 +1560,24 @@
  			if (worldUpdateRate == 0)
  				return;
  
-@@ -45668,8 +_,14 @@
+@@ -45668,8 +_,10 @@
  			if (Main.dayTime)
  				return;
  
 +			timePass += Main.desiredWorldEventsUpdateRate;
-+			if (timePass < 1)
-+				return;
-+
-+			double timePassReference = timePass;
 -			for (int l = 0; l < Main.dayRate; l++) {
-+			for (int l = 0; l < (int)timePassReference; l++) {
++			for (int l = 1; l < (int)timePass; l++) {
 +				timePass -= 1.0;
 -				float num6 = Main.maxTilesX / 4200;
 +				float num6 = Main.maxTilesX / 4200f;
  				num6 *= Star.starfallBoost;
  				if (!((float)Main.rand.Next(8000) < 10f * num6))
  					continue;
-@@ -45702,8 +_,8 @@
+@@ -45700,10 +_,11 @@
+ 					Projectile.NewProjectile(position.X, position.Y, num13, num14, 720, 0, 0f, Main.myPlayer, 0f, num10);
+ 				}
  			}
++			timePass %= 1.0;
  		}
  
 -		public static int GetWorldUpdateRate() {


### PR DESCRIPTION
- The rate at which time flows and the rate at which tiles in the world update may both now be set to decimal values.
- The rate at which events in the world occur (e.g. fallen star/fairy spawns, weather changes) can now be set independently of `Main.dayRate`, although by default it will have the same value `Main.dayRate` would have after vanilla calculations.
- Updated `ModSystem.ModifyTimeRate` to better reflect the new and improved system of time distortion.

The main benefit of this change set is that it becomes possible to **slow the flow of time (and tile/world updates)** compared to the rate at which time normally passes in the game (1 in-game minute per 1 real-life second, or 1 min/sec). For example, setting `Main.dayRate` to 0.5 causes the game to move at 0.5 min/sec, causing the game's time to move half as quickly as normal. Furthermore, you are now able to decide if events should update faster or slower than they normally would with a certain `Main.dayRate` value --- this should grant much more flexibility in how time is handled.

As extra clarification, **this does not hinder or otherwise affect aspects of the game that would not normally be affected by changing the flow of time**. The only changes made were changes which were required to ensure things whose behavior DOES change with the flow of time still behaved properly following the conversion of `Main.dayRate` and related variables.

"Why not use floats?"
Doubles are much more precise (the relative inaccuracy of float values is why the Lunar Pillars are able to slowly sink into the ground as they hover), and they are already used by a few important time-related fields (most notably `Main.time`, the field responsible for keeping track of the time universally in the current world) in the base game. Using doubles for the rest of the fields, as such, seems like the most appropriate option. While you could *technically* argue that floats would take up slightly less patch size, it seems counterintuitive to consciously give up precision and consistency (especially on something as fundamental to the game as the flow of time) simply to lower the number of lines shown by the patch by a relatively-insignificant amount, as the change would hardly prevent any of the significant changes from needing to be made *anyway*.

"Isn't `Main.dayRate` cast to a float a few times?"
For rendering the sky, yes. These casts aren't really relevant to the PR, though, as the difference made by changing them at all would be so minimal it's practically unnoticeable, and since you can safely cast a double to a float, it seems unnecessary to change them when they already work fine after the change.