### PR TITLE
[1.4] Make some Player and Projectile methods public

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3762,6 +3762,15 @@
  						if (tile.halfBrick()) {
  							WorldGen.PoundTile(x, y);
  							if (Main.netMode == 1)
+@@ -31998,7 +_,7 @@
+ 			}
+ 		}
+ 
+-		private bool IsTargetTileInItemRange(Item sItem) {
++		public bool IsTargetTileInItemRange(Item sItem) {
+ 			if (position.X / 16f - (float)tileRangeX - (float)sItem.tileBoost <= (float)tileTargetX && (position.X + (float)width) / 16f + (float)tileRangeX + (float)sItem.tileBoost - 1f >= (float)tileTargetX && position.Y / 16f - (float)tileRangeY - (float)sItem.tileBoost <= (float)tileTargetY)
+ 				return (position.Y + (float)height) / 16f + (float)tileRangeY + (float)sItem.tileBoost - 2f >= (float)tileTargetY;
+ 
 @@ -32341,7 +_,8 @@
  				}
  
@@ -3857,6 +3866,15 @@
  
  				if (projToShoot == 76) {
  					projToShoot += Main.rand.Next(3);
+@@ -33969,7 +_,7 @@
+ 			return startPos;
+ 		}
+ 
+-		private int SpawnMinionOnCursor(IProjectileSource projectileSource, int ownerIndex, int minionProjectileId, int originalDamageNotScaledByMinionDamage, float KnockBack, Vector2 offsetFromCursor = default(Vector2), Vector2 velocityOnSpawn = default(Vector2)) {
++		public int SpawnMinionOnCursor(IProjectileSource projectileSource, int ownerIndex, int minionProjectileId, int originalDamageNotScaledByMinionDamage, float KnockBack, Vector2 offsetFromCursor = default(Vector2), Vector2 velocityOnSpawn = default(Vector2)) {
+ 			Vector2 pointPoisition = Main.MouseWorld;
+ 			pointPoisition += offsetFromCursor;
+ 			LimitPointToPlayerReachableArea(ref pointPoisition);
 @@ -34460,6 +_,10 @@
  		}
  

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -485,6 +485,15 @@
  				}
  			}
  
