### PR TITLE
Fix Tile IO legacy unloaded

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Basic.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Basic.cs
@@ -60,7 +60,7 @@ namespace Terraria.ModLoader.IO
 						else { // If it can't be found, then add entry to the end of the entries list and set the loadedType to the unloaded placeholder
 							savedEntryLookup[entry.type] = entry;
 							entry.type = (ushort)entries.Count;
-							entry.loadedType = canPurgeOldData ? entry.vanillaReplacementType : ModContent.Find<TBlock>(entry.unloadedType).Type;
+							entry.loadedType = canPurgeOldData ? entry.vanillaReplacementType : ModContent.Find<TBlock>(entry.unloadedType.Length > 0 ? entry.unloadedType : entry.DefaultUnloadedType).Type;
 							entries.Add(entry);
 						}
 					}

--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Basic.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Basic.cs
@@ -60,7 +60,7 @@ namespace Terraria.ModLoader.IO
 						else { // If it can't be found, then add entry to the end of the entries list and set the loadedType to the unloaded placeholder
 							savedEntryLookup[entry.type] = entry;
 							entry.type = (ushort)entries.Count;
-							entry.loadedType = canPurgeOldData ? entry.vanillaReplacementType : ModContent.Find<TBlock>(entry.unloadedType.Length > 0 ? entry.unloadedType : entry.DefaultUnloadedType).Type;
+							entry.loadedType = canPurgeOldData ? entry.vanillaReplacementType : ModContent.Find<TBlock>(string.IsNullOrEmpty(entry.unloadedType) ? entry.DefaultUnloadedType : entry.unloadedType).Type;
 							entries.Add(entry);
 						}
 					}


### PR DESCRIPTION
Bring back pathing functionality from https://github.com/tModLoader/tModLoader/tree/2aeb37630e1fc196d459b09814d1b39ebbffd8b4/patches/tModLoader/Terraria/ModLoader/IO

Fixes ModContent.Find to correctly path based on entry.unloadedType.Length, as legacy worlds will have this as an empty string on first load so they need to use the entry.DefaultUnloadedType.