### PR TITLE
Fix ModBuild & improve Mod Finding

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -168,8 +168,6 @@ namespace Terraria.ModLoader.Core
 
 		internal static void BuildModCommandLine(string modFolder)
 		{
-			Main.dedServ = true; // Some boolean like this is required to skip attempts to access workshop data.
-
 			LanguageManager.Instance.SetLanguage(GameCulture.DefaultCulture);
 			Lang.InitializeLegacyLocalization();
 

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -37,11 +37,10 @@ namespace Terraria.ModLoader.Core
 
 			WorkshopFileFinder.Refresh(new WorkshopIssueReporter());
 
-			if (ModCompile.DeveloperMode) {
-				// Prioritize loading Mods from Mods folder for Dev/Beta simplicitiy.
-				modRepos.Add(ModLoader.ModPath);
-			}
-
+			// Prioritize loading Mods from Mods folder for Dev/Beta simplicitiy.
+			modRepos.Add(ModLoader.ModPath);
+			
+			// Load Mods from Workshop downloads
 			modRepos.AddRange(WorkshopFileFinder.ModPaths);
 
 			foreach (string repo in modRepos) {

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -35,18 +35,14 @@ namespace Terraria.ModLoader.Core
 
 			DeleteTemporaryFiles();
 
-			if (!Main.dedServ) {
-				WorkshopFileFinder.Refresh(new WorkshopIssueReporter());
-			}
+			WorkshopFileFinder.Refresh(new WorkshopIssueReporter());
 
 			if (ModCompile.DeveloperMode) {
 				// Prioritize loading Mods from Mods folder for Dev/Beta simplicitiy.
 				modRepos.Add(ModLoader.ModPath);
 			}
 
-			if (!Main.dedServ) {
-				modRepos.AddRange(WorkshopFileFinder.ModPaths);
-			}
+			modRepos.AddRange(WorkshopFileFinder.ModPaths);
 
 			foreach (string repo in modRepos) {
 				foreach (string fileName in Directory.GetFiles(repo, "*.tmod", SearchOption.TopDirectoryOnly)) {

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -87,7 +87,7 @@
  
  			try {
  				Console.OutputEncoding = Encoding.UTF8;
-@@ -138,32 +_,59 @@
+@@ -138,32 +_,58 @@
  			}
  		}
  
@@ -108,9 +108,9 @@
 +			if (File.Exists("savehere.txt"))
 +				SavePath = "ModLoader"; // Fallback for unresolveable antivirus/onedrive issues. Also makes the game portable I guess.
 +
-+			bool dedServ = LaunchParameters.ContainsKey("-server");
++			Main.dedServ = LaunchParameters.ContainsKey("-server");
 +			try {
-+				Logging.Init(dedServ);
++				Logging.Init(Main.dedServ);
 +			}
 +			catch (Exception e) {
 +				DisplayException(e);
@@ -122,10 +122,10 @@
 +				// Anything beyond this point will not be executed
 +				ModCompile.BuildModCommandLine(build);
 +
-+			LaunchGame_(dedServ);
++			LaunchGame_();
 +		}
 +
-+		public static void LaunchGame_(bool dedServ) {
++		public static void LaunchGame_() {
  			if (Platform.IsOSX) {
  				Main.OnEngineLoad += delegate {
  					Main.instance.IsMouseVisible = false;
@@ -135,7 +135,6 @@
 -			LaunchParameters = Utils.ParseArguements(args);
 -#if SERVER
 -			Main.dedServ = true;
-+			Main.dedServ = dedServ;
 -#else
 -			Main.dedServ = LaunchParameters.ContainsKey("-server");
 -#endif

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -41,7 +41,7 @@ namespace Terraria.Social.Steam
 
 		internal class ModManager
 		{
-			internal static bool SteamUser { get; set; } = true;
+			internal static bool SteamUser { get; set; } = false;
 			internal static AppId_t thisApp = ModLoader.Engine.Steam.TMLAppID_t;
 
 			protected Callback<DownloadItemResult_t> m_DownloadItemResult;
@@ -51,14 +51,14 @@ namespace Terraria.Social.Steam
 			internal static void Initialize() {
 				if (!ModLoader.Engine.Steam.IsSteamApp) {
 					// Non-steam tModLoader will use the SteamGameServer to perform Browsing & Downloading
-					SteamUser = false;
-
 					GameServer.Init(0x7f000001, 7776, 7775, 7774, EServerMode.eServerModeNoAuthentication, "0.11.9.0");
 
 					SteamGameServer.SetGameDescription("tModLoader Mod Browser");
 					SteamGameServer.SetProduct(thisApp.ToString());
 					SteamGameServer.LogOnAnonymous();
 				}
+				else
+					SteamUser = true;
 			}
 
 			internal ModManager(PublishedFileId_t itemID) {

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -31,7 +31,7 @@
  			}
  
  			public class Downloader
-@@ -34,26 +_,52 @@
+@@ -34,26 +_,60 @@
  					private set;
  				}
  
@@ -62,7 +62,15 @@
 +							}
 +						}
 +					}
++					else if (Main.dedServ) {
++						// Try to load mods that are installed by Steam users when server launches without Steam. No guarantees if Steam not installed in standard location.
++						var workshopLoc = Path.Combine(Directory.GetParent(Directory.GetParent(Directory.GetCurrentDirectory().ToString()).ToString()).ToString(), "workshop", "content", ModManager.thisApp.m_AppId.ToString());
++						if (Directory.Exists(workshopLoc)) {
++							list.AddRange(Directory.EnumerateDirectories(workshopLoc));
++						}
++					}
 +
++					// Load mods installed by GoG / Manually copied steamapps\workshop directories.
 +					string gogDirectory = Path.Combine(Directory.GetCurrentDirectory(), "steamapps", "workshop", "content", ModManager.thisApp.ToString());
 +					if (Directory.Exists(gogDirectory)) {
 +						list.AddRange(Directory.EnumerateDirectories(gogDirectory));


### PR DESCRIPTION
### What is the bug?
Mod Building via CLI w/out Steam logged in failed due to attempting to use Steam API.
Server launched as Steam-less by a steam user should have an attempt to find mods installed by Steam in the default location.

### How did you fix the bug?
Reworked SteamUser to start false, and moved Main.DedServ to be set prior to CLI build.

