### PR TITLE
[1.4] Fixed vanilla info displays being listed in the wrong order

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/InfoDisplayLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/InfoDisplayLoader.cs
@@ -10,17 +10,17 @@ namespace Terraria.ModLoader
 		internal static readonly List<InfoDisplay> InfoDisplays = new List<InfoDisplay>() {
 			InfoDisplay.Watches,
 			InfoDisplay.WeatherRadio,
-			InfoDisplay.FishFinder,
-			InfoDisplay.Compass,
-			InfoDisplay.DepthMeter,
-			InfoDisplay.Radar,
-			InfoDisplay.TallyCounter,
 			InfoDisplay.Sextant,
-			InfoDisplay.Dummy,
-			InfoDisplay.Stopwatch,
+			InfoDisplay.FishFinder,
 			InfoDisplay.MetalDetector,
 			InfoDisplay.LifeformAnalyzer,
-			InfoDisplay.DPSMeter
+			InfoDisplay.Radar,
+			InfoDisplay.TallyCounter,
+			InfoDisplay.Dummy,
+			InfoDisplay.DPSMeter,
+			InfoDisplay.Stopwatch,
+			InfoDisplay.Compass,
+			InfoDisplay.DepthMeter
 		};
 
 		private static readonly int DefaultDisplayCount = InfoDisplays.Count;


### PR DESCRIPTION
An incredibly small PR which does as the title explains. Vanilla info displays should now be listed in the same order as that in which they are listed in vanilla.