### PR TITLE
Minor changes in Recipe

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalRecipe.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalRecipe.cs
@@ -26,5 +26,14 @@
 		/// <param name="recipe">The recipe used to create the item.</param>
 		public virtual void OnCraft(Item item, Recipe recipe) {
 		}
+
+		/// <summary>
+		/// Allows to edit the amount of item the player uses in a recipe.
+		/// </summary>
+		/// <param name="recipe">The recipe used for the craft.</param>
+		/// <param name="type">Type of the ingredient.</param>
+		/// <param name="amount">Modifiable amount of the item consumed.</param>
+		public virtual void ConsumeItem(Recipe recipe, int type, ref int amount) {
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
@@ -74,5 +74,19 @@ namespace Terraria.ModLoader
 				globalRecipe.OnCraft(item, recipe);
 			}
 		}
+
+		/// <summary>
+		/// Allows to edit the amount of item the player uses in a recipe.
+		/// </summary>
+		/// <param name="recipe">The recipe used for the craft.</param>
+		/// <param name="type">Type of the ingredient.</param>
+		/// <param name="amount">Modifiable amount of the item consumed.</param>
+		public static void ConsumeItem(Recipe recipe, int type, ref int amount) {
+			recipe.ConsumeItemHooks?.Invoke(recipe, type, ref amount);
+
+			foreach (GlobalRecipe globalRecipe in globalRecipes) {
+				globalRecipe.ConsumeItem(recipe, type, ref amount);
+			}
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/Recipe.TML.cs
+++ b/patches/tModLoader/Terraria/Recipe.TML.cs
@@ -102,7 +102,7 @@ namespace Terraria
 		public delegate void ConsumeItemCallback(Recipe recipe, int type, ref int amount);
 		
 		internal OnCraftCallback OnCraftHooks { get; private set; }
-		public ConsumeItemCallback ConsumeItemHooks { get; private set; }
+		internal ConsumeItemCallback ConsumeItemHooks { get; private set; }
 
 		private void AddGroup(int id) {
 			acceptedGroups.Add(id);

--- a/patches/tModLoader/Terraria/Recipe.TML.cs
+++ b/patches/tModLoader/Terraria/Recipe.TML.cs
@@ -102,7 +102,7 @@ namespace Terraria
 		public delegate void ConsumeItemCallback(Recipe recipe, int type, ref int amount);
 		
 		internal OnCraftCallback OnCraftHooks { get; private set; }
-		internal ConsumeItemCallback ConsumeItemHooks { get; private set; }
+		public ConsumeItemCallback ConsumeItemHooks { get; private set; }
 
 		private void AddGroup(int id) {
 			acceptedGroups.Add(id);

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -333,7 +333,7 @@
  			if (ingridients.Length == 1) {
  				ingridients = new int[2] {
  					ingridients[0],
-@@ -14246,18 +_,56 @@
+@@ -14246,18 +_,57 @@
  			}
  		}
  
@@ -392,6 +392,7 @@
 +			for (int i = 0; i < maxVanillaRequirements; i++)
 +				currentRecipe.requiredItem.Add(new Item());
 +
++			RecipeIndex = numRecipes;
  			numRecipes++;
  		}
  

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -151,7 +151,7 @@
  					}
  				}
  
-+				ConsumeItemHooks?.Invoke(this, item2.type, ref num);
++				RecipeLoader.ConsumeItem(this, item2.type, ref num);
 +
  				if (num <= 0)
  					continue;
@@ -392,7 +392,7 @@
 +			for (int i = 0; i < maxVanillaRequirements; i++)
 +				currentRecipe.requiredItem.Add(new Item());
 +
-+			RecipeIndex = numRecipes;
++			currentRecipe.RecipeIndex = numRecipes;
  			numRecipes++;
  		}
  


### PR DESCRIPTION
### What is the new feature?
Added an index to vanilla recipes and made Recipe.ConsumeItemHooks getter public

### Why should this be part of tModLoader?
Current design require a trick to use ConsumeItemHooks by adding instructions to it or with reflection.
The recipe index is only assigned to the modded recipes while it could be used in some mods, and make the debugging easier.