### PR TITLE
New exceptions on invalid drop rule

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/CommonDrop.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/CommonDrop.cs.patch
@@ -1,0 +1,18 @@
+--- src/Terraria/Terraria/GameContent/ItemDropRules/CommonDrop.cs
++++ src/tModLoader/Terraria/GameContent/ItemDropRules/CommonDrop.cs
+@@ -1,3 +_,4 @@
++using System;
+ using System.Collections.Generic;
+ 
+ namespace Terraria.GameContent.ItemDropRules
+@@ -16,6 +_,10 @@
+ 		}
+ 
+ 		public CommonDrop(int itemId, int chanceDenominator, int amountDroppedMinimum = 1, int amountDroppedMaximum = 1, int chanceNumerator = 1) {
++			if (amountDroppedMinimum > amountDroppedMaximum) {
++				throw new ArgumentOutOfRangeException(nameof(amountDroppedMinimum), $"{nameof(amountDroppedMinimum)} must be lesser or equal to {nameof(amountDroppedMaximum)}.");
++			}
++
+ 			this.itemId = itemId;
+ 			this.chanceDenominator = chanceDenominator;
+ 			this.amountDroppedMinimum = amountDroppedMinimum;

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/DropOneByOne.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/DropOneByOne.cs.patch
@@ -1,0 +1,37 @@
+--- src/Terraria/Terraria/GameContent/ItemDropRules/DropOneByOne.cs
++++ src/tModLoader/Terraria/GameContent/ItemDropRules/DropOneByOne.cs
+@@ -1,3 +_,4 @@
++using System;
+ using System.Collections.Generic;
+ 
+ namespace Terraria.GameContent.ItemDropRules
+@@ -19,7 +_,11 @@
+ 		}
+ 
+ 		public int itemId;
+-		public Parameters parameters;
++
++		public Parameters parameters {
++			get;
++			private init;
++		}
+ 
+ 		public List<IItemDropRuleChainAttempt> ChainedRules {
+ 			get;
+@@ -27,6 +_,16 @@
+ 		}
+ 
+ 		public DropOneByOne(int itemId, Parameters parameters) {
++			if (parameters.MinimumItemDropsCount > parameters.MaximumItemDropsCount) {
++				throw new ArgumentException($"{nameof(parameters.MinimumItemDropsCount)} must be lesser or equal to {nameof(parameters.MaximumItemDropsCount)}.", nameof(parameters));
++			}
++			if (parameters.MinimumStackPerChunkBase > parameters.MaximumStackPerChunkBase) {
++				throw new ArgumentException($"{nameof(parameters.MinimumStackPerChunkBase)} must be lesser or equal to {nameof(parameters.MaximumStackPerChunkBase)}.", nameof(parameters));
++			}
++			if (parameters.BonusMinDropsPerChunkPerPlayer > parameters.BonusMaxDropsPerChunkPerPlayer) {
++				throw new ArgumentException($"{nameof(parameters.BonusMinDropsPerChunkPerPlayer)} must be lesser or equal to {nameof(parameters.BonusMaxDropsPerChunkPerPlayer)}.", nameof(parameters));
++			}
++
+ 			ChainedRules = new List<IItemDropRuleChainAttempt>();
+ 			this.parameters = parameters;
+ 			this.itemId = itemId;

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.cs.patch
@@ -44,3 +44,13 @@
  		}
  
  		private void RegisterFoodDrops() {
+@@ -897,7 +_,8 @@
+ 			RegisterToNPC(476, ItemDropRule.Common(2676, 3, 2, 4));
+ 			RegisterToNPC(476, ItemDropRule.Common(2272, 3));
+ 			RegisterToNPC(476, ItemDropRule.Common(4731, 3));
++			//Removed to avoid an exception on load
+-			RegisterToNPC(476, ItemDropRule.Common(4986, 3, 69));
++			//RegisterToNPC(476, ItemDropRule.Common(4986, 3, 69));
+ 			int[] npcNetIds4 = new int[3] {
+ 				473,
+ 				474,


### PR DESCRIPTION
### What is the new feature?
To help people to debug the drop rates, with this PR, all the vanilla drop rules will throw an exception if the minimum amount of something is below the maximum.
This design prevents people from changing the DropOneByOne.parameters during the game, but I believe that if someone is techy enough to want it, they will have a better design by creating a custom class anyway
I also chose to prevent the bonus per chunk per player from reducing the spread to avoid some unexpected bugs with an high number of players