### PR TITLE
Workshop fixes

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/States/AWorkshopPublishInfoState.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/AWorkshopPublishInfoState.cs.patch
@@ -37,6 +37,25 @@
  		}
  
  		public override void OnInitialize() {
+@@ -77,13 +_,12 @@
+ 		}
+ 
+ 		private void SetDefaultOptions() {
+-			_optionPublicity = WorkshopItemPublicSettingId.Public;
+-			GroupOptionButton<WorkshopItemPublicSettingId>[] publicityOptions = _publicityOptions;
+-			for (int i = 0; i < publicityOptions.Length; i++) {
+-				publicityOptions[i].SetCurrentOption(_optionPublicity);
+-			}
+-
+ 			SetTagsFromFoundEntry();
++			GroupOptionButton<WorkshopItemPublicSettingId>[] publicityOptions = _publicityOptions;
++			for (int i = 0; i < publicityOptions.Length; i++) {
++				publicityOptions[i].SetCurrentOption(_optionPublicity);
++			}
++
+ 			UpdateImagePreview();
+ 		}
+ 
 @@ -96,6 +_,11 @@
  			uIElement.SetPadding(0f);
  			uiList.Add(uIElement);
@@ -49,6 +68,18 @@
  			uiList.Add(CreatePreviewImageSelectionPanel("image"));
  			uiList.Add(CreatePublicSettingsRow(0f, 44f, "public"));
  			uiList.Add(CreateTagOptionsPanel(0f, 44, "tags"));
+@@ -163,10 +_,7 @@
+ 				}
+ 			}
+ 
+-			GroupOptionButton<WorkshopItemPublicSettingId>[] publicityOptions = _publicityOptions;
+-			for (int i = 0; i < publicityOptions.Length; i++) {
+-				publicityOptions[i].SetCurrentOption(info.publicity);
+-			}
++			_optionPublicity = info.publicity;
+ 		}
+ 
+ 		protected abstract bool TryFindingTags(out FoundWorkshopEntryInfo info);
 @@ -232,7 +_,7 @@
  		}
  

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModDownloadItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModDownloadItem.cs
@@ -295,7 +295,7 @@ namespace Terraria.ModLoader.UI.ModBrowser
 							Left = { Percent = 0f },
 							Top = { Percent = 0f },
 							Width = { Pixels = 80f },
-							Height = {Pixels = 80f}
+							Height = { Pixels = 80f }
 						};
 						_modIconStatus = ModIconStatus.READY;
 						success = true;

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModDownloadItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModDownloadItem.cs
@@ -293,7 +293,9 @@ namespace Terraria.ModLoader.UI.ModBrowser
 
 						_modIcon = new UIImage(iconTexture) {
 							Left = { Percent = 0f },
-							Top = { Percent = 0f }
+							Top = { Percent = 0f },
+							Width = { Pixels = 80f },
+							Height = {Pixels = 80f}
 						};
 						_modIconStatus = ModIconStatus.READY;
 						success = true;

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModDownloadItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModDownloadItem.cs
@@ -294,8 +294,9 @@ namespace Terraria.ModLoader.UI.ModBrowser
 						_modIcon = new UIImage(iconTexture) {
 							Left = { Percent = 0f },
 							Top = { Percent = 0f },
-							Width = { Pixels = 80f },
-							Height = { Pixels = 80f }
+							MaxWidth = { Pixels = 80f, Percent = 0f },
+							MaxHeight = { Pixels = 80f, Percent = 0f },
+							ScaleToFit = true
 						};
 						_modIconStatus = ModIconStatus.READY;
 						success = true;

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -430,7 +430,7 @@ namespace Terraria.Social.Steam
 								update = updateIsDowngrade = true;
 						}
 
-						items.Add(new UIModDownloadItem(displayname, metadata["name"], cVersion.ToString(), metadata["author"], metadata["modreferences"], modside, modIconURL, id.m_PublishedFileId.ToString(), (int)downloads, (int)hot, lastUpdate.ToString(), update, updateIsDowngrade, installed, metadata["modloaderversion"], metadata["homepage"], i));
+						items.Add(new UIModDownloadItem(displayname, metadata["name"], cVersion.ToString(), metadata["author"], metadata["modreferences"], modside, modIconURL, id.m_PublishedFileId.ToString(), (int)downloads, (int)hot, lastUpdate.ToString(), update, updateIsDowngrade, installed, metadata["modloaderversion"], metadata["homepage"], (queryPage - 1) * 50 + i));
 					}
 					ReleaseWorkshopQuery();
 				} while (_queryReturnCount == Steamworks.Constants.kNumUGCResultsPerPage); // 50 is based on kNumUGCResultsPerPage constant in ISteamUGC. Can't find constant itself? - Solxan

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -111,7 +111,7 @@
  							}
  							else {
  								WorldPaths.Add(listOfSubscribedItemsPath);
-@@ -159,7 +_,7 @@
+@@ -159,11 +_,12 @@
  				private FinishedPublishingAction _endAction;
  				private WorkshopIssueReporter _issueReporter;
  
@@ -120,6 +120,11 @@
  					_issueReporter = issueReporter;
  					_endAction = endAction;
  					_createItemHook = CallResult<CreateItemResult_t>.Create(CreateItemResult);
+ 					_updateItemHook = CallResult<SubmitItemUpdateResult_t>.Create(UpdateItemResult);
++					_publicity = publicity;
+ 					ERemoteStoragePublishedFileVisibility visibility = GetVisibility(publicity);
+ 					_entryData = new SteamWorkshopItem {
+ 						Title = itemTitle,
 @@ -171,19 +_,31 @@
  						ContentFolderPath = contentFolderPath,
  						Tags = tags,


### PR DESCRIPTION
### What is the bug?
Vanilla workshop supports images up to 512x512 and have an annoying bug where the workshop visibility defaults to private is the upload is an update.
The correct info could only be shown to mods being in the first page, as only the info of the first page could be shown.

### How did you fix the bug?
To not break the vanilla workshop, I made so that mod icons would always be resized to 80x80 in the mod browser.
The workshop visibility now works as intended, I guess it will also fix the bug on vanilla upload as the base code is the same, though any mod published before this fix is implemented will need another update before working properly (as the publicity data is missing from the header).
For the info, I added the page shift to fetch the correct info.

### Are there alternatives to your fix?
For the mod icon, upload could be limited at 80x80, but I don't see the point as a better resolution can be shown on the steam workshop.
For the workshop visibility, I don't think so.
For the info, no.