### PR TITLE
[1.4] Shoot Rework fix

### DIFF
--- a/ExampleMod/Common/GlobalItems/ShortswordGlobalItem.cs
+++ b/ExampleMod/Common/GlobalItems/ShortswordGlobalItem.cs
@@ -22,7 +22,7 @@ namespace ExampleMod.Common.GlobalItems
 
 		public override void Shoot(Item item, Player player, ProjectileSource_Item_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback) {
 			// Make it shoot grenades for no reason
-			Projectile.NewProjectileDirect(source, player.Center, velocity * 5f, ProjectileID.Grenade, damage, knockBack, player.whoAmI);
+			Projectile.NewProjectileDirect(source, player.Center, velocity * 5f, ProjectileID.Grenade, damage, knockback, player.whoAmI);
 		}
 	}
 }

--- a/ExampleMod/Content/Items/Weapons/ExampleShotgun.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleShotgun.cs
@@ -41,16 +41,14 @@ namespace ExampleMod.Content.Items.Weapons
 			const int NumProjectiles = 8; //The humber of projectiles that this gun will shoot.
 
 			for (int i = 0; i < NumProjectiles; i++) {
-				Vector2 newVelocity = velocity;
-
 				// Rotate the velocity randomly by 30 degrees at max.
-				newVelocity = velocity.RotatedByRandom(MathHelper.ToRadians(15));
+				Vector2 newVelocity = velocity.RotatedByRandom(MathHelper.ToRadians(15));
 
 				// Decrease velocity randomly for nicer visuals.
 				newVelocity *= 1f - Main.rand.NextFloat(0.3f);
 
 				//Create a projectile.
-				Projectile.NewProjectileDirect(source, position, velocity, type, damage, knockback, player.whoAmI);
+				Projectile.NewProjectileDirect(source, position, newVelocity, type, damage, knockback, player.whoAmI);
 			}
 
 			return false; // Return false because we don't want tModLoader to shoot projectile

--- a/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
+++ b/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
@@ -70,7 +70,7 @@ namespace ExampleMod.Content.Projectiles.Minions
 			Item.shoot = ModContent.ProjectileType<ExampleSimpleMinion>(); // This item creates the minion projectile.
 		}
 
-		public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockBack) {
+		public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback) {
 			// This is needed so the buff that keeps your minion alive and allows you to despawn it properly applies
 			player.AddBuff(Item.buffType, 2);
 


### PR DESCRIPTION
* Changed missed instances of `knockBack` to `knockback`.
* Fixed ExampleShotgun not randomnizing its projectile spread.