### PR TITLE
AlphaPrep: Disable ModBrowser, cleanup InstallVerifier check, add betaWelcomeMessage

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -6,7 +6,7 @@
 		"MenuMods": "Mods",
 		"MenuModSources": "Mod Sources",
 		"MenuEnableDeveloperMode": "Enable Developer Mode",
-		"WelcomeMessageBeta": "Welcome to tModLoader 1.4 Alpha.\n\nYou have successfully installed an unstable tModLoader that may contain game-breaking bugs. \n\nJoin the tModLoader Discord to learn more about which development oriented mods/tools are available for 1.4 tModLoader.",
+		"WelcomeMessageBeta": "Welcome to tModLoader 1.4 Alpha.\n\nYou have successfully installed an unstable tModLoader that may contain game-breaking bugs. \n\nJoin the tModLoader Discord to learn more about which testing mods and/or tools are available for 1.4 tModLoader as part of its 1.4 overhaul.",
 		"FirstLaunchWelcomeMessage": "Welcome to tModLoader.\n\nYou have successfully installed tModLoader. Use the Mod Browser menu to find mods you wish to download. Use the Mods menu to change which mods are currently active. After changing mods, make sure you click the Reload Mods button to reload them.",
 		"tModLoaderSettings": "tModLoader Settings",
 		"ModMenuSwap": "Switch Menu Theme",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -6,6 +6,7 @@
 		"MenuMods": "Mods",
 		"MenuModSources": "Mod Sources",
 		"MenuEnableDeveloperMode": "Enable Developer Mode",
+		"WelcomeMessageBeta": "Welcome to tModLoader 1.4 Alpha.\n\nYou have successfully installed an unstable tModLoader that may contain game-breaking bugs. \n\nJoin the tModLoader Discord to learn more about which development oriented mods/tools are available for 1.4 tModLoader.",
 		"FirstLaunchWelcomeMessage": "Welcome to tModLoader.\n\nYou have successfully installed tModLoader. Use the Mod Browser menu to find mods you wish to download. Use the Mods menu to change which mods are currently active. After changing mods, make sure you click the Reload Mods button to reload them.",
 		"tModLoaderSettings": "tModLoader Settings",
 		"ModMenuSwap": "Switch Menu Theme",

--- a/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
@@ -93,20 +93,18 @@ namespace Terraria.ModLoader.Engine
 			}
 
 			// If its clearly a steam install/launch, use Steam API.
-			if (Directory.GetCurrentDirectory().Contains("steamapps") || Program.LaunchParameters.ContainsKey("-steam")) {
+			if (Directory.GetCurrentDirectory().Contains("steamapps") || Program.LaunchParameters.ContainsKey("-steam"))
 				return CheckSteam();
-			}
 
 			Logging.tML.Info("Checking if GoG or Steam...");
 
-			// If can't find a GoG folder, than it is a Steam launch
+			// If can't find a GoG folder, than assume it must be a Steam launch
 			if (!ObtainVanillaExePath(out var steamApiPath, out var exePath))
 				return CheckSteam();
 
-			// Handle the nonsense that is OSX installs. We want Terraria.app/Contents/MacOS/osx as the directory
-			if (Platform.IsOSX) {
+			// Handle uniqueness of OSX installs. We want Terraria.app/Contents/MacOS/osx as the directory for steam_api file
+			if (Platform.IsOSX)
 				steamApiPath = Path.Combine(Directory.GetParent(steamApiPath).FullName, "MacOS", "osx");
-			}
 
 			// If the steam_api file is present in the vanilla folder, than it is a Steam launch
 			if (File.Exists(Path.Combine(steamApiPath, vanillaSteamAPI)))
