### PR TITLE
De-hardcode ProjectReferences Setting Library Dir

### DIFF
--- a/ExampleMod/Common/ExamplePlayerDrawLayer.cs
+++ b/ExampleMod/Common/ExamplePlayerDrawLayer.cs
@@ -34,7 +34,7 @@ namespace ExampleMod.Common
 			//The following code draws ExampleItem's texture behind the player's head.
 
 			if (exampleItemTexture == null) {
-				exampleItemTexture = ModContent.GetTexture("ExampleMod/Content/Items/ExampleItem");
+				exampleItemTexture = ModContent.Request<Texture2D>("ExampleMod/Content/Items/ExampleItem");
 			}
 
 			var position = drawInfo.Center + new Vector2(0f, -20f) - Main.screenPosition;

--- a/ExampleMod/Content/ExampleModMenu.cs
+++ b/ExampleMod/Content/ExampleModMenu.cs
@@ -14,9 +14,9 @@ namespace ExampleMod.Content
 
 		public override Asset<Texture2D> Logo => base.Logo;
 
-		public override Asset<Texture2D> SunTexture => ModContent.GetTexture($"{menuAssetPath}/ExampleSun");
+		public override Asset<Texture2D> SunTexture => ModContent.Request<Texture2D>($"{menuAssetPath}/ExampleSun");
 
-		public override Asset<Texture2D> MoonTexture => ModContent.GetTexture($"{menuAssetPath}/ExampliumMoon");
+		public override Asset<Texture2D> MoonTexture => ModContent.Request<Texture2D>($"{menuAssetPath}/ExampliumMoon");
 
 		/*public override int Music => Mod.GetSoundSlot(SoundType.Music, ""); TODO: Reimplement music loading */
 

--- a/ExampleMod/Content/Items/ExampleDye.cs
+++ b/ExampleMod/Content/Items/ExampleDye.cs
@@ -15,7 +15,7 @@ namespace ExampleMod.Content.Items
 				//The following code creates an effect (shader) reference and associates it with this item's type Id.
 				GameShaders.Armor.BindShader(
 					Item.type,
-					new ArmorShaderData(new Ref<Effect>(Mod.GetEffect("Assets/Effects/ExampleEffect").Value), "ExampleDyePass") //Be sure to update the effect path and pass name here.
+					new ArmorShaderData(new Ref<Effect>(Mod.Assets.Request<Effect>("Assets/Effects/ExampleEffect").Value), "ExampleDyePass") //Be sure to update the effect path and pass name here.
 				);
 			}
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 3;

