### PR TITLE
Fix Linux SDL2 being loaded from System

### DIFF
--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -1,9 +1,12 @@
+using ReLogic.OS;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Terraria.ModLoader;
 
 namespace Terraria
 {
@@ -25,6 +28,26 @@ namespace Terraria
 			RuntimeHelpers.PrepareMethod(method.MethodHandle);
 
 			Interlocked.Increment(ref ThingsLoaded);
+		}
+
+		/// <summary>
+		/// The Linker on Linux was discovered to be using the SDL2 on the system, instead of the portable included.
+		/// Pointing the Linker to the correct location via LD_LIBRARY_PATH in .sh rectifies this, but also introduces SegFaults from SDL.
+		/// A separately run app suggests through cross comparison that SDL2 is not initialized under this setup. 
+		/// Thus we initialize it ourselves prior to FNA usage - Solxan
+		/// The root issue comes from: https://github.com/dotnet/runtime/issues/34711
+		/// </summary>
+		private static void SDLFixUnix() {
+			if (Platform.IsWindows)
+				return; // Not applicable, windows uses the portable correctly.
+
+			if (Platform.IsOSX)
+				return; // Not observed as an issue.
+
+			if (SDL2.SDL.SDL_INIT_EVERYTHING != SDL2.SDL.SDL_WasInit(SDL2.SDL.SDL_INIT_EVERYTHING)) {
+				Logging.tML.Info("Ensuring SDL2 is initialized prior to FNA usage.");
+				SDL2.SDL.SDL_Init(SDL2.SDL.SDL_INIT_EVERYTHING);
+			}
 		}
 
 		private static void ForceStaticInitializers(Type[] types) {

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -37,14 +37,15 @@ namespace Terraria
 		/// Thus we initialize it ourselves prior to FNA usage - Solxan
 		/// The root issue comes from: https://github.com/dotnet/runtime/issues/34711
 		/// </summary>
-		private static void SDLFixUnix() {
+		private static void SDLFixUnix(bool isServer) {
 			if (Platform.IsWindows)
 				return; // Not applicable, windows uses the portable correctly.
 
 			if (Platform.IsOSX)
 				return; // Not observed as an issue.
 
-			if (SDL2.SDL.SDL_INIT_EVERYTHING != SDL2.SDL.SDL_WasInit(SDL2.SDL.SDL_INIT_EVERYTHING)) {
+			//TODO: Re-add IsServer condition once https://github.com/tModLoader/tModLoader/issues/1632 is fixed
+			if (/*!isServer && */ SDL2.SDL.SDL_INIT_EVERYTHING != SDL2.SDL.SDL_WasInit(SDL2.SDL.SDL_INIT_EVERYTHING)) {
 				Logging.tML.Info("Ensuring SDL2 is initialized prior to FNA usage.");
 				SDL2.SDL.SDL_Init(SDL2.SDL.SDL_INIT_EVERYTHING);
 			}

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -87,7 +87,7 @@
  
  			try {
  				Console.OutputEncoding = Encoding.UTF8;
-@@ -138,32 +_,62 @@
+@@ -138,32 +_,64 @@
  			}
  		}
  
@@ -115,6 +115,8 @@
 +				DisplayException(e);
 +				return;
 +			}
++
++			SDLFixUnix();
 +
 +			LaunchGame_(isServer);
 +		}

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -116,7 +116,7 @@
 +				return;
 +			}
 +
-+			SDLFixUnix();
++			SDLFixUnix(isServer);
 +
 +			LaunchGame_(isServer);
 +		}

--- a/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
+++ b/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
@@ -11,6 +11,14 @@ cd "$script_dir"
 echo "Verifying Net Framework...."
 echo "This may take a few moments."
 
+#Set Environment Variables here to workaround https://github.com/dotnet/runtime/issues/34711 for FNA3D -> SDL2 failing
+if [[ "$(uname)" == Darwin ]]; then
+  # Not known if applies to MacOS, kept here in case
+  #export DYLD_LIBRARY_PATH="$script_dir/Libraries/Native/OSX"
+else
+  export LD_LIBRARY_PATH="$script_dir/Libraries/Native/Linux"
+fi
+
 #Parse version from runtimeconfig, jq would be a better solution here, but its not installed by default on all distros.
 version=$(sed -n 's/^.*"version": "\(.*\)"/\1/p' <tModLoader.runtimeconfig.json) #sed, go die plskthx
 version=${version%$'\r'} # remove trailing carriage return that sed may leave in variable, producing a bad folder name


### PR DESCRIPTION
### What is the bug?
The current behavior of .NetCore is for Native Libraries to load decencies from System installations first on Linux.
This lead to out of date SDL2 being used relative to the requisite version used by the portable.

.NetCore has recorded this issue primarily on: https://github.com/dotnet/runtime/issues/34711

### How did you fix the bug?
Adjusting the LD_Library_Path to be setup in the launch scripts, and adding a forceful call to Init the portable appears to resolve this erroneous lookup.

During testing this, it was suggested that we might need to rename libSDL2-2.0.so.0 to be libSDL2.so. It remains to be seen if this is necessary.

### Are there alternatives to your fix?