+@@ -14147,7 +_,7 @@
+ 			tileCollide = false;
+ 		}
+ 
+-		private void Resize(int newWidth, int newHeight) {
++		public void Resize(int newWidth, int newHeight) {
+ 			position = base.Center;
+ 			width = newWidth;
+ 			height = newHeight;
 @@ -14155,6 +_,10 @@
  		}
  
@@ -514,6 +523,24 @@
  								int num = damage;
  								position = base.Center;
  								int num2 = 0;
+@@ -27717,7 +_,7 @@
+ 			}
+ 		}
+ 
+-		private NPC FindTargetWithinRange(float maxRange) {
++		public NPC FindTargetWithinRange(float maxRange) {
+ 			NPC result = null;
+ 			float num = maxRange;
+ 			for (int i = 0; i < 200; i++) {
+@@ -28093,7 +_,7 @@
+ 			return result;
+ 		}
+ 
+-		private int FindTargetWithLineOfSight(float maxRange = 800f) {
++		public int FindTargetWithLineOfSight(float maxRange = 800f) {
+ 			float num = maxRange;
+ 			int result = -1;
+ 			for (int i = 0; i < 200; i++) {
 @@ -32271,6 +_,9 @@
  					if (num3 > (float)num9)
  						ai[0] = 1f;
@@ -643,7 +670,21 @@
  			active = false;
  		}
  
-@@ -51336,6 +_,9 @@
+@@ -51311,7 +_,7 @@
+ 			}
+ 		}
+ 
+-		private bool ShouldWallExplode(Vector2 compareSpot, int radius, int minI, int maxI, int minJ, int maxJ) {
++		public bool ShouldWallExplode(Vector2 compareSpot, int radius, int minI, int maxI, int minJ, int maxJ) {
+ 			bool result = false;
+ 			for (int i = minI; i <= maxI; i++) {
+ 				for (int j = minJ; j <= maxJ; j++) {
+@@ -51332,10 +_,13 @@
+ 			return Main.hslToRgb(0.66f + 0.33f * num, 0.7f, 0.6f) * 0.7f;
+ 		}
+ 
+-		private bool CanExplodeTile(int x, int y) {
++		public bool CanExplodeTile(int x, int y) {
  			if (Main.tileDungeon[Main.tile[x, y].type] || TileID.Sets.BasicChest[Main.tile[x, y].type])
  				return false;
  
@@ -653,6 +694,15 @@
  			switch (Main.tile[x, y].type) {
  				case 26:
  				case 88:
+@@ -51372,7 +_,7 @@
+ 			return true;
+ 		}
+ 
+-		private void ExplodeTiles(Vector2 compareSpot, int radius, int minI, int maxI, int minJ, int maxJ, bool wallSplode) {
++		public void ExplodeTiles(Vector2 compareSpot, int radius, int minI, int maxI, int minJ, int maxJ, bool wallSplode) {
+ 			AchievementsHelper.CurrentlyMining = true;
+ 			for (int i = minI; i <= maxI; i++) {
+ 				for (int j = minJ; j <= maxJ; j++) {
 @@ -51396,7 +_,7 @@
  
  					for (int k = i - 1; k <= i + 1; k++) {
@@ -662,6 +712,15 @@
  								WorldGen.KillWall(k, l);
  								if (Main.tile[k, l].wall == 0 && Main.netMode != 0)
  									NetMessage.SendData(17, -1, -1, null, 2, k, l);
+@@ -51409,7 +_,7 @@
+ 			AchievementsHelper.CurrentlyMining = false;
+ 		}
+ 
+-		private void ExplodeCrackedTiles(Vector2 compareSpot, int radius, int minI, int maxI, int minJ, int maxJ) {
++		public void ExplodeCrackedTiles(Vector2 compareSpot, int radius, int minI, int maxI, int minJ, int maxJ) {
+ 			AchievementsHelper.CurrentlyMining = true;
+ 			for (int i = minI; i <= maxI; i++) {
+ 				for (int j = minJ; j <= maxJ; j++) {
 @@ -51450,6 +_,10 @@
  		}
  


### PR DESCRIPTION
### What is the new feature?
Makes some private methods from the `Player` and `Projectile` classes public. These methods are very useful, if not entirely required, for implementing content similar to vanilla. The methods in question are:

* **Player**:
  * **bool IsTargetTileInItemRange(Item sItem)**: Returns whether the target tile (the one at `Player.tileTargetX`, `Player.tileTargetY`) is within the item's range, taking into account the player's `tileRangeX` and `tileRangeY`, which could have been modified by equipment or buffs, and the item's `tileBoost`. Useful when implementing items that do something to the target tile on use, while taking into account the item's range.
  * **int SpawnMinionOnCursor(IProjectileSource projectileSource, int ownerIndex, int minionProjectileId, int originalDamageNotScaledByMinionDamage, float KnockBack, Vector2 offsetFromCursor = default(Vector2), Vector2 velocityOnSpawn = default(Vector2))**: Spawns a projectile, with the given `minionProjectileId` as its type, at the cursor's position. The projectile will have its `originalDamage` field set to `originalDamageNotScaledByMinionDamage`, which should often be the item's `damage` field. Useful for spawning minions and turrets that have their damage scale correctly, as it is recalculated every tick depending on its `originalDamage` and the player's `minionDamage`. Returns the index of the projectile in `Main.projectile`.

* **Projectile**:
  * **void Resize(int newWidth, int newHeight)**: Simply resizes the projectile's hitbox without changing the position of its center. Useful for creating explosions, as these often damage a bigger area than the projectile's original hitbox.
  * **bool ShouldWallExplode(Vector2 compareSpot, int radius, int minI, int maxI, int minJ, int maxJ)**: Returns whether there is at least 1 missing wall within a given area. The area is delimited by the tile coordinates `minI` (minimum X), `maxI` (maximum X), `minJ` (minimum Y), `maxJ` (maximum Y), and the walls should also be within `radius` of `compareSpot` in world coordinates. Useful when creating explosions that should behave like vanilla ones on walls.
  * **bool CanExplodeTile(int x, int y)**: Returns whether a tile at the given `x` and `y` tile coordinates should destroyed by explosions, taking modded tiles into account. Useful when creating explosions that should behave like vanilla ones on tiles, while also keeping mod compatibility.
  * **void ExplodeTiles(Vector2 compareSpot, int radius, int minI, int maxI, int minJ, int maxJ, bool wallSplode)**: Tries to explode the tiles within a given area. The area is delimited similarly to the one in the `ShouldWallExplode` method, and the `wallSplode` field should be the return value of said method. The explosion takes into account the resistances to explosions of vanilla and modded tiles and walls.  Useful when creating explosions that should behave like vanilla ones, while also keeping mod compatibility.
  * **void ExplodeCrackedTiles(Vector2 compareSpot, int radius, int minI, int maxI, int minJ, int maxJ)**: Tries to explode cracked tiles (the ones found in the dungeon) within a given area, in a manner similar to the `ExplodeTiles` method. This method is only used by grenades in vanilla, but should be useful for moders who want to implement their own.
  * **NPC FindTargetWithinRange(float maxRange)**: Returns the closest chaseable `NPC` within the give `maxRange` that can be hit by the projectile, or null if no `NPC` is found. Useful for creating homing projectiles. 
  * **int FindTargetWithLineOfSight(float maxRange = 800f)**: Returns the index in `Main.npc` of the closest chaseable `NPC` within the give `maxRange` that is within line of sight of, and can be hit by, the projectile, or -1 if no `NPC` is found. Useful for creating homing projectiles that should care about obstacles.

### Why should this be part of tModLoader?
 * To eliminate boilerplate, as these methods would have to be reproduced almost identically on the contexts where they would otherwise be used.
 * To maintain mod compatibility, as some of these methods call hooks within tModLoader.
