### PR TITLE
Random Assortment of Patches from MacOS testing

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/States/UIWorldLoad.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UIWorldLoad.cs.patch
@@ -1,0 +1,12 @@
+--- src/Terraria/Terraria/GameContent/UI/States/UIWorldLoad.cs
++++ src/tModLoader/Terraria/GameContent/UI/States/UIWorldLoad.cs
+@@ -59,6 +_,9 @@
+ 				text = _progress.Message;
+ 			}
+ 
++			if (text != _progressMessage.Text)
++				ModLoader.Logging.tML.Info(text + "...");
++
+ 			_progressBar.SetProgress(overallProgress, currentProgress);
+ 			_progressMessage.Text = text;
+ 			if (WorldGen.drunkWorldGenText && !WorldGen.placingTraps) {

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -56,6 +56,7 @@ namespace Terraria.ModLoader
 			tML.InfoFormat("Working Directory: {0}", Path.GetFullPath(Directory.GetCurrentDirectory()));
 			tML.InfoFormat("Launch Parameters: {0}", string.Join(' ', Environment.GetCommandLineArgs().Skip(1)));
 			tML.InfoFormat("Parsed Launch Parameters: {0}", string.Join(' ', Program.LaunchParameters.Select(p => ($"{p.Key} {p.Value}").Trim())));
+			tML.InfoFormat("Override Default Thread Stack Size Limit: {0}", Environment.GetEnvironmentVariable("COMPlus_DefaultStackSize"));
 
 			if (ModCompile.DeveloperMode)
 				tML.Info("Developer mode enabled");

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -54,9 +54,16 @@ namespace Terraria.ModLoader
 			tML.InfoFormat("Running on {0} {1} {2}", ReLogic.OS.Platform.Current.Type, FrameworkVersion.Framework, FrameworkVersion.Version);
 			tML.InfoFormat("Executable: {0}", Assembly.GetEntryAssembly().Location);
 			tML.InfoFormat("Working Directory: {0}", Path.GetFullPath(Directory.GetCurrentDirectory()));
-			tML.InfoFormat("Launch Parameters: {0}", string.Join(' ', Environment.GetCommandLineArgs().Skip(1)));
-			tML.InfoFormat("Parsed Launch Parameters: {0}", string.Join(' ', Program.LaunchParameters.Select(p => ($"{p.Key} {p.Value}").Trim())));
-			tML.InfoFormat("Override Default Thread Stack Size Limit: {0}", Environment.GetEnvironmentVariable("COMPlus_DefaultStackSize"));
+
+			string args = string.Join(' ', Environment.GetCommandLineArgs().Skip(1));
+			if (!string.IsNullOrEmpty(args)) {
+				tML.InfoFormat("Launch Parameters: {0}", );
+				tML.InfoFormat("Parsed Launch Parameters: {0}", string.Join(' ', Program.LaunchParameters.Select(p => ($"{p.Key} {p.Value}").Trim())));
+			}
+
+			string stackLimit = Environment.GetEnvironmentVariable("COMPlus_DefaultStackSize");
+			if (!string.IsNullOrEmpty(stackLimit))
+				tML.InfoFormat("Override Default Thread Stack Size Limit: {0}", stackLimit);
 
 			if (ModCompile.DeveloperMode)
 				tML.Info("Developer mode enabled");

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -42,6 +42,7 @@ namespace Terraria.Social.Steam
 		internal class ModManager
 		{
 			internal static bool SteamUser { get; set; } = false;
+			internal static bool SteamAvailable { get; set; } = true;
 			internal static AppId_t thisApp = ModLoader.Engine.Steam.TMLAppID_t;
 
 			protected Callback<DownloadItemResult_t> m_DownloadItemResult;
@@ -49,16 +50,21 @@ namespace Terraria.Social.Steam
 			private PublishedFileId_t itemID;
 
 			internal static void Initialize() {
-				if (!ModLoader.Engine.Steam.IsSteamApp) {
-					// Non-steam tModLoader will use the SteamGameServer to perform Browsing & Downloading
-					GameServer.Init(0x7f000001, 7775, 7774, EServerMode.eServerModeNoAuthentication, "0.11.9.0");
+				// Non-steam tModLoader will use the SteamGameServer to perform Browsing & Downloading
+				if (ModLoader.Engine.Steam.IsSteamApp) {
+					SteamUser = true;
+					return;
+				}
 
+				if (GameServer.Init(0x7f000001, 7775, 7774, EServerMode.eServerModeNoAuthentication, "0.11.9.0")) {
 					SteamGameServer.SetGameDescription("tModLoader Mod Browser");
 					SteamGameServer.SetProduct(thisApp.ToString());
 					SteamGameServer.LogOnAnonymous();
 				}
-				else
-					SteamUser = true;
+				else {
+					Logging.tML.Error("Steam Game Server failed to Init. Steam Workshop downloading on GoG is unavailable. Make sure Steam is installed");
+					SteamAvailable = false;
+				}
 			}
 
 			internal ModManager(PublishedFileId_t itemID) {
@@ -292,6 +298,9 @@ namespace Terraria.Social.Steam
 				incompleteModCount = 0;
 				items = new List<UIModDownloadItem>();
 				LocalMod[] installedMods = ModOrganizer.FindMods();
+
+				if (!ModManager.SteamAvailable)
+					return false;
 
 				do {
 					QueryForPage(++queryPage);

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -120,7 +120,7 @@
  					_issueReporter = issueReporter;
  					_endAction = endAction;
  					_createItemHook = CallResult<CreateItemResult_t>.Create(CreateItemResult);
-@@ -171,7 +_,8 @@
+@@ -171,19 +_,31 @@
  						ContentFolderPath = contentFolderPath,
  						Tags = tags,
  						PreviewImagePath = previewImagePath,
@@ -129,8 +129,18 @@
 +						BuildData = buildData
  					};
  
++					if (!File.Exists(previewImagePath)) {
++						_issueReporter.ReportInstantUploadProblem("Workshop.ReportIssue_FailedToPublish_CouldNotFindFolderToUpload" + " NoPreviewImage");
++						return;
++					}
++					else if (!Directory.Exists(contentFolderPath)) {
++						_issueReporter.ReportInstantUploadProblem("Workshop.ReportIssue_FailedToPublish_CouldNotFindFolderToUpload" + " NoContentFolder");
++						return;
++					}
++
  					ulong? num = null;
-@@ -180,10 +_,12 @@
+ 					if (AWorkshopEntry.TryReadingManifest(contentFolderPath + Path.DirectorySeparatorChar + "workshop.json", out FoundWorkshopEntryInfo info))
+ 						num = info.workshopEntryId;
  
  					if (num.HasValue && finder.HasItemOfId(num.Value)) {
  						_publishedFileID = new PublishedFileId_t(num.Value);

--- a/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
+++ b/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
@@ -22,6 +22,9 @@ else
   ln -sf "$library_dir/libSDL2-2.0.so.0" "$library_dir/libSDL2.so"
 fi
 
+# Ensure sufficient stack size on MacOS secondary threads, doesn't hurt for Linux
+export COMPlus_DefaultStackSize=4000000
+
 #Parse version from runtimeconfig, jq would be a better solution here, but its not installed by default on all distros.
 version=$(sed -n 's/^.*"version": "\(.*\)"/\1/p' <tModLoader.runtimeconfig.json) #sed, go die plskthx
 version=${version%$'\r'} # remove trailing carriage return that sed may leave in variable, producing a bad folder name

--- a/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
+++ b/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
@@ -15,15 +15,17 @@ echo "This may take a few moments."
 # Additionally, something in dotnet is requesting 'libSDL2.so' (instead of 'libSDL2-2.0.so.0' that is specified in dependencies)
 # without actually invoking managed NativeLibrary resolving events!
 if [[ "$(uname)" == Darwin ]]; then
-  export DYLD_LIBRARY_PATH="$script_dir/Libraries/Native/OSX"
+  library_dir="$script_dir/Libraries/Native/OSX"
+  export DYLD_LIBRARY_PATH="$$library_dir"
+  ln -sf "$library_dir/libSDL2-2.0.0.dylib" "$library_dir/libSDL2.dylib"
 else
   library_dir="$script_dir/Libraries/Native/Linux"
   export LD_LIBRARY_PATH="$library_dir"
   ln -sf "$library_dir/libSDL2-2.0.so.0" "$library_dir/libSDL2.so"
 fi
 
-# Ensure sufficient stack size on MacOS secondary threads, doesn't hurt for Linux
-export COMPlus_DefaultStackSize=4000000
+# Ensure sufficient stack size (4MB) on MacOS secondary threads, doesn't hurt for Linux. 16^5 = 1MB, value in hex 
+export COMPlus_DefaultStackSize=400000
 
 #Parse version from runtimeconfig, jq would be a better solution here, but its not installed by default on all distros.
 version=$(sed -n 's/^.*"version": "\(.*\)"/\1/p' <tModLoader.runtimeconfig.json) #sed, go die plskthx

--- a/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
+++ b/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
@@ -16,7 +16,7 @@ echo "This may take a few moments."
 # without actually invoking managed NativeLibrary resolving events!
 if [[ "$(uname)" == Darwin ]]; then
   library_dir="$script_dir/Libraries/Native/OSX"
-  export DYLD_LIBRARY_PATH="$$library_dir"
+  export DYLD_LIBRARY_PATH="$library_dir"
   ln -sf "$library_dir/libSDL2-2.0.0.dylib" "$library_dir/libSDL2.dylib"
 else
   library_dir="$script_dir/Libraries/Native/Linux"


### PR DESCRIPTION
export COMPlus_DefaultStackSize=4000000 so that the default secondary thread MacOS stack limit of 512kb becomes 4MB and add logging for it being received (untested if it fixes Mac stack size issues)

update Workshop Publisher to error on missing icon/content folder prior to upload instead of during

add logging worldgen stage to log file for easier debugging

update SteamGameServer.Init to actually use its bool return and path better.

update the logging around launch parameters so that if none are used, it doesn't show up in the log 

update the Mac library look change to also include creating the symlink so as to avoid the SegFault issues seen on Linux re-occuring.