### PR TITLE
Implemented forgotten ModSystem.PreSaveAndQuit

### DIFF
--- a/patches/tModLoader/Terraria/IngameOptions.cs.patch
+++ b/patches/tModLoader/Terraria/IngameOptions.cs.patch
@@ -77,6 +77,15 @@
  			if (DrawLeftSide(sb, Lang.menu[118].Value, num10, vector, vector2, leftScale)) {
  				leftHover = num10;
  				if (flag4)
+@@ -276,6 +_,8 @@
+ 			if (DrawLeftSide(sb, Lang.inter[35].Value, num10, vector, vector2, leftScale)) {
+ 				leftHover = num10;
+ 				if (flag4) {
++					SystemLoader.PreSaveAndQuit();
++					// Calls before anything else is
+ 					Close();
+ 					Main.menuMode = 10;
+ 					Main.gameMenu = true;
 @@ -301,6 +_,7 @@
  					break;
  				case 1:


### PR DESCRIPTION
### What is the bug?
`ModSystem.PreSaveAndQuit()` was not being called at all.
### How did you fix the bug?
Added it to the list of actions called when left-clicking `Save & Exit` from the Ingame Options menu.
### Are there alternatives to your fix?
There most definitely are, just chose the most accessible way.