### PR TITLE
[1.4] Update Mod Config buttons to refresh UI when pressed

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
@@ -283,6 +283,7 @@ namespace Terraria.ModLoader.Config.UI
 			//else
 			//{
 			DoMenuModeState();
+			OnActivate();
 			//}
 		}
 
@@ -290,6 +291,7 @@ namespace Terraria.ModLoader.Config.UI
 			SoundEngine.PlaySound(SoundID.MenuOpen);
 			pendingRevertDefaults = true;
 			DoMenuModeState();
+			OnActivate();
 		}
 
 		private void RevertConfig(UIMouseEvent evt, UIElement listeningElement) {
@@ -299,6 +301,7 @@ namespace Terraria.ModLoader.Config.UI
 
 		private void DiscardChanges() {
 			DoMenuModeState();
+			OnActivate();
 		}
 
 		bool pendingChanges;


### PR DESCRIPTION
### What is the bug?
Issue #1532 | Issue is caused by the buttons not getting removed from the `uIElement` collection when buttons are pressed.

### How did you fix the bug?
Made changes for buttons related functions to call `onActivate` - This fixes the issue listed as well as updates the UI with the default / original values when `RestoreDefaults` and `RevertConfig` are called respectively.

### Are there alternatives to your fix?
Two alternatives I can think of are:
1. Instead of redrawing the UI, you instead just manually remove the elements from the UI when the buttons are pressed. i.e. `uIElement.RemoveChild(saveConfigButton)`. This seems like a more roundabout fix as opposed to refreshing the UI itself.
2. Create a `UpdateUI` function that will essentially perform the same actions as `onActivate` - I was not opposed to this however, I felt as though it was unnecessary code duplication when it seems `onActivate` does what is needed perfectly. If it is felt a `UpdateUI` or similar function is necessary, it can be done instead! 🙂 