### PR TITLE
Fixed a crash with ModMenu during mod building

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
@@ -144,6 +144,8 @@ namespace Terraria.ModLoader
 		}
 
 		internal static void Unload() {
+			currentMenu = MenutML; // Prevent asset disposed exceptions by disallowing modded menus during the unload process.
+
 			loading = true;
 			if (menus.IndexOf(currentMenu) >= DefaultMenuCount) {
 				switchToMenu = MenutML;


### PR DESCRIPTION
### What is the bug?

This bug occurs when a there is a non-vanilla ModMenu active and it is unloaded. This can cause AssetDisposedException's because it attempts to draw the unloaded textures (caused by unloading occurring on a different thread).

### How did you fix the bug?

Setting the ModMenu to MenutML at the beginning of the unload process.

### Are there alternatives to your fix?

Something like https://github.com/Mirsario/Terraria-BetterRussian/blob/master/BetterRussianMod.cs, which uses a TaskCompletionSource to await the unloading of the menu assets.