### PR TITLE
Update InstallNetFramework.sh to fix Mac Launching FNA3D/SDL crash

### DIFF
--- a/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
+++ b/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
@@ -14,18 +14,17 @@ echo "This may take a few moments."
 # The following is a workaround for the system's SDL2 library being preferred by the linkers for some reason.
 # Additionally, something in dotnet is requesting 'libSDL2.so' (instead of 'libSDL2-2.0.so.0' that is specified in dependencies)
 # without actually invoking managed NativeLibrary resolving events!
+# Ensure sufficient stack size (4MB) on MacOS secondary threads. 16^5 = 1MB, value in hex 
 if [[ "$(uname)" == Darwin ]]; then
-  library_dir="$script_dir/Libraries/Native/OSX"
-  export DYLD_LIBRARY_PATH="$library_dir"
-  ln -sf "$library_dir/libSDL2-2.0.0.dylib" "$library_dir/libSDL2.dylib"
+  export COMPlus_DefaultStackSize=400000
 else
   library_dir="$script_dir/Libraries/Native/Linux"
   export LD_LIBRARY_PATH="$library_dir"
   ln -sf "$library_dir/libSDL2-2.0.so.0" "$library_dir/libSDL2.so"
 fi
 
-# Ensure sufficient stack size (4MB) on MacOS secondary threads, doesn't hurt for Linux. 16^5 = 1MB, value in hex 
-export COMPlus_DefaultStackSize=400000
+
+
 
 #Parse version from runtimeconfig, jq would be a better solution here, but its not installed by default on all distros.
 version=$(sed -n 's/^.*"version": "\(.*\)"/\1/p' <tModLoader.runtimeconfig.json) #sed, go die plskthx

--- a/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
+++ b/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
@@ -23,9 +23,6 @@ else
   ln -sf "$library_dir/libSDL2-2.0.so.0" "$library_dir/libSDL2.so"
 fi
 
-
-
-
 #Parse version from runtimeconfig, jq would be a better solution here, but its not installed by default on all distros.
 version=$(sed -n 's/^.*"version": "\(.*\)"/\1/p' <tModLoader.runtimeconfig.json) #sed, go die plskthx
 version=${version%$'\r'} # remove trailing carriage return that sed may leave in variable, producing a bad folder name


### PR DESCRIPTION
The changing LibraryPath was just failing entirely, even with symlink.
Needs further thought. Can tackle later, have it running first as is.

I'll leave an issue to "Verify and ensure SDL launches from the portable on MacOS" so that it isn't forgotten.
