### PR TITLE
Fix Mod Loading on Dedicated Servers with conditionals

### DIFF
--- a/patches/tModLoader/ReLogic/Content/AssetRepository.cs.patch
+++ b/patches/tModLoader/ReLogic/Content/AssetRepository.cs.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/ReLogic/Content/AssetRepository.cs
 +++ src/tModLoader/ReLogic/Content/AssetRepository.cs
-@@ -1,89 +_,184 @@
+@@ -1,89 +_,194 @@
 +using ReLogic.Content.Readers;
  using ReLogic.Content.Sources;
  using System;
@@ -79,6 +79,12 @@
 +		}
 +
 +		private void Invoke(Action action) {
++			// Skip loading assets if this is a dedicated server; this avoids deadlocks on waiting for queue to empty
++			if (_readers == null) {
++				_assetTransferQueue.Clear();
++				return;
++			}
++				
 +			var evt = new ManualResetEvent(false);
 +			_assetTransferQueue.Enqueue(() => { action(); evt.Set(); });
 +			evt.WaitOne();
@@ -171,6 +177,10 @@
 +
 -		public Asset<T> Request<T>(string assetName, AssetRequestMode mode = AssetRequestMode.ImmediateLoad) where T : class {
 +		public virtual Asset<T> Request<T>(string assetName, AssetRequestMode mode = AssetRequestMode.AsyncLoad) where T : class {
++			// Skip loading assets if this is a dedicated server
++			if (_readers == null)
++				mode = AssetRequestMode.DoNotLoad;
++			
  			ThrowIfDisposed();
  			assetName = AssetPathHelper.CleanPath(assetName);
 -			lock (_requestLock) {

--- a/patches/tModLoader/Terraria/ModLoader/Assets/TModContentSource.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Assets/TModContentSource.cs
@@ -13,6 +13,11 @@ namespace Terraria.ModLoader.Assets
 
 		public TModContentSource(TmodFile file) {
 			this.file = file ?? throw new ArgumentNullException(nameof(file));
+
+			// Skip loading assets if this is a dedicated server
+			if (Main.dedServ)
+				return;
+
 			// Filter assets based on the current reader set. Custom mod asset readers will need to be added before content sources are initialized
 			// Unfortunately this means that if a reader is missing, the asset will be missing, causing a misleading error message, but there's little
 			// we can do about that while still supporting multiple files with the same extension. Unless we provided a hardcoded exclusion for .cs files...

--- a/patches/tModLoader/Terraria/ModLoader/Core/MemoryTracking.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/MemoryTracking.cs
@@ -52,12 +52,14 @@ namespace Terraria.ModLoader.Core
 					.GetLoadedAssets()
 					.OfType<Asset<Texture2D>>()
 					.Select(asset => asset.Value)
+					.Where(val => val != null)
 					.Sum(tex => tex.Width * tex.Height * 4);
 
 				usage.sounds = mod.Assets
 					.GetLoadedAssets()
 					.OfType<Asset<SoundEffect>>()
 					.Select(asset => asset.Value)
+					.Where(val => val != null)
 					.Sum(sound => (long)sound.Duration.TotalSeconds * 44100 * 2 * 2);
 			}
 			Logging.tML.Info($"RAM usage: {UI.UIMemoryBar.SizeSuffix(System.Diagnostics.Process.GetCurrentProcess().WorkingSet64)}");

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -89,7 +89,11 @@ namespace Terraria.ModLoader
 					}
 				}
 			}
-			
+
+			// Skip loading client assets if this is a dedicated server;
+			if (Main.dedServ)
+				return;
+
 			if (Properties.AutoloadGores)
 				GoreLoader.AutoloadGores(this);
 			

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -96,7 +96,11 @@ namespace Terraria.ModLoader
 		public static Asset<T> Request<T>(string name, AssetRequestMode mode = AssetRequestMode.AsyncLoad) where T : class {
 			SplitName(name, out string modName, out string subName);
 
-			if(modName == "Terraria")
+			// Initialize Main.Assets on server in case it hasn't been initialized. This prevents later crashes when checking Terraria assets
+			if (Main.dedServ && Main.Assets == null)
+				Main.Assets = new AssetRepository(null);
+
+			if (modName == "Terraria")
 				return Main.Assets.Request<T>(subName, mode);
 
 			if (!ModLoader.TryGetMod(modName, out var mod))

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -102,10 +102,6 @@ namespace Terraria.ModLoader
 
 		internal static void PrepareAssets()
 		{
-			if (Main.dedServ) {
-				return;
-			}
-
 			ManifestContentSource = new AssemblyResourcesContentSource(Assembly.GetExecutingAssembly());
 			ManifestAssets = new AssetRepository(AssetInitializer.assetReaderCollection, new[] { ManifestContentSource }) {
 				AssetLoadFailHandler = Main.OnceFailedLoadingAnAsset


### PR DESCRIPTION
### What is the bug?
The dedicated server was unable to load ModLoader Mod and other mods after changes made on the Asset Loading PR.
This PR adds the necessary null checks to be able to allow for mod loading so that dedicated servers at least can reach their Main Menu.

### How did you fix the bug?
1) Add null checks in Asset Repository to divert loading of client assets to not happen & not deadlock
2) Add null & main.dedServ checks elsewhere as was required.

### Are there alternatives to your fix?