--- a/ExampleMod/Content/Items/Tools/ExampleHook.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleHook.cs
@@ -37,7 +37,7 @@ namespace ExampleMod.Content.Items.Tools
 
 		public override void Load() { //This is called once on mod (re)load when this piece of content is being loaded.
 			// This is the path to the texture that we'll use for the hook's chain. Make sure to update it.
-			chainTexture = ModContent.GetTexture("ExampleMod/Content/Items/Tools/ExampleHookChain");
+			chainTexture = ModContent.Request<Texture2D>("ExampleMod/Content/Items/Tools/ExampleHookChain");
 		}
 
 		public override void Unload() { //This is called once on mod reload when this piece of content is being unloaded.

--- a/ExampleMod/Content/Mounts/ExampleMount.cs
+++ b/ExampleMod/Content/Mounts/ExampleMount.cs
@@ -129,7 +129,7 @@ namespace ExampleMod.Content.Mounts
 				// We draw some extra balloons before _Back texture
 				var balloons = (CarSpecificData)drawPlayer.mount._mountSpecificData;
 				int timer = DateTime.Now.Millisecond % 800 / 200;
-				Texture2D balloonTexture = Mod.GetTexture("Content/Items/Armor/SimpleAccessory_Balloon").Value;
+				Texture2D balloonTexture = Mod.Assets.Request<Texture2D>("Content/Items/Armor/SimpleAccessory_Balloon").Value;
 
 				for (int i = 0; i < balloons.count; i++) {
 					var position = drawPosition + new Vector2((-36 + CarSpecificData.offsets[i]) * drawPlayer.direction, 14);

--- a/ExampleMod/Content/Projectiles/ExampleAdvancedAnimatedProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleAdvancedAnimatedProjectile.cs
@@ -105,7 +105,7 @@ namespace ExampleMod.Content.Projectiles
 				spriteEffects = SpriteEffects.FlipHorizontally;
 
 			// Getting texture of projectile
-			Texture2D texture = (Texture2D)ModContent.GetTexture(Texture);
+			Texture2D texture = (Texture2D)ModContent.Request<Texture2D>(Texture);
 
 			// Calculating frameHeight and current Y pos dependence of frame
 			// If texture without animation frameHeight = texture.Height is always and startY is always 0

--- a/ExampleMod/Content/Tiles/ExampleAnimatedGlowmaskTile.cs
+++ b/ExampleMod/Content/Tiles/ExampleAnimatedGlowmaskTile.cs
@@ -50,8 +50,8 @@ namespace ExampleMod.Content.Tiles
 
 		public override bool PreDraw(int i, int j, SpriteBatch spriteBatch) {
 			Tile tile = Main.tile[i, j];
-			Texture2D texture = ModContent.GetTexture("ExampleMod/Content/Tiles/ExampleAnimatedGlowmaskTile").Value;
-			Texture2D glowTexture = ModContent.GetTexture("ExampleMod/Content/Tiles/ExampleAnimatedGlowmaskTile_Glow").Value;
+			Texture2D texture = ModContent.Request<Texture2D>("ExampleMod/Content/Tiles/ExampleAnimatedGlowmaskTile").Value;
+			Texture2D glowTexture = ModContent.Request<Texture2D>("ExampleMod/Content/Tiles/ExampleAnimatedGlowmaskTile_Glow").Value;
 
 			// If you are using ModTile.SpecialDraw or PostDraw or PreDraw, use this snippet and add zero to all calls to spriteBatch.Draw
 			// The reason for this is to accommodate the shift in drawing coordinates that occurs when using the different Lighting mode

--- a/ExampleMod/Content/Tiles/ExampleAnimatedTile.cs
+++ b/ExampleMod/Content/Tiles/ExampleAnimatedTile.cs
@@ -95,7 +95,7 @@ namespace ExampleMod.Content.Tiles
 
 
 			Tile tile = Main.tile[i, j];
-			Texture2D texture = ModContent.GetTexture("ExampleMod/Content/Tiles/ExampleAnimatedTileTile").Value;
+			Texture2D texture = ModContent.Request<Texture2D>("ExampleMod/Content/Tiles/ExampleAnimatedTileTile").Value;
 
 			// If you are using ModTile.SpecialDraw or PostDraw or PreDraw, use this snippet and add zero to all calls to spriteBatch.Draw
 			// The reason for this is to accommodate the shift in drawing coordinates that occurs when using the different Lighting mode

--- a/ExampleMod/Content/Tiles/ExampleLamp.cs
+++ b/ExampleMod/Content/Tiles/ExampleLamp.cs
@@ -38,7 +38,7 @@ namespace ExampleMod.Content.Tiles
 
 			// Assets
 			if (!Main.dedServ) {
-				flameTexture = ModContent.GetTexture("ExampleMod/Content/Tiles/ExampleLamp_Flame"); // We could also reuse Main.FlameTexture[] textures, but using our own texture is nice.
+				flameTexture = ModContent.Request<Texture2D>("ExampleMod/Content/Tiles/ExampleLamp_Flame"); // We could also reuse Main.FlameTexture[] textures, but using our own texture is nice.
 			}
 		}
 

--- a/ExampleMod/Content/Tiles/ExampleTorch.cs
+++ b/ExampleMod/Content/Tiles/ExampleTorch.cs
@@ -1,3 +1,4 @@
+using ExampleMod.Content.Biomes;
 using ExampleMod.Content.Dusts;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -58,7 +59,7 @@ namespace ExampleMod.Content.Tiles
 
 			// Assets
 			if (!Main.dedServ) {
-				flameTexture = ModContent.GetTexture("ExampleMod/Content/Tiles/ExampleTorch_Flame");
+				flameTexture = ModContent.Request<Texture2D>("ExampleMod/Content/Tiles/ExampleTorch_Flame");
 			}
 		}
 
@@ -75,9 +76,8 @@ namespace ExampleMod.Content.Tiles
 
 			// The influence positive torch luck can have overall is 0.1 (if positive luck is any number less than 1) or 0.2 (if positive luck is greater than or equal to 1)
 
-			// TODO: when ExampleBiome is implemented, replace this with an actual biome check.
-			bool inExampleBiome = true;
-			return inExampleBiome ? 1f : -0.1f; // ExampleTorch gives maximum positive luck when in example biome, otherwise a small negative luck
+			bool inExampleUndergroundBiome = Main.LocalPlayer.InModBiome(ModContent.GetInstance<ExampleUndergroundBiome>());
+			return inExampleUndergroundBiome ? 1f : -0.1f; // ExampleTorch gives maximum positive luck when in example biome, otherwise a small negative luck
 		}
 
 		public override void NumDust(int i, int j, bool fail, ref int num) => num = Main.rand.Next(1, 3);

