### PR TITLE
Made PrefixLoader.Roll public

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/PrefixLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PrefixLoader.cs
@@ -61,7 +61,7 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Performs a mod prefix roll. If the vanillaWeight wins the roll, then prefix is unchanged.
 		/// </summary>
-		internal static void Roll(Item item, ref int prefix, int vanillaWeight, params PrefixCategory[] categories) {
+		public static void Roll(Item item, ref int prefix, int vanillaWeight, params PrefixCategory[] categories) {
 			var wr = new WeightedRandom<byte>();
 
 			foreach (PrefixCategory category in categories) {


### PR DESCRIPTION
Change of PrefixLoader.Roll from internal to public to allow accurate recreation of base tml features without reflection if item.Prefix(-2) is in some way unusable for the situation