### PR TITLE
Patch HasAsset Dictionairy issues

### DIFF
--- a/patches/tModLoader/ReLogic/Content/Sources/ContentSource.cs
+++ b/patches/tModLoader/ReLogic/Content/Sources/ContentSource.cs
@@ -21,7 +21,7 @@ namespace ReLogic.Content.Sources
 			foreach (var path in assetPaths) {
 				var ext = Path.GetExtension(path);
 
-				// ReLogic sets all assets to use back slash in their paths in AssetPathHelper. Changing this by itself can lead to vanilla load issues
+				// ReLogic sets all assets to use Path.DirectorySepChar in their paths in AssetPathHelper.
 				var name = AssetPathHelper.CleanPath(path[..^ext.Length]);
 					
 				if (assetExtensions.TryGetValue(name, out var ext2))
@@ -33,8 +33,8 @@ namespace ReLogic.Content.Sources
 
 		public IEnumerable<string> EnumerateAssets() => assetPaths;
 
-		// Use Replace to match the assetName path to the 'cleaned path' in assetExtensions, keeping patches minimal.
-		public string GetExtension(string assetName) => assetExtensions.TryGetValue(assetName.Replace("/", "\\"), out var ext) ? ext : null;
+		// Use CleanPath to ensure match the assetName path to the 'cleaned path' in assetExtensions for mods, keeping patches minimal.
+		public string GetExtension(string assetName) => assetExtensions.TryGetValue(AssetPathHelper.CleanPath(assetName), out var ext) ? ext : null;
 
 		public abstract Stream OpenStream(string fullAssetName);
 	}

--- a/patches/tModLoader/ReLogic/Content/Sources/ContentSource.cs
+++ b/patches/tModLoader/ReLogic/Content/Sources/ContentSource.cs
@@ -20,7 +20,10 @@ namespace ReLogic.Content.Sources
 
 			foreach (var path in assetPaths) {
 				var ext = Path.GetExtension(path);
+
+				// ReLogic sets all assets to use back slash in their paths in AssetPathHelper. Changing this by itself can lead to vanilla load issues
 				var name = AssetPathHelper.CleanPath(path[..^ext.Length]);
+					
 				if (assetExtensions.TryGetValue(name, out var ext2))
 					throw new Exception($"Multiple extensions for asset {name}, ({ext}, {ext2})");
 
@@ -30,7 +33,8 @@ namespace ReLogic.Content.Sources
 
 		public IEnumerable<string> EnumerateAssets() => assetPaths;
 
-		public string GetExtension(string assetName) => assetExtensions.TryGetValue(assetName, out var ext) ? ext : null;
+		// Use Replace to match the assetName path to the 'cleaned path' in assetExtensions, keeping patches minimal.
+		public string GetExtension(string assetName) => assetExtensions.TryGetValue(assetName.Replace("/", "\\"), out var ext) ? ext : null;
 
 		public abstract Stream OpenStream(string fullAssetName);
 	}


### PR DESCRIPTION
### What is the bug?
HasAsset() currently always return false due to the following:
![image](https://user-images.githubusercontent.com/59670736/126237949-a22bbcbe-7bf5-4636-b5ca-fca5b307d437.png)


### How did you fix the bug?
I've taken the less exhaustive approach of just using String.Replace() on the lookup string to convert tML standard forward slash into back slash as needed.

### Are there alternatives to your fix?
Yes, could also rework AssetExtensions dictionary to be based on forward slash; however elected not to given that the entirety of vanilla assets is standardized to back slash, which likely would take quite a bit more effort to swap over relative to a single String.Replace().