--- a/patches/tModLoader/Terraria/GameContent/Bestiary/UnlockableNPCEntryIcon.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Bestiary/UnlockableNPCEntryIcon.cs.patch
@@ -13,7 +13,7 @@
  
  				if (value.CustomTexturePath != null)
 -					asset = Main.Assets.Request<Texture2D>(value.CustomTexturePath);
-+					asset = ModContent.GetTexture(value.CustomTexturePath);
++					asset = ModContent.Request<Texture2D>(value.CustomTexturePath);
  
  				if (asset != null && asset.IsLoaded)
  					_customTexture = asset;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2965,7 +2965,7 @@
 -					if (num27 == 8)
 -						num27 = 7;
  
-+					Texture2D icon = ModContent.GetTexture(info.Texture).Value;
++					Texture2D icon = ModContent.Request<Texture2D>(info.Texture).Value;
  					Microsoft.Xna.Framework.Color color = Microsoft.Xna.Framework.Color.White;
  					bool flag14 = false;
  					if (playerInventory) {

--- a/patches/tModLoader/Terraria/ModLoader/BackgroundLoaders.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BackgroundLoaders.cs
@@ -47,7 +47,7 @@ namespace Terraria.ModLoader
 			if (!mod.loading)
 				throw new Exception(Language.GetTextValue("tModLoader.LoadErrorNotLoading"));
 
-			ModContent.GetTexture(texture);
+			ModContent.Request<Texture2D>(texture);
 
 			backgrounds[texture] = Instance.Reserve();
 		}
