### PR TITLE
Fix Golden Slime hit effect on all modded NPCs

### DIFF
--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -746,6 +746,15 @@
  			if (!active)
  				return;
  
+@@ -63461,7 +_,7 @@
+ 				}
+ 			}
+ 
+-			if (type >= 667) {
++			if (type == 667) {
+ 				int num23 = 7;
+ 				float num24 = 1.1f;
+ 				int num25 = 10;
 @@ -70233,6 +_,8 @@
  			return false;
  		}


### PR DESCRIPTION
There's a type check in `VanillaHitEffect` that erroneously checks for 667 and above, causing the Golden Slime's fake coin hit effect to be present on all modded NPCs. This simple PR fixes this.