### PR TITLE
Renamed ZonePurity player variables to ZoneForest for consistency wit…

### DIFF
--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -118,14 +118,14 @@ namespace Terraria
 		public bool InModBiome(ModBiome baseInstance) => modBiomeFlags[baseInstance.ZeroIndexType];
 
 		/// <summary>
-		/// The zone property storing if the player is in the purity/forest biome. Updated in <see cref="UpdateBiomes"/>
+		/// The zone property storing if the player is in the forest/purity biome. Updated in <see cref="UpdateBiomes"/>
 		/// </summary>
-		public bool ZonePurity { get; set; } = false;
+		public bool ZoneForest { get; set; } = false;
 
 		/// <summary>
-		/// Calculates whether or not the player is in the purity/forest biome.
+		/// Calculates whether or not the player is in the forest/purity biome.
 		/// </summary>
-		public bool InZonePurity() {
+		public bool InZoneForest() {
 			bool one = ZoneBeach || ZoneCorrupt || ZoneCrimson || ZoneDesert || ZoneDungeon || ZoneGemCave;
 			bool two = ZoneGlowshroom || ZoneGranite || ZoneGraveyard || ZoneHallow || ZoneHive || ZoneJungle;
 			bool three = ZoneLihzhardTemple || ZoneMarble || ZoneMeteor || ZoneSnow || ZoneUnderworldHeight;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1870,7 +1870,7 @@
  				}
  			}
  
-+			ZonePurity = InZonePurity();
++			ZoneForest = InZoneForest();
 +			LoaderManager.Get<BiomeLoader>().PostUpdateBiome(this);
  			if (!dead) {
  				Point point2 = base.Center.ToTileCoordinates();


### PR DESCRIPTION
Renamed ZonePurity player variables to ZoneForest for consistency with vanilla's use of the term for the default biome

<!--
We recommend using one of our pull request templates if you want your PR taken seriously.

You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.
If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:

Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->