@@ -59,7 +59,7 @@ namespace Terraria.ModLoader
 
 			foreach (string texture in backgrounds.Keys) {
 				int slot = backgrounds[texture];
-				var tex = ModContent.GetTexture(texture);
+				var tex = ModContent.Request<Texture2D>(texture);
 
 				TextureAssets.Background[slot] = tex;
 				Main.backgroundWidth[slot] = tex.Width();

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/AndromedonBodyGlow.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/AndromedonBodyGlow.cs
@@ -9,7 +9,7 @@ namespace Terraria.ModLoader.Default.Developer.Jofairden
 		private static Asset<Texture2D> _glowTexture;
 
 		public override DrawDataInfo GetData(PlayerDrawSet info) {
-			_glowTexture ??= ModContent.GetTexture("ModLoader/Developer.Jofairden.PowerRanger_Body_Body_Glow");
+			_glowTexture ??= ModContent.Request<Texture2D>("ModLoader/Developer.Jofairden.PowerRanger_Body_Body_Glow");
 
 			return GetBodyDrawDataInfo(info, _glowTexture.Value);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/AndromedonBodyShader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/AndromedonBodyShader.cs
@@ -9,7 +9,7 @@ namespace Terraria.ModLoader.Default.Developer.Jofairden
 		private static Asset<Texture2D> _shaderTexture;
 
 		public override DrawDataInfo GetData(PlayerDrawSet info) {
-			_shaderTexture ??= ModContent.GetTexture("ModLoader/Developer.Jofairden.PowerRanger_Body_Body_Shader");
+			_shaderTexture ??= ModContent.Request<Texture2D>("ModLoader/Developer.Jofairden.PowerRanger_Body_Body_Shader");
 
 			return GetBodyDrawDataInfo(info, _shaderTexture.Value);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/AndromedonHeadGlow.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/AndromedonHeadGlow.cs
@@ -11,7 +11,7 @@ namespace Terraria.ModLoader.Default.Developer.Jofairden
 		public override bool IsHeadLayer => true;
 
 		public override DrawDataInfo GetData(PlayerDrawSet info) {
-			_glowTexture ??= ModContent.GetTexture("ModLoader/Developer.Jofairden.PowerRanger_Head_Head_Glow");
+			_glowTexture ??= ModContent.Request<Texture2D>("ModLoader/Developer.Jofairden.PowerRanger_Head_Head_Glow");
 
 			return GetHeadDrawDataInfo(info, _glowTexture.Value);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/AndromedonHeadShader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/AndromedonHeadShader.cs
@@ -11,7 +11,7 @@ namespace Terraria.ModLoader.Default.Developer.Jofairden
 		public override bool IsHeadLayer => true;
 
 		public override DrawDataInfo GetData(PlayerDrawSet info) {
-			_shaderTexture ??= ModContent.GetTexture("ModLoader/Developer.Jofairden.PowerRanger_Head_Head_Shader");
+			_shaderTexture ??= ModContent.Request<Texture2D>("ModLoader/Developer.Jofairden.PowerRanger_Head_Head_Shader");
 
 			return GetHeadDrawDataInfo(info, _shaderTexture.Value);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/AndromedonLegsGlow.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/AndromedonLegsGlow.cs
@@ -9,7 +9,7 @@ namespace Terraria.ModLoader.Default.Developer.Jofairden
 		private static Asset<Texture2D> _glowTexture;
 
 		public override DrawDataInfo GetData(PlayerDrawSet info) {
-			_glowTexture ??= ModContent.GetTexture("ModLoader/Developer.Jofairden.PowerRanger_Legs_Legs_Glow");
+			_glowTexture ??= ModContent.Request<Texture2D>("ModLoader/Developer.Jofairden.PowerRanger_Legs_Legs_Glow");
 
 			return GetLegDrawDataInfo(info, _glowTexture.Value);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/AndromedonLegsShader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/AndromedonLegsShader.cs
@@ -9,7 +9,7 @@ namespace Terraria.ModLoader.Default.Developer.Jofairden
 		private static Asset<Texture2D> _shaderTexture;
 
 		public override DrawDataInfo GetData(PlayerDrawSet info) {
-			_shaderTexture ??= ModContent.GetTexture("ModLoader/Developer.Jofairden.PowerRanger_Legs_Legs_Shader");
+			_shaderTexture ??= ModContent.Request<Texture2D>("ModLoader/Developer.Jofairden.PowerRanger_Legs_Legs_Shader");
 
 			return GetLegDrawDataInfo(info, _shaderTexture.Value);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/EquipLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/EquipLoader.cs
@@ -86,11 +86,11 @@ namespace Terraria.ModLoader
 					int slot = entry.Key;
 					EquipTexture texture = entry.Value;
 					
-					GetTextureArray(type)[slot] = ModContent.GetTexture(texture.Texture, AssetRequestMode.AsyncLoad);
+					GetTextureArray(type)[slot] = ModContent.Request<Texture2D>(texture.Texture, AssetRequestMode.AsyncLoad);
 
 					if (type == EquipType.Body) {
-						TextureAssets.FemaleBody[slot] = ModContent.GetTexture(femaleTextures[slot], AssetRequestMode.AsyncLoad);
-						TextureAssets.ArmorArm[slot] = ModContent.GetTexture(armTextures[slot], AssetRequestMode.AsyncLoad);
+						TextureAssets.FemaleBody[slot] = ModContent.Request<Texture2D>(femaleTextures[slot], AssetRequestMode.AsyncLoad);
+						TextureAssets.ArmorArm[slot] = ModContent.Request<Texture2D>(armTextures[slot], AssetRequestMode.AsyncLoad);
 					}
 				}
 			}

--- a/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GoreLoader.cs
@@ -70,7 +70,7 @@ namespace Terraria.ModLoader
 			}
 
 			foreach (var pair in gores) {
-				TextureAssets.Gore[pair.Key] = ModContent.GetTexture(pair.Value.Texture);
+				TextureAssets.Gore[pair.Key] = ModContent.Request<Texture2D>(pair.Value.Texture);
 			}
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/InfoDisplay.cs
+++ b/patches/tModLoader/Terraria/ModLoader/InfoDisplay.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
-using System.Linq;
 using Terraria.Localization;
 
 namespace Terraria.ModLoader
@@ -48,7 +47,7 @@ namespace Terraria.ModLoader
 		public abstract string DisplayValue();
 
 		public sealed override void SetupContent() {
-			ModContent.GetTexture(Texture);
+			ModContent.Request<Texture2D>(Texture);
 			SetDefaults();
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -239,7 +239,7 @@ namespace Terraria.ModLoader
 			NPCHeadLoader.heads[texture] = slot;
 			
 			if (!Main.dedServ) {
-				ModContent.GetTexture(texture);
+				ModContent.Request<Texture2D>(texture);
 			}
 			/*else if (Main.dedServ && !(ModLoader.FileExists(texture + ".png") || ModLoader.FileExists(texture + ".rawimg")))
 			{
@@ -263,7 +263,7 @@ namespace Terraria.ModLoader
 
 			int slot = NPCHeadLoader.ReserveBossHeadSlot(texture);
 			NPCHeadLoader.bossHeads[texture] = slot;
-			ModContent.GetTexture(texture);
+			ModContent.Request<Texture2D>(texture);
 			if (npcType >= 0) {
 				NPCHeadLoader.npcToBossHead[npcType] = slot;
 			}

--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -409,18 +409,6 @@ namespace Terraria.ModLoader
 			return true;
 		}
 
-		[Obsolete("Use Mod.Assets.Request<Texture2D> instead")]
-		public Asset<Texture2D> GetTexture(string name) => Assets.Request<Texture2D>(name);
-
-		[Obsolete("Use Mod.HasAsset instead")]
-		public bool TextureExists(string name) => HasAsset(name);
-
-		[Obsolete("Use Mod.Assets.Request<SoundEffect> instead")]
-		public Asset<SoundEffect> GetSound(string name) => Assets.Request<SoundEffect>(name);
-
-		[Obsolete("Use Mod.HasAsset instead")]
-		public bool SoundExists(string name) => HasAsset(name);
-
 		/// <summary>
 		/// Shorthand for calling ModContent.GetMusic(this.FileName(name)).
 		/// </summary>
@@ -440,18 +428,6 @@ namespace Terraria.ModLoader
 		/// <param name="name">The name.</param>
 		/// <returns></returns>
 		public bool MusicExists(string name) => musics.ContainsKey(name);
-
-		[Obsolete("Use Mod.Assets.Request<DynamicSpriteFont> instead")]
-		public Asset<DynamicSpriteFont> GetFont(string name) => Assets.Request<DynamicSpriteFont>(name);
-
-		[Obsolete("Use Mod.HasAsset instead")]
-		public bool FontExists(string name) => HasAsset(name);
-
-		[Obsolete("Use Mod.Assets.Request<Effect> instead")]
-		public Asset<Effect> GetEffect(string name) => Assets.Request<Effect>(name);
-
-		[Obsolete("Use Mod.HasAsset instead")]
-		public bool EffectExists(string name) => HasAsset(name);
 
 		/// <summary>
 		/// Used for weak inter-mod communication. This allows you to interact with other mods without having to reference their types or namespaces, provided that they have implemented this method.

--- a/patches/tModLoader/Terraria/ModLoader/ModBuff.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBuff.cs
@@ -1,4 +1,4 @@
-using System;
+using Microsoft.Xna.Framework.Graphics;
 using Terraria.GameContent;
 using Terraria.ID;
 
@@ -35,7 +35,7 @@ namespace Terraria.ModLoader
 		}
 
 		public sealed override void SetupContent() {
-			TextureAssets.Buff[Type] = ModContent.GetTexture(Texture);
+			TextureAssets.Buff[Type] = ModContent.Request<Texture2D>(Texture);
 			SetDefaults();
 			BuffID.Search.Add(FullName, Type);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -130,18 +130,6 @@ namespace Terraria.ModLoader
 			return true;
 		}
 
-		[Obsolete("Use ModContent.Request<Texture2D> or Mod.Assets.Request<Texture2D> instead")]
-		public static Asset<Texture2D> GetTexture(string name, AssetRequestMode mode = AssetRequestMode.AsyncLoad) => Request<Texture2D>(name, mode);
-
-		[Obsolete("Use ModContent.HasAsset or Mod.HasAsset instead")]
-		public static bool TextureExists(string name) => HasAsset(name);
-
-		[Obsolete("Use ModContent.Request<Texture2D> or Mod.Assets.Request<Texture2D> instead")]
-		public static Asset<SoundEffect> GetSound(string name, AssetRequestMode mode = AssetRequestMode.AsyncLoad) => Request<SoundEffect>(name, mode);
-
-		[Obsolete("Use ModContent.HasAsset or Mod.HasAsset instead")]
-		public static bool SoundExists(string name) => HasAsset(name);
-
 		/// <summary>
 		/// Gets the music with the specified name. The name is in the same format as for texture names. Throws an ArgumentException if the music does not exist. Note: SoundMP3 is in the Terraria.ModLoader namespace.
 		/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModDust.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModDust.cs
@@ -29,7 +29,7 @@ namespace Terraria.ModLoader
 
 			Type = DustLoader.ReserveDustID();
 
-			Texture2D = !string.IsNullOrEmpty(Texture) ? ModContent.GetTexture(Texture).Value : TextureAssets.Dust.Value;
+			Texture2D = !string.IsNullOrEmpty(Texture) ? ModContent.Request<Texture2D>(Texture).Value : TextureAssets.Dust.Value;
 		}
 
 		internal void Draw(Dust dust, Color alpha, float scale) {

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -114,7 +114,7 @@ namespace Terraria.ModLoader
 		/// Automatically sets certain static defaults. Override this if you do not want the properties to be set for you.
 		/// </summary>
 		public virtual void AutoStaticDefaults() {
-			TextureAssets.Item[Item.type] = ModContent.GetTexture(Texture);
+			TextureAssets.Item[Item.type] = ModContent.Request<Texture2D>(Texture);
 
 			if (ModContent.RequestIfExists<Texture2D>(Texture + "_Flame", out var flameTexture)) {
 				TextureAssets.ItemFlame[Item.type] = flameTexture;

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -156,7 +156,7 @@ namespace Terraria.ModLoader
 		/// Automatically sets certain static defaults. Override this if you do not want the properties to be set for you.
 		/// </summary>
 		public virtual void AutoStaticDefaults() {
-			TextureAssets.Npc[NPC.type] = ModContent.GetTexture(Texture);
+			TextureAssets.Npc[NPC.type] = ModContent.Request<Texture2D>(Texture);
 
 			if (Banner != 0 && BannerItem != 0) {
 				NPCLoader.bannerToItem[Banner] = BannerItem;

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -119,7 +119,7 @@ namespace Terraria.ModLoader
 		/// Automatically sets certain static defaults. Override this if you do not want the properties to be set for you.
 		/// </summary>
 		public virtual void AutoStaticDefaults() {
-			TextureAssets.Projectile[Projectile.type] = ModContent.GetTexture(Texture);
+			TextureAssets.Projectile[Projectile.type] = ModContent.Request<Texture2D>(Texture);
 			Main.projFrames[Projectile.type] = 1;
 			if (Projectile.hostile) {
 				Main.projHostile[Projectile.type] = true;

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -142,7 +142,7 @@ namespace Terraria.ModLoader
 		}
 
 		public sealed override void SetupContent() {
-			TextureAssets.Tile[Type] = ModContent.GetTexture(Texture);
+			TextureAssets.Tile[Type] = ModContent.Request<Texture2D>(Texture);
 
 			SetDefaults();
 
@@ -161,7 +161,7 @@ namespace Terraria.ModLoader
 			PostSetDefaults();
 
 			if (TileID.Sets.HasOutlines[Type])
-				TextureAssets.HighlightMask[Type] = ModContent.GetTexture(HighlightTexture);
+				TextureAssets.HighlightMask[Type] = ModContent.Request<Texture2D>(HighlightTexture);
 
 			TileID.Search.Add(FullName, Type);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModWall.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWall.cs
@@ -1,4 +1,5 @@
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using Terraria.GameContent;
@@ -72,7 +73,7 @@ namespace Terraria.ModLoader
 		}
 
 		public sealed override void SetupContent() {
-			TextureAssets.Wall[Type] = ModContent.GetTexture(Texture);
+			TextureAssets.Wall[Type] = ModContent.Request<Texture2D>(Texture);
 			SetDefaults();
 			WallID.Search.Add(FullName, Type);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModWaterStyle.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWaterStyle.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Terraria.GameContent;
 using Terraria.GameContent.Liquid;
 
@@ -22,8 +23,8 @@ namespace Terraria.ModLoader
 		}
 
 		public sealed override void SetupContent() {
-			LiquidRenderer.Instance._liquidTextures[Slot] = ModContent.GetTexture(Texture);
-			TextureAssets.Liquid[Slot] = ModContent.GetTexture(BlockTexture);
+			LiquidRenderer.Instance._liquidTextures[Slot] = ModContent.Request<Texture2D>(Texture);
+			TextureAssets.Liquid[Slot] = ModContent.Request<Texture2D>(BlockTexture);
 		}
 
 		/// <summary>
@@ -74,7 +75,7 @@ namespace Terraria.ModLoader
 		}
 
 		public sealed override void SetupContent() {
-			Main.instance.waterfallManager.waterfallTexture[Slot] = ModContent.GetTexture(Texture);
+			Main.instance.waterfallManager.waterfallTexture[Slot] = ModContent.Request<Texture2D>(Texture);
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/NPCHeadLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCHeadLoader.cs
@@ -71,11 +71,11 @@ namespace Terraria.ModLoader
 			ResetHeadRenderer(ref Main.BossNPCHeadRenderer, TextureAssets.NpcHeadBoss);
 
 			foreach (string texture in heads.Keys) {
-				TextureAssets.NpcHead[heads[texture]] = ModContent.GetTexture(texture);
+				TextureAssets.NpcHead[heads[texture]] = ModContent.Request<Texture2D>(texture);
 			}
 
 			foreach (string texture in bossHeads.Keys) {
-				TextureAssets.NpcHeadBoss[bossHeads[texture]] = ModContent.GetTexture(texture);
+				TextureAssets.NpcHeadBoss[bossHeads[texture]] = ModContent.Request<Texture2D>(texture);
 			}
 
 			//Sets. The arrays modified here are resized in NPCLoader.

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/Terraria.csproj
 +++ src/tModLoader/Terraria/Terraria.csproj
-@@ -2,69 +_,142 @@
+@@ -2,69 +_,148 @@
    <Import Project="../Configuration.targets" />
    <Import Project="../../WorkspaceInfo.targets" />
    <PropertyGroup>
@@ -55,15 +55,8 @@
 -      <LogicalName>Terraria.Libraries.ReLogic.ReLogic.dll</LogicalName>
 -    </EmbeddedResource>
 +    <Reference Include="TerrariaHooks" />
-+      <ProjectReference Include="../ReLogic/ReLogic.csproj">
-+          <!--Version has to match deps.json and project version. Hardcode here as resolving from metadata is difficult without custom Task. Specifically, getting the pdb to output in the right directory-->
-+          <DestinationSubDirectory>Libraries/ReLogic/1.0.0/</DestinationSubDirectory>
-+      </ProjectReference>
-+      <ProjectReference Include="..\..\..\FNA\FNA.csproj">
-+          <!--Todo, extract version from FNA\src\Properties\AssemblyInfo.cs or some other way-->
-+		  <!--Currently for whatever reason, the deps.json generates with version 1.0.0 as the referenced version. Even though the assembly has version 21.06.0.0-->
-+          <DestinationSubDirectory>Libraries/FNA/1.0.0/</DestinationSubDirectory>
-+	  </ProjectReference>
++    <ProjectReference Include="../ReLogic/ReLogic.csproj" />
++    <ProjectReference Include="..\..\..\FNA\FNA.csproj" />
      <Reference Include="Steamworks.NET" />
      <Reference Include="SteelSeriesEngineWrapper" />
 -    <Reference Update="@(Reference)">
@@ -150,9 +143,22 @@
 +      <!--Note that associated files, like pdbs/xmls won't be resolved properly here. Prefer nuget packages for that-->
 +      <ReferenceCopyLocalPaths Condition="%(ReferenceCopyLocalPaths.ReferenceSourceTarget) == 'ResolveAssemblyReference'">
 +        <DirectoryVersion>$([System.String]::Copy('%(ReferenceCopyLocalPaths.FusionName)').Remove($([System.String]::Copy('%(ReferenceCopyLocalPaths.FusionName)').IndexOf(", C"))).Substring($([System.String]::Copy('%(ReferenceCopyLocalPaths.FusionName)').IndexOf(","))).Substring(10))</DirectoryVersion>
-+        </ReferenceCopyLocalPaths>
++      </ReferenceCopyLocalPaths>
 +      <ReferenceCopyLocalPaths Condition="%(ReferenceCopyLocalPaths.ReferenceSourceTarget) == 'ResolveAssemblyReference'">
 +        <DestinationSubDirectory>Libraries\%(ReferenceCopyLocalPaths.OriginalItemSpec)\%(ReferenceCopyLocalPaths.DirectoryVersion)\</DestinationSubDirectory>
++      </ReferenceCopyLocalPaths>
++    </ItemGroup>
++  </Target>
++  <Target Name="RedirectProjectReferencesToLib" AfterTargets="ResolveAssemblyReferences">
++    <ItemGroup>
++      <!--Version is bugged in deps.json for ProjectReferences, doesn't reflect AssemblyVersion for whatever reason. Uses 1.0.0-->
++      <!--As well, FusionName isn't available, so alternate string manipulation to get Name-->
++      <ReferenceCopyLocalPaths Condition="%(ReferenceCopyLocalPaths.ReferenceSourceTarget) == 'ProjectReference'">
++        <VersionHack>1.0.0</VersionHack>
++        <DllName>$([System.String]::Copy('%(ReferenceCopyLocalPaths.ResolvedFrom)').Remove($([System.String]::Copy('%(ReferenceCopyLocalPaths.ResolvedFrom)').IndexOf(".dll"))).SubString($([System.String]::Copy('%(ReferenceCopyLocalPaths.ResolvedFrom)').LastIndexOf("\"))).Substring(1))</DllName>
++      </ReferenceCopyLocalPaths>
++      <ReferenceCopyLocalPaths Condition="%(ReferenceCopyLocalPaths.ReferenceSourceTarget) == 'ProjectReference'">
++        <DestinationSubDirectory>Libraries\%(ReferenceCopyLocalPaths.DllName)\%(ReferenceCopyLocalPaths.VersionHack)\</DestinationSubDirectory>
 +      </ReferenceCopyLocalPaths>
 +    </ItemGroup>
 +  </Target>


### PR DESCRIPTION
1) For de-hardcoding FNA lib output:
Couldn't fix the version mis-labelling - all ProjectReferences are consistent on that. 
Have squashed the hardcode to just be one occurrence of "VersionHack".
Resolving is working fine for launching. Haven't checked ReLogic.dll is connecting ok, but assume it is.

Do we need the Version to be correct in the folder for any reason other than aesthetics? If we do need it, I can take another swing.

2) I've also gone through the trouble to Ctrl+H away the GetSound/GetTexture obsolete methods from tModLoader and ExampleMod