### PR TITLE
Fixed duplication menu scrolling

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1150,13 +1150,12 @@
  			if (!dedServ && (double)screenPosition.Y < worldSurface * 16.0 + 16.0 && netMode != 2) {
  				Star.UpdateStars();
  				Cloud.UpdateClouds();
-@@ -12835,8 +_,14 @@
- 			if (InGameUI != null)
+@@ -12836,7 +_,13 @@
  				InGameUI.Update(gameTime);
  
+ 			CreativeMenu.Update(gameTime);
 +			SystemHooks.UpdateUI(gameTime);
 +			PlayerInput.ScrollWheelDeltaForUI = 0; //TODO: Should this be before PlayerInput.ResetInputsOnActiveStateChange()?
- 			CreativeMenu.Update(gameTime);
 +
 +			BossBarLoader.HandleStyle(); //Has to be outside of the !gameMenu check because it deals with switching and saving the boss style in menus, including the main menu
 +


### PR DESCRIPTION
### What is the bug?
Journey mode duplication menu does not respond to mouse scroll (fixes #1475).
### How did you fix the bug?
I moved the `CreativeMenu.Update` call above where `PlayerInput.ScrollWheelDeltaForUI` is set to 0.
### Are there alternatives to your fix?
None that I am aware of. 
<!--
We recommend using one of our pull request templates if you want your PR taken seriously.

You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.
If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:

Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->