@@ -130,40 +128,35 @@ namespace Terraria.ModLoader.Engine
 			vanillaPath = Path.Combine(vanillaPath, "Terraria");
 			if (Platform.IsOSX) {
 				// GOG installs to /Applications/Terraria.app, Steam installs to /Applications/Terraria/Terraria.app
-				// working directory is /Applications/tModLoader/tModLoader.app/Contents/MacOS/ for steam manual installs
-				// working directory is /Applications/tModLoader.app/Contents/MacOS/ for GOG installs
 				// Vanilla .exe files are in /Contents/Resources/, not /Contents/MacOS/
-				if (Directory.Exists("../../../../Terraria/Terraria.app/")) {
-					vanillaPath = "../../../../Terraria/Terraria.app/Contents/Resources/";
-					Logging.tML.Info($"Mac installation location found at {vanillaPath}, assuming Steam manual install");
+				if (Directory.Exists("../Terraria/Terraria.app/")) {
+					vanillaPath = "../Terraria/Terraria.app/Contents/Resources/";
+					Logging.tML.Info($"Mac installation location found at {vanillaPath}, assuming Steam install");
 				}
-				else if (Directory.Exists("../../../Terraria.app/")) {
-					vanillaPath = "../../../Terraria.app/Contents/Resources/";
-					Logging.tML.Info($"Mac installation location found at {vanillaPath}, assuming GOG manual install");
-				}
-				else {
-					Logging.tML.Info($"Mac installation location not found.");
+				else if (Directory.Exists("../Terraria.app/")) {
+					vanillaPath = "../Terraria.app/Contents/Resources/";
+					Logging.tML.Info($"Mac installation location found at {vanillaPath}, assuming GOG install");
 				}
 			}
 
 			if (CheckForExe(vanillaPath, out exePath))
 				return true;
 
+			Logging.tML.Info($"No nearby installation location found. Presuming Steam");
 			return false;
 		} 
 
 		private static bool CheckForExe(string vanillaPath, out string exePath) {
-			exePath = Path.Combine(vanillaPath, DefaultExe);
+			exePath = Path.Combine(vanillaPath, CheckExe);
 			if (File.Exists(exePath))
 				return true;
 
-			exePath = Path.Combine(vanillaPath, CheckExe);
+			exePath = Path.Combine(vanillaPath, DefaultExe);
 			if (File.Exists(exePath))
 				return true;
 
 			return false;
 		}
-
 
 		// Check if Steam installation is correct
 		private static bool CheckSteam() {

--- a/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
@@ -15,6 +15,8 @@ namespace Terraria.ModLoader.Engine
 	{
 		public const string TmlContentDirectory = "Content";
 		public const string SteamAppIDPath = "steam_appid.txt";
+		private const string DefaultExe = "Terraria.exe";
+		private static string CheckExe = $"Terraria_1.4.2.3.exe"; // This should match the hashes. {Main.versionNumber}
 		public const bool RequireContentDirectory = false; // Not currently needed, due to tML matching vanilla's version.
 
 		private static bool? isValid;
@@ -23,6 +25,7 @@ namespace Terraria.ModLoader.Engine
 		public static bool IsSteam = false;
 
 		private static string steamAPIPath;
+		private static string vanillaSteamAPI;
 		private static byte[] steamAPIHash;
 		private static byte[] gogHash;
 		private static byte[] steamHash;
@@ -38,18 +41,21 @@ namespace Terraria.ModLoader.Engine
 					steamAPIHash = ToByteArray("8AFDE2D19C89D0BF1A9F6EC475AA0EBB");
 				}
 
+				vanillaSteamAPI = "steam_api.dll";
 				gogHash = ToByteArray("ff61b96a07894a9e65f880fb9608fb37"); // Don't forget to update CheckExe in CheckGoG
 				steamHash = ToByteArray("4fd8072ca82ded3d9da1be577a478788");
 			}
 			else if (Platform.IsOSX) {
 				steamAPIPath = "Libraries/Native/OSX/libsteam_api.dylib";
 				steamAPIHash = ToByteArray("FB32124B2E07ED2AAE54FE8823D069B3");
+				vanillaSteamAPI = "libsteam_api.dylib";
 				gogHash = ToByteArray("181c586d0fe64156adb0ecd4b9fabf9d");
 				steamHash = ToByteArray("12c8d2ac5af6c8505bd1a9339dc75231");
 			}
 			else if (Platform.IsLinux) {
 				steamAPIPath = "Libraries/Native/Linux/libsteam_api.so";
 				steamAPIHash = ToByteArray("8915306857EEF2A516956A2398845EA2");
+				vanillaSteamAPI = "libsteam_api.so";
 				gogHash = ToByteArray("4a051352dd6ecc323c5a0a15e5b598fb");
 				steamHash = ToByteArray("debcc318ca4e14295e3ac22e380e289b");
 			}
@@ -86,15 +92,74 @@ namespace Terraria.ModLoader.Engine
 				return false;
 			}
 
-			// Check if we are within a steamapps subfolder OR are trying to force run as steam install; if not, return GoG.
-			if (!(Directory.GetCurrentDirectory().Contains("steamapps") || Program.LaunchParameters.ContainsKey("-steam"))) {
-				return CheckGoG();
+			// If its clearly a steam install/launch, use Steam API.
+			if (Directory.GetCurrentDirectory().Contains("steamapps") || Program.LaunchParameters.ContainsKey("-steam")) {
+				return CheckSteam();
 			}
 
-			return CheckSteam();
+			Logging.tML.Info("Checking if GoG or Steam...");
+
+			// Find the vanilla Exe and path
+			var pathExe = ObtainVanillaExePath(out var vanillaPath);
+
+			// If can't find a GoG folder, or the steam_api file is present in the vanilla folder, than it is a Steam launch
+			if (String.IsNullOrEmpty(pathExe) || File.Exists(Path.Combine(vanillaPath, vanillaSteamAPI)))
+				return CheckSteam();
+
+			return CheckGoG(pathExe);
 		}
 
-		// Check if steam installation is correct
+		private static string ObtainVanillaExePath(out string vanillaPath) {
+			// Check if in the same folder somehow.
+			vanillaPath = "";
+
+			if (File.Exists(CheckExe))
+				return CheckExe;
+			else if (File.Exists(DefaultExe))
+				return DefaultExe;
+
+			// If .exe not present, check Terraria directory (Side-by-Side Manual Install)
+			vanillaPath = Path.Combine("..", "Terraria");
+			if (Platform.IsOSX) {
+				// GOG installs to /Applications/Terraria.app, Steam installs to /Applications/Terraria/Terraria.app
+				// working directory is /Applications/tModLoader/tModLoader.app/Contents/MacOS/ for steam manual installs
+				// working directory is /Applications/tModLoader.app/Contents/MacOS/ for GOG installs
+				// Vanilla .exe files are in /Contents/Resources/, not /Contents/MacOS/
+				if (Directory.Exists("../../../../Terraria/Terraria.app/")) {
+					vanillaPath = "../../../../Terraria/Terraria.app/Contents/Resources/";
+					Logging.tML.Info($"Mac installation location found at {vanillaPath}, assuming Steam manual install");
+				}
+				else if (Directory.Exists("../../../Terraria.app/")) {
+					vanillaPath = "../../../Terraria.app/Contents/Resources/";
+					Logging.tML.Info($"Mac installation location found at {vanillaPath}, assuming GOG manual install");
+				}
+				else {
+					Logging.tML.Info($"Mac installation location not found.");
+				}
+			}
+
+			string defaultPath = Path.Combine(vanillaPath, DefaultExe);
+			string checkPath = Path.Combine(vanillaPath, CheckExe);
+			if (File.Exists(checkPath))
+				return checkPath;
+			else if (File.Exists(defaultPath))
+				return defaultPath;
+
+			// If .exe not present check parent directory (Nested Manual Install)
+			vanillaPath = "..";
+
+			defaultPath = Path.Combine(vanillaPath, DefaultExe);
+			checkPath = Path.Combine(vanillaPath, CheckExe);
+			if (File.Exists(checkPath))
+				return checkPath;
+			else if (File.Exists(defaultPath))
+				return defaultPath;
+
+			return null;
+		} 
+
+
+		// Check if Steam installation is correct
 		private static bool CheckSteam() {
 			Logging.tML.Info("Checking Steam installation...");
 			IsSteam = true;
@@ -122,68 +187,31 @@ namespace Terraria.ModLoader.Engine
 			return true;
 		}
 
-		// Check if GOG install or manual install is correct
-		private static bool CheckGoG() {
-			Logging.tML.Info("Checking GOG or manual installation...");
+		// Check if GOG install is correct
+		private static bool CheckGoG(string vanillaExePath) {
+			Logging.tML.Info("Checking GOG installation...");
 			IsGoG = true;
 
-			const string DefaultExe = "Terraria.exe";
-			string CheckExe = $"Terraria_1.4.2.1.exe"; // This should match the hashes. {Main.versionNumber}
-			string vanillaPath = File.Exists(CheckExe) ? CheckExe : DefaultExe;
-
-			// If .exe not present, check Terraria directory (Side-by-Side Manual Install)
-			if (!File.Exists(vanillaPath)) {
-				vanillaPath = Path.Combine("..", "Terraria");
-
-				if (Platform.IsOSX) {
-					// GOG installs to /Applications/Terraria.app, Steam installs to /Applications/Terraria/Terraria.app
-					// working directory is /Applications/tModLoader/tModLoader.app/Contents/MacOS/ for steam manual installs
-					// working directory is /Applications/tModLoader.app/Contents/MacOS/ for GOG installs
-					// Vanilla .exe files are in /Contents/Resources/, not /Contents/MacOS/
-					if (Directory.Exists("../../../../Terraria/Terraria.app/")) {
-						vanillaPath = "../../../../Terraria/Terraria.app/Contents/Resources/";
-						Logging.tML.Info($"Mac installation location found at {vanillaPath}, assuming Steam manual install");
-					}
-					else if (Directory.Exists("../../../Terraria.app/")) {
-						vanillaPath = "../../../Terraria.app/Contents/Resources/";
-						Logging.tML.Info($"Mac installation location found at {vanillaPath}, assuming GOG manual install");
-					}
-					else {
-						Logging.tML.Info($"Mac installation location not found.");
-					}
-				}
-
-				string defaultExe = Path.Combine(vanillaPath, DefaultExe);
-				string checkExe = Path.Combine(vanillaPath, CheckExe);
-				vanillaPath = File.Exists(checkExe) ? checkExe : defaultExe;
-			}
-			// If .exe not present check parent directory (Nested Manual Install)
-			if (!File.Exists(vanillaPath)) {
-				string defaultExe = Path.Combine("..", DefaultExe);
-				string checkExe = Path.Combine("..", CheckExe);
-				vanillaPath = File.Exists(checkExe) ? checkExe : defaultExe;
-			}
-
-			if (!File.Exists(vanillaPath)) {
+			if (!File.Exists(vanillaExePath)) {
 				if(Main.dedServ)
 					return false;
 
-				Exit(Language.GetTextValue("tModLoader.VanillaGOGNotFound", vanillaPath, CheckExe), string.Empty);
+				Exit(Language.GetTextValue("tModLoader.VanillaGOGNotFound", vanillaExePath, CheckExe), string.Empty);
 				return false;
 			}
 
-			if (!HashMatchesFile(vanillaPath, gogHash) && !HashMatchesFile(vanillaPath, steamHash)) {
-				Exit(Language.GetTextValue("tModLoader.GOGHashMismatch", vanillaPath), string.Empty);
+			if (!HashMatchesFile(vanillaExePath, gogHash) && !HashMatchesFile(vanillaExePath, steamHash)) {
+				Exit(Language.GetTextValue("tModLoader.GOGHashMismatch", vanillaExePath), string.Empty);
 				return false;
 			}
 
-			if (Path.GetFileName(vanillaPath) != CheckExe) {
-				string pathToCheckExe = Path.Combine(Path.GetDirectoryName(vanillaPath), CheckExe);
-				Logging.tML.Info($"Backing up {Path.GetFileName(vanillaPath)} to {CheckExe}");
-				File.Copy(vanillaPath, pathToCheckExe);
+			if (Path.GetFileName(vanillaExePath) != CheckExe) {
+				string pathToCheckExe = Path.Combine(Path.GetDirectoryName(vanillaExePath), CheckExe);
+				Logging.tML.Info($"Backing up {Path.GetFileName(vanillaExePath)} to {CheckExe}");
+				File.Copy(vanillaExePath, pathToCheckExe);
 			}
 
-			Logging.tML.Info("GOG or manual installation OK.");
+			Logging.tML.Info("GOG installation OK.");
 			return true;
 		}
 	}

--- a/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
@@ -109,6 +109,7 @@ namespace Terraria.ModLoader.Engine
 			}
 
 			// If the steam_api file is present in the vanilla folder, than it is a Steam launch
+			if (File.Exists(Path.Combine(steamApiPath, vanillaSteamAPI)))
 				return CheckSteam();
 
 			return CheckGoG(exePath);

--- a/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
@@ -86,11 +86,12 @@ namespace Terraria.ModLoader.Engine
 				return false;
 			}
 
-			// Whether the steam_appid.txt file exists, indicating we'd have to check steam installation
-			if (File.Exists(SteamAppIDPath))
-				return CheckSteam();
+			// Check if we are within a steamapps subfolder OR are trying to force run as steam install; if not, return GoG.
+			if (!(Directory.GetCurrentDirectory().Contains("steamapps") || Program.LaunchParameters.ContainsKey("-steam"))) {
+				return CheckGoG();
+			}
 
-			return CheckGoG();
+			return CheckSteam();
 		}
 
 		// Check if steam installation is correct

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -78,13 +78,14 @@ namespace Terraria.ModLoader.UI
 				buttonIndex++;
 				numButtons++;
 			}
-			buttonNames[buttonIndex] = Language.GetTextValue("tModLoader.MenuModBrowser");
+			// Disable Mod Browser on 1.4 branch, until such time as it is safe to implement.
+			/*buttonNames[buttonIndex] = Language.GetTextValue("tModLoader.MenuModBrowser");
 			if (selectedMenu == buttonIndex) {
 				SoundEngine.PlaySound(10, -1, -1, 1);
 				Main.menuMode = modBrowserID;
 			}
 			buttonIndex++;
-			numButtons++;
+			numButtons++;*/
 			offY = 220;
 			for (int k = 0; k < numButtons; k++) {
 				buttonScales[k] = 0.82f;
@@ -121,7 +122,9 @@ namespace Terraria.ModLoader.UI
 			if (Main.menuMode == loadModsID) {
 				if (ModLoader.ShowFirstLaunchWelcomeMessage) {
 					ModLoader.ShowFirstLaunchWelcomeMessage = false;
-					infoMessage.Show(Language.GetTextValue("tModLoader.FirstLaunchWelcomeMessage"), Main.menuMode);
+					// Temporary display for the alpha/beta version.
+					infoMessage.Show(Language.GetTextValue("tModLoader.WelcomeMessageBeta"), Main.menuMode);
+					//infoMessage.Show(Language.GetTextValue("tModLoader.FirstLaunchWelcomeMessage"), Main.menuMode);
 				}
 				//else if (ModLoader.ShowWhatsNew) {
 				//	// TODO: possibly pull from github

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -116,21 +116,29 @@ namespace Terraria.ModLoader.UI
 		//	virticalSpacing[numButtons - 1] = 8;
 		//}
 
+		private static bool betaWelcomed = false;
+
 		//add to end of if else chain of Main.menuMode in Terraria.Main.DrawMenu
 		//Interface.ModLoaderMenus(this, this.selectedMenu, array9, array7, array4, ref num2, ref num4, ref num5, ref flag5);
 		internal static void ModLoaderMenus(Main main, int selectedMenu, string[] buttonNames, float[] buttonScales, int[] buttonVerticalSpacing, ref int offY, ref int spacing, ref int numButtons, ref bool backButtonDown) {
 			if (Main.menuMode == loadModsID) {
 				if (ModLoader.ShowFirstLaunchWelcomeMessage) {
 					ModLoader.ShowFirstLaunchWelcomeMessage = false;
-					// Temporary display for the alpha/beta version.
-					infoMessage.Show(Language.GetTextValue("tModLoader.WelcomeMessageBeta"), Main.menuMode);
-					//infoMessage.Show(Language.GetTextValue("tModLoader.FirstLaunchWelcomeMessage"), Main.menuMode);
+					infoMessage.Show(Language.GetTextValue("tModLoader.FirstLaunchWelcomeMessage"), Main.menuMode);
 				}
 				//else if (ModLoader.ShowWhatsNew) {
 				//	// TODO: possibly pull from github
 				//	ModLoader.ShowWhatsNew = false;
 				//	infoMessage.Show(Language.GetTextValue("tModLoader.WhatsNewMessage"), Main.menuMode);
 				//}
+
+#if RELEASE
+				// Temporary display for the alpha/beta version.
+				if (!betaWelcomed) {
+					betaWelcomed = true;
+					infoMessage.Show(Language.GetTextValue("tModLoader.WelcomeMessageBeta"), Main.menuMode);
+				}
+#endif
 			}
 			if (Main.menuMode == modsMenuID) {
 				Main.MenuUI.SetState(modsMenu);

--- a/patches/tModLoader/Terraria/Social/SocialAPI.cs.patch
+++ b/patches/tModLoader/Terraria/Social/SocialAPI.cs.patch
@@ -6,7 +6,7 @@
  using Terraria.Social.Base;
  using Terraria.Social.Steam;
  using Terraria.Social.WeGame;
-@@ -20,16 +_,20 @@
+@@ -20,16 +_,21 @@
  		public static SocialMode Mode => _mode;
  
  		public static void Initialize(SocialMode? mode = null) {
@@ -15,11 +15,12 @@
  				mode = SocialMode.None;
  				if(!Main.dedServ)
 +#if DEBUG
-+				if (!Program.LaunchParameters.ContainsKey("-nosteam"))
++					if (!Program.LaunchParameters.ContainsKey("-nosteam"))
 +#endif
-+				if (InstallVerifier.IsValid && InstallVerifier.IsSteam)
++						if (InstallVerifier.IsValid && InstallVerifier.IsSteam)
 -				mode = SocialMode.Steam;
-+					mode = SocialMode.Steam;
++							mode = SocialMode.Steam;
++
  				if (Main.dedServ && Program.LaunchParameters.ContainsKey("-steam"))
  					mode = SocialMode.Steam;
  			}


### PR DESCRIPTION
### What is the change?
In preparation for moving from Indev to Alpha, this PR addresses a handful of small ToDos.

1) Disables Mod Browser button - Mod Browser as is, is 1.3. Steam Workshop PRs will restore this overtime. As well, its terribly slow due to #1328 
2) Cleanups InstallVerifier check to not require deleting steamapp_id.txt. This file is needed for GoG's steam workshop; also was unnecessary extra install step when better programming exists.
3) Adds a betaWelcomeMessage to clearly denote this is the beta version. **Only appears every run for release builds**

