### PR TITLE
Fix SoundLoader vanilla count return & fix unloaded tile MP bug

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedTile.cs
@@ -13,11 +13,13 @@ namespace Terraria.ModLoader.Default
 			Player player = Main.LocalPlayer;
 
 			//NOTE: Onwards only works in singleplayer, as the lists aren't synced afaik.
-			ushort type = TileIO.Tiles.unloadedEntryLookup.Lookup(i, j);
-			var info = TileIO.Tiles.entries[type];
-			player.cursorItemIconEnabled = true;
-			player.cursorItemIconID = -1;
-			player.cursorItemIconText = $"{info.modName}: {info.name}";
+			if (TileIO.Tiles.unloadedEntryLookup != null) {
+				ushort type = TileIO.Tiles.unloadedEntryLookup.Lookup(i, j);
+				var info = TileIO.Tiles.entries[type];
+				player.cursorItemIconEnabled = true;
+				player.cursorItemIconID = -1;
+				player.cursorItemIconText = $"{info.modName}: {info.name}";
+			}
 		}
 
 		public override void MouseOverFar(int i, int j) => MouseOver(i, j);

--- a/patches/tModLoader/Terraria/ModLoader/SoundLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SoundLoader.cs
@@ -143,11 +143,11 @@ namespace Terraria.ModLoader
 				case SoundType.Custom:
 					return 0;
 				case SoundType.Item:
-					return SoundID.ItemSoundCount + 1;
+					return SoundID.ItemSoundCount;
 				case SoundType.NPCHit:
-					return SoundID.NPCHitCount + 1;
+					return SoundID.NPCHitCount;
 				case SoundType.NPCKilled:
-					return SoundID.NPCDeathCount + 1;
+					return SoundID.NPCDeathCount;
 				case SoundType.Music:
 					return Main.maxMusic;
 			}


### PR DESCRIPTION
### What is the bug?
1) #1436  
2) Multiplayer hover over unloaded tile bug.

### How did you fix the bug?
1) Change vanilla count in SoundLoader to be vanilla count, not one more than
2) Re-add the null check against the unloadedEntriesLookup

### Are there alternatives to your fix?
1) Will become unneeded once SoundFix is merged, but for now patch
2) Straightforward bug fix.