### PR TITLE
Re-default tML steam dir to tModLoaderDev by renaming setup setting

### DIFF
--- a/setup/Properties/Settings.Designer.cs
+++ b/setup/Properties/Settings.Designer.cs
@@ -61,7 +61,7 @@ namespace Terraria.ModLoader.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("1.4.2.1")]
+        [global::System.Configuration.DefaultSettingValueAttribute("1.4.2.2")]
         public string ClientVersion {
             get {
                 return ((string)(this["ClientVersion"]));
@@ -70,7 +70,7 @@ namespace Terraria.ModLoader.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("1.4.2.1")]
+        [global::System.Configuration.DefaultSettingValueAttribute("1.4.2.2")]
         public string ServerVersion {
             get {
                 return ((string)(this["ServerVersion"]));
@@ -103,7 +103,7 @@ namespace Terraria.ModLoader.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("ff61b96a07894a9e65f880fb9608fb37")]
+        [global::System.Configuration.DefaultSettingValueAttribute("00d7f0d6590efadeed6393d00e59f777")]
         public string GoGClientWinMD5 {
             get {
                 return ((string)(this["GoGClientWinMD5"]));
@@ -112,19 +112,19 @@ namespace Terraria.ModLoader.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("C:\\Program Files (x86)\\Steam\\steamapps\\common\\tModLoaderDev")]
-        public string TMLSteamDir {
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string TMLDevSteamDir {
             get {
-                return ((string)(this["TMLSteamDir"]));
+                return ((string)(this["TMLDevSteamDir"]));
             }
             set {
-                this["TMLSteamDir"] = value;
+                this["TMLDevSteamDir"] = value;
             }
         }
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("6ebb2e222126aaae302d34a3a2c82cb9")]
+        [global::System.Configuration.DefaultSettingValueAttribute("acfd53772989dbbd7231f98d38669651")]
         public string SteamClientWinMD5 {
             get {
                 return ((string)(this["SteamClientWinMD5"]));

--- a/setup/Properties/Settings.settings
+++ b/setup/Properties/Settings.settings
@@ -26,8 +26,8 @@
     <Setting Name="GoGClientWinMD5" Type="System.String" Scope="Application">
       <Value Profile="(Default)">00d7f0d6590efadeed6393d00e59f777</Value>
     </Setting>
-    <Setting Name="TMLSteamDir" Type="System.String" Scope="User">
-      <Value Profile="(Default)">C:\Program Files (x86)\Steam\steamapps\common\tModLoaderDev</Value>
+    <Setting Name="TMLDevSteamDir" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
     </Setting>
     <Setting Name="SteamClientWinMD5" Type="System.String" Scope="Application">
       <Value Profile="(Default)">acfd53772989dbbd7231f98d38669651</Value>

--- a/setup/Setup/Program.cs
+++ b/setup/Setup/Program.cs
@@ -16,7 +16,7 @@ namespace Terraria.ModLoader.Setup
 		public static readonly string logsDir = Path.Combine("setup", "logs");
 
 		public static string SteamDir => Settings.Default.SteamDir;
-		public static string TMLSteamDir => Settings.Default.TMLSteamDir;
+		public static string TMLDevSteamDir => Settings.Default.TMLDevSteamDir;
 		public static string TerrariaPath => Path.Combine(SteamDir, "Terraria.exe");
 		public static string TerrariaServerPath => Path.Combine(SteamDir, "TerrariaServer.exe");
 
@@ -33,9 +33,9 @@ namespace Terraria.ModLoader.Setup
 				return;
 			}*/
 #if AUTO
-			Settings.Default.TMLSteamDir = Settings.Default.SteamDir = @".\1422\Windows";
+			Settings.Default.TMLDevSteamDir = Settings.Default.SteamDir = @".\1422\Windows";
 #else
-			UpdateTmlSteamDir();
+			CreateTMLSteamDirIfNecessary();
 #endif
 
 			UpdateTargetsFile();
@@ -129,9 +129,10 @@ namespace Terraria.ModLoader.Setup
 				}
 				else {
 					Settings.Default.SteamDir = Path.GetDirectoryName(dialog.FileName);
+					Settings.Default.TMLDevSteamDir = "";
 					Settings.Default.Save();
 
-					UpdateTmlSteamDir(true);
+					CreateTMLSteamDirIfNecessary();
 					UpdateTargetsFile();
 
 					return true;
@@ -152,7 +153,7 @@ namespace Terraria.ModLoader.Setup
 				if (dialog.ShowDialog() != DialogResult.OK)
 					return false;
 
-				Settings.Default.TMLSteamDir = Path.GetDirectoryName(dialog.FileName);
+				Settings.Default.TMLDevSteamDir = Path.GetDirectoryName(dialog.FileName);
 				Settings.Default.Save();
 
 				UpdateTargetsFile();
@@ -161,20 +162,18 @@ namespace Terraria.ModLoader.Setup
 			}
 		}
 
-		private static void UpdateTmlSteamDir(bool manualSet = false) {
-			if (manualSet || !Directory.Exists(TMLSteamDir)) {
-				Settings.Default.TMLSteamDir = Path.GetFullPath(Path.Combine(Settings.Default.SteamDir, "..", "tModLoaderDev"));
-				Settings.Default.Save();
-			}
+		private static void CreateTMLSteamDirIfNecessary() {
+			if (Directory.Exists(TMLDevSteamDir))
+				return;
+			
+			Settings.Default.TMLDevSteamDir = Path.GetFullPath(Path.Combine(Settings.Default.SteamDir, "..", "tModLoaderDev"));
+			Settings.Default.Save();
 
-			//Lame.
-			if (manualSet && !Directory.Exists(TMLSteamDir)) {
-				try {
-					Directory.CreateDirectory(TMLSteamDir);
-				}
-				catch(Exception e) {
-					Console.WriteLine($"{e.GetType().Name}: {e.Message}");
-				}
+			try {
+				Directory.CreateDirectory(TMLDevSteamDir);
+			}
+			catch (Exception e) {
+				Console.WriteLine($"{e.GetType().Name}: {e.Message}");
 			}
 		}
 
@@ -208,7 +207,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 	<BranchName>{branch}</BranchName>
 	<CommitSHA>{gitsha}</CommitSHA>
 	<TerrariaSteamPath>{SteamDir}</TerrariaSteamPath>
-    <tModLoaderSteamPath>{TMLSteamDir}</tModLoaderSteamPath>
+    <tModLoaderSteamPath>{TMLDevSteamDir}</tModLoaderSteamPath>
   </PropertyGroup>
 </Project>";
 

--- a/setup/app.config
+++ b/setup/app.config
@@ -25,8 +25,8 @@
             <setting name="FormatAfterDecompiling" serializeAs="String">
                 <value>True</value>
             </setting>
-            <setting name="TMLSteamDir" serializeAs="String">
-                <value>C:\Program Files (x86)\Steam\steamapps\common\tModLoaderDev</value>
+            <setting name="TMLDevSteamDir" serializeAs="String">
+                <value />
             </setting>
         </Terraria.ModLoader.Properties.Settings>
     </userSettings>


### PR DESCRIPTION
The new tML build location should be a separate folder from the steam install. We've decided to set tModLoaderDev as the default.

This PR forces everyone to move to the new folder from this commit on, unless they manually override it again.