### PR TITLE
FixStylesOfUnloadedChest and Dresser

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedChest.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedChest.cs
@@ -22,7 +22,7 @@ namespace Terraria.ModLoader.Default
 
 			TileID.Sets.BasicChest[Type] = true;
 
-			TileObjectData.newTile.CopyFrom(TileObjectData.Style1x1); // Disables hammering
+			TileObjectData.newTile.CopyFrom(TileObjectData.Style2x2); // Disables hammering
 			TileObjectData.addTile(Type);
 				
 			Main.tileSpelunker[Type] = true;

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedDresser.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedDresser.cs
@@ -19,7 +19,7 @@ namespace Terraria.ModLoader.Default
 			Main.tileSolidTop[Type] = true;
 			TileID.Sets.BasicDresser[Type] = true;
 
-			TileObjectData.newTile.CopyFrom(TileObjectData.Style1x1); // Disables hammering
+			TileObjectData.newTile.CopyFrom(TileObjectData.Style3x2); // Disables hammering
 			TileObjectData.addTile(Type);
 		}
 	}


### PR DESCRIPTION
### What is the bug?
Mining unloaded Chests, Dressers will crash the game due to a stack overflow.

### How did you fix the bug?
Setting them so they have the correct style templates to match their corresponding set fixes the crash.

