### PR TITLE
Fix errors tossed from ExampleMod, put a temp fix for DrawFarTexture

### DIFF
--- a/ExampleMod/Content/Biomes/ExampleSurfaceBackgroundStyle.cs
+++ b/ExampleMod/Content/Biomes/ExampleSurfaceBackgroundStyle.cs
@@ -23,7 +23,7 @@ namespace ExampleMod.Backgrounds
 		}
 
 		public override int ChooseFarTexture() {
-			return BackgroundTextureLoader.GetBackgroundSlot("Assets/Textures/Backgrounds/ExampleBiomeSurfaceFar");
+			return BackgroundTextureLoader.GetBackgroundSlot("ExampleMod/Assets/Textures/Backgrounds/ExampleBiomeSurfaceFar");
 		}
 
 		private static int SurfaceFrameCounter;
@@ -35,20 +35,20 @@ namespace ExampleMod.Backgrounds
 			}
 			switch (SurfaceFrame) {
 				case 0:
-					return BackgroundTextureLoader.GetBackgroundSlot("Assets/Textures/Backgrounds/ExampleBiomeSurfaceMid0");
+					return BackgroundTextureLoader.GetBackgroundSlot("ExampleMod/Assets/Textures/Backgrounds/ExampleBiomeSurfaceMid0");
 				case 1:
-					return BackgroundTextureLoader.GetBackgroundSlot("Assets/Textures/Backgrounds/ExampleBiomeSurfaceMid1");
+					return BackgroundTextureLoader.GetBackgroundSlot("ExampleMod/Assets/Textures/Backgrounds/ExampleBiomeSurfaceMid1");
 				case 2:
-					return BackgroundTextureLoader.GetBackgroundSlot("Assets/Textures/Backgrounds/ExampleBiomeSurfaceMid2");
+					return BackgroundTextureLoader.GetBackgroundSlot("ExampleMod/Assets/Textures/Backgrounds/ExampleBiomeSurfaceMid2");
 				case 3:
-					return BackgroundTextureLoader.GetBackgroundSlot("Assets/Textures/Backgrounds/ExampleBiomeSurfaceMid3");
+					return BackgroundTextureLoader.GetBackgroundSlot("ExampleMod/Assets/Textures/Backgrounds/ExampleBiomeSurfaceMid3");
 				default:
 					return -1;
 			}
 		}
 
 		public override int ChooseCloseTexture(ref float scale, ref double parallax, ref float a, ref float b) {
-			return BackgroundTextureLoader.GetBackgroundSlot("Assets/Textures/Backgrounds/ExampleBiomeSurfaceClose");
+			return BackgroundTextureLoader.GetBackgroundSlot("ExampleMod/Assets/Textures/Backgrounds/ExampleBiomeSurfaceClose");
 		}
 	}
 }

--- a/ExampleMod/Content/Biomes/ExampleUndergroundBackgroundStyle.cs
+++ b/ExampleMod/Content/Biomes/ExampleUndergroundBackgroundStyle.cs
@@ -4,12 +4,11 @@ namespace ExampleMod.Backgrounds
 {
 	public class ExampleUndergroundBackgroundStyle : ModUndergroundBackgroundStyle
 	{
-		//TODO: This currently doesn't work
 		public override void FillTextureArray(int[] textureSlots) {
-			textureSlots[0] = BackgroundTextureLoader.GetBackgroundSlot("Assets/Textures/Backgrounds/ExampleBiomeUnderground0");
-			textureSlots[1] = BackgroundTextureLoader.GetBackgroundSlot("Assets/Textures/Backgrounds/ExampleBiomeUnderground1");
-			textureSlots[2] = BackgroundTextureLoader.GetBackgroundSlot("Assets/Textures/Backgrounds/ExampleBiomeUnderground2");
-			textureSlots[3] = BackgroundTextureLoader.GetBackgroundSlot("Assets/Textures/Backgrounds/ExampleBiomeUnderground3");
+			textureSlots[0] = BackgroundTextureLoader.GetBackgroundSlot("ExampleMod/Assets/Textures/Backgrounds/ExampleBiomeUnderground0");
+			textureSlots[1] = BackgroundTextureLoader.GetBackgroundSlot("ExampleMod/Assets/Textures/Backgrounds/ExampleBiomeUnderground1");
+			textureSlots[2] = BackgroundTextureLoader.GetBackgroundSlot("ExampleMod/Assets/Textures/Backgrounds/ExampleBiomeUnderground2");
+			textureSlots[3] = BackgroundTextureLoader.GetBackgroundSlot("ExampleMod/Assets/Textures/Backgrounds/ExampleBiomeUnderground3");
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/BackgroundLoaders.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BackgroundLoaders.cs
@@ -167,7 +167,12 @@ namespace Terraria.ModLoader
 				return;
 			}
 
-			// TODO: Causes background to flicker during load because Main.bgAlpha2 is resized after surfaceBackgroundStyles is added to in AutoLoad.
+			//TODO: This suppresses an error instead of fixing it.
+			// Avoids background flicker during load because Main.bgAlphaFarBackLayer is resized after surfaceBackgroundStyles is added to in AutoLoad.
+			if (TotalCount != Main.bgAlphaFarBackLayer.Length) {
+				return;
+			}
+
 			foreach (var style in list) {
 				int slot = style.Slot;
 				float alpha = Main.bgAlphaFarBackLayer[slot];


### PR DESCRIPTION
### What is the bug?
...Loader.GetBackgroundSlot() does not auto-add the Mod.Name as compared to original Mod.GetBackgroundSlot().

Logging known issue via silently caught error from: "Main.bgAlphaFarBackLayer is resized after surfaceBackgroundStyles is added to in AutoLoad" in Loader.DrawFarTexture(). 

### How did you fix the bug?
Add ExampleMod\ to all ExampleMod calls;

Toss a quick Count != Array.Length to catch the condition.  

### Are there alternatives to your fix?
Former no;

Latter maybe? No obvious solution as it appears to be a race condition during mod loading, so moving it from logging silent to internal TODO instead of non-useful error in logs.
