### PR TITLE
Fix tile IO post cleanup on exit call

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -710,6 +710,14 @@
  					else if (text == Language.GetTextValue("CLI.Settle_Command")) {
  						if (!Liquid.panicMode)
  							Liquid.StartPanic();
+@@ -4534,6 +_,7 @@
+ 					}
+ 					else if (text == Language.GetTextValue("CLI.Exit_Command")) {
+ 						WorldFile.SaveWorld();
++						TileIO.PostExitWorldCleanup();
+ 						Netplay.Disconnect = true;
+ 						SocialAPI.Shutdown();
+ 					}
 @@ -4587,11 +_,12 @@
  						Console.WriteLine(Language.GetTextValue("CLI.Port", Netplay.ListenPort));
  					}

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -36,8 +36,6 @@ namespace Terraria.ModLoader.IO
 			TagIO.ToStream(tag, stream);
 			var data = stream.ToArray();
 			FileUtilities.Write(path, data, data.Length, isCloudSave);
-
-			TileIO.PostExitWorldCleanup();
 		}
 		//add near end of Terraria.IO.WorldFile.loadWorld before setting failure and success
 		internal static void Load(string path, bool isCloudSave) {

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -254,15 +254,17 @@
  #endif
  					num2 = 0;
  					num = 0;
-@@ -2303,7 +_,7 @@
+@@ -2303,8 +_,9 @@
  			}
  
  			if (!flag) {
 -				Console.WriteLine(Language.GetTextValue("Net.ServerAutoShutdown"));
 +				Logging.ServerConsoleLine(Language.GetTextValue("Net.ServerAutoShutdown"));
  				WorldFile.SaveWorld();
++				TileIO.PostExitWorldCleanup();
  				Netplay.Disconnect = true;
  			}
+ 		}
 @@ -2354,11 +_,12 @@
  					SendData(5, toWho, fromWho, null, plr, 94 + m, (int)Main.player[plr].miscDyes[m].prefix);
  				}

--- a/patches/tModLoader/Terraria/Netplay.cs.patch
+++ b/patches/tModLoader/Terraria/Netplay.cs.patch
@@ -6,7 +6,7 @@
  using System.IO;
  using System.Linq;
  using System.Net;
-@@ -7,10 +_,12 @@
+@@ -7,10 +_,13 @@
  using System.Runtime.CompilerServices;
  #endif
  using System.Threading;
@@ -16,6 +16,7 @@
  using Terraria.Localization;
  using Terraria.Map;
 +using Terraria.ModLoader;
++using Terraria.ModLoader.IO;
  using Terraria.Net;
  using Terraria.Net.Sockets;
  using Terraria.Social;
@@ -56,6 +57,14 @@
  		private static void OpenPort(int port) {
  #if SERVER && WINDOWS
  			string localIPAddress = GetLocalIPAddress();
+@@ -286,6 +_,7 @@
+ 				Main.netMode = 0;
+ 				Main.menuMode = 10;
+ 				WorldFile.SaveWorld();
++				TileIO.PostExitWorldCleanup();
+ 				Main.menuMode = 0;
+ 			}
+ 			else {
 @@ -422,6 +_,7 @@
  		}
  

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -100,6 +100,14 @@
  			Main.invasionProgress = -1;
  			Main.invasionProgressDisplayLeft = 0;
  			Main.invasionProgressAlpha = 0f;
+@@ -2354,6 +_,7 @@
+ 			Rain.ClearRain();
+ 			if (netMode == 0) {
+ 				WorldFile.SaveWorld();
++				TileIO.PostExitWorldCleanup();
+ 				SoundEngine.PlaySound(10);
+ 			}
+ 			else {
 @@ -2370,10 +_,21 @@
  
  		public static void SaveAndQuit(Action callback = null) {


### PR DESCRIPTION
### What is the bug?
Currently the location of TileIO.PostExitWorldCleanup is run during in world save and continue, despite being intended for during exiting a world after save has occurred.

### How did you fix the bug?
This PR moves it to occur after WorldFile.SaveWorld() during the cases where the world is closing.

### Are there alternatives to your fix?
I couldn't find a singular spot to 'cleanup' so to speak on world exit.