### PR TITLE
[1.4] Fix rename character label flickering

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UICharacterListItem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UICharacterListItem.cs.patch
@@ -31,7 +31,7 @@
  			Height.Set(96f, 0f);
  			Width.Set(0f, 1f);
  			SetPadding(6f);
-@@ -101,15 +_,82 @@
+@@ -101,6 +_,73 @@
  			_deleteButton = uIImageButton5;
  			Append(uIImageButton5);
  			num += 4f;
@@ -104,10 +104,8 @@
 +			//}
  			_buttonLabel = new UIText("");
  			_buttonLabel.VAlign = 1f;
--			_buttonLabel.Left.Set(num, 0f);
-+			_buttonLabel.Left.Set(buttonLabelLeft, 0f);
- 			_buttonLabel.Top.Set(-3f, 0f);
- 			Append(_buttonLabel);
+ 			_buttonLabel.Left.Set(num, 0f);
+@@ -109,7 +_,7 @@
  			_deleteButtonLabel = new UIText("");
  			_deleteButtonLabel.VAlign = 1f;
  			_deleteButtonLabel.HAlign = 1f;


### PR DESCRIPTION
### What is the bug?
Bug description is found in #1489. 
The bug is caused by the UIText object being positioned over the `Rename` button causing the OnMouseOver event to constantly fire causing the flickering text.

### How did you fix the bug?
Fixed this by assigning the UITexts left position to use the `num` variable just like in `UIWorldListItem.cs`. This causes the UIText button to be positioned off the of the button preventing the flicker.

### Are there alternatives to your fix?
Initially, I was going to use the position of the `Rename` button to determine the placement of the `_ButtonLabel` however after cross comparing code to `UIWorldListItem.cs` it seems using the already existent `num` variable that is used is most likely the best practice.

### Note
This is my first pull request and I'm unsure if the patch is correct. I applied the patch using the tool and all seemed to be fine but feel free to let me know 🙂 