### PR TITLE
Fix #1348 

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -8,6 +8,7 @@ using Terraria.GameContent.Biomes.CaveHouse;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader.Core;
+using Terraria.ModLoader.IO;
 using Terraria.ObjectData;
 
 namespace Terraria.ModLoader
@@ -919,7 +920,7 @@ namespace Terraria.ModLoader
 		}
 
 		public static bool CanGrowModCactus(int type) {
-			return cacti.ContainsKey(type);
+			return cacti.ContainsKey(type) || TileIO.Tiles.unloadedTypes.Contains((ushort)type);
 		}
 
 		public static Texture2D GetCactusTexture(int type) {


### PR DESCRIPTION
### What is the bug?
#1348 

### How did you fix the bug?
I added a check against TileIO.Tiles.UnloadedTypes in the CanGrowModCactus hook.

### Are there alternatives to your fix?
There are several, but this should be the least maintenance option.
Creating a new unloaded type could also be done, but takes more lines and seems unnecessary.
Could also check specific types, but than you have to grab those type values which again seems unnecessary
Could also add the tile to the cacti dictionary, but that creates can complicate things if later adding another unloaded type.