### PR TITLE
[1.4] Reimplement TileCollideStyle projectile hooks

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -94,14 +94,15 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to determine how a projectile interacts with tiles. Width and height determine the projectile's hitbox for tile collision, and default to -1. Leave them as -1 to use the projectile's real size. Fallthrough determines whether the projectile can fall through platforms, etc., and defaults to true.
+		/// Allows you to determine how a projectile interacts with tiles. Return false if you completely override a projectile's tile collision behavior. Returns true by default.
 		/// </summary>
-		/// <param name="projectile"></param>
-		/// <param name="width"></param>
-		/// <param name="height"></param>
-		/// <param name="fallThrough"></param>
+		/// <param name="projectile"> The projectile. </param>
+		/// <param name="width"> The width of the hitbox the projectile will use for tile collision. If vanilla or a mod don't modify it, defaults to -1. Leave it as -1 to use the projectile's real width. </param>
+		/// <param name="height"> The height of the hitbox the projectile will use for tile collision. If vanilla or a mod don't modify it, defaults to -1. Leave it as -1 to use the projectile's real height. </param>
+		/// <param name="fallThrough"> Whether or not the projectile falls through platforms and similar tiles. </param>
+		/// <param name="hitboxOffsetMult"> If either width or height isn't -1, this determines by how much the tile collision hitbox will be offset from the projectile's real center. If set to null, the position will be offset by half the width and height, making the tile collision hitbox center align with the real center. </param>
 		/// <returns></returns>
-		public virtual bool TileCollideStyle(Projectile projectile, ref int width, ref int height, ref bool fallThrough) {
+		public virtual bool TileCollideStyle(Projectile projectile, ref int width, ref int height, ref bool fallThrough, ref Vector2? hitboxOffsetMult) {
 			return true;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -171,12 +171,14 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to determine how this projectile interacts with tiles. Width and height determine the projectile's hitbox for tile collision, and default to -1. Leave them as -1 to use the projectile's real size. Fallthrough determines whether the projectile can fall through platforms, etc., and defaults to true.
+		/// Allows you to determine how this projectile interacts with tiles. Return false if you completely override this projectile's tile collision behavior. Returns true by default.
 		/// </summary>
-		/// <param name="width">Width of the hitbox.</param>
-		/// <param name="height">Height of the hitbox.</param>
-		/// <param name="fallThrough">If the projectile can fall through platforms etc.</param>
-		public virtual bool TileCollideStyle(ref int width, ref int height, ref bool fallThrough) {
+		/// <param name="width"> The width of the hitbox this projectile will use for tile collision. If vanilla or a mod don't modify it, defaults to -1. Leave it as -1 to use the projectile's real width. </param>
+		/// <param name="height"> The height of the hitbox this projectile will use for tile collision. If vanilla or a mod don't modify it, defaults to -1. Leave it as -1 to use the projectile's real height. </param>
+		/// <param name="fallThrough"> Whether or not the projectile falls through platforms and similar tiles. </param>
+		/// <param name="hitboxOffsetMult"> If either width or height isn't -1, this determines by how much the tile collision hitbox will be offset from the projectile's real center. If set to null, the position will be offset by half the width and height, making the tile collision hitbox center align with the real center. </param>
+		/// <returns></returns>
+		public virtual bool TileCollideStyle(ref int width, ref int height, ref bool fallThrough, ref Vector2? hitboxOffsetMult) {
 			return true;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -222,16 +222,16 @@ namespace Terraria.ModLoader
 			return true;
 		}
 
-		private delegate bool DelegateTileCollideStyle(Projectile projectile, ref int width, ref int height, ref bool fallThrough);
+		private delegate bool DelegateTileCollideStyle(Projectile projectile, ref int width, ref int height, ref bool fallThrough, ref Vector2? hitboxOffsetMult);
 		private static HookList HookTileCollideStyle = AddHook<DelegateTileCollideStyle>(g => g.TileCollideStyle);
 
-		public static bool TileCollideStyle(Projectile projectile, ref int width, ref int height, ref bool fallThrough) {
-			if (IsModProjectile(projectile) && !projectile.ModProjectile.TileCollideStyle(ref width, ref height, ref fallThrough)) {
+		public static bool TileCollideStyle(Projectile projectile, ref int width, ref int height, ref bool fallThrough, ref Vector2? hitboxOffsetMult) {
+			if (IsModProjectile(projectile) && !projectile.ModProjectile.TileCollideStyle(ref width, ref height, ref fallThrough, ref hitboxOffsetMult)) {
 				return false;
 			}
 
 			foreach (GlobalProjectile g in HookTileCollideStyle.Enumerate(projectile.globalProjectiles)) {
-				if (!g.TileCollideStyle(projectile, ref width, ref height, ref fallThrough)) {
+				if (!g.TileCollideStyle(projectile, ref width, ref height, ref fallThrough, ref hitboxOffsetMult)) {
 					return false;
 				}
 			}

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -451,6 +451,17 @@
  				}
  
  				if (minion && numUpdates == -1 && type != 625 && type != 628) {
+@@ -11831,7 +_,9 @@
+ 					overrideHeight = 4;
+ 				}
+ 
++				if (!ProjectileLoader.TileCollideStyle(this, ref overrideWidth, ref overrideHeight, ref flag6, ref vector)) {
++				}
+-				if (((type != 440 && type != 449 && type != 606) || ai[1] != 1f) && (type != 466 || localAI[1] != 1f) && (type != 580 || !(localAI[1] > 0f)) && (type != 640 || !(localAI[1] > 0f))) {
++				else if (((type != 440 && type != 449 && type != 606) || ai[1] != 1f) && (type != 466 || localAI[1] != 1f) && (type != 580 || !(localAI[1] > 0f)) && (type != 640 || !(localAI[1] > 0f))) {
+ 					if (aiStyle == 10) {
+ 						if (type >= 736 && type <= 738) {
+ 							base.velocity = Collision.TileCollision(base.position, base.velocity, base.width, base.height, flag6, flag6);
 @@ -12105,7 +_,9 @@
  						}
  					}


### PR DESCRIPTION
### What is the new feature?
* Made it so `ProjectileLoader.TileCollideStyle` is once again called by the vanilla `Projectile.HandleMovement` method, in the same section as in 1.3 .
* Added `hitboxOffsetMult` parameter, which allows adjusting the tile collision hitbox position.

### Why should this be part of tModLoader?
* Currently, apart from the hook not being called at all, `TileCollideStyle` only allows modifying the size of the tile collision hitbox, but not to offset its position. Some vanilla projectiles do offset the hitbox position, so passing the variable used for this to the hooks allow mods to do the same.

### Are there alternative designs?
The `hitboxOffsetMult` variable can be confusing to use. I tried to provide an explanation of its usage, but i believe it could better.

### Sample usage for the new feature
```cs
public override bool TileCollideStyle(ref int width, ref int height, ref bool fallThrough, ref Vector2? hitboxOffsetMult) {
	width = 12;
	height = 12;
	hitboxOffsetMult = new Vector2(1, 0.5f);
	return true;
}
```
The above code would resize the tile collision hitbox of the projectile to be 12 x 12. If `hitboxOffsetMult` is null, the new hitbox would have its center aligned with the projectile's center, which would be equivalent to `hitboxOffsetMult` being `new Vector2(0.5f, 0.5f)`, but the code above would make the new hitbox have its **bottom center** align with the projectile's center. Do note that the way the vanilla code is setup, either `width` or `height` have to be changed from -1 for `hitboxOffsetMult` to have any effect.


