### PR TITLE
Fixed issue where Mod Browser sorting by recent did not work.

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModDownloadItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModDownloadItem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -171,7 +172,17 @@ namespace Terraria.ModLoader.UI.ModBrowser
 				case ModBrowserSortMode.DownloadsDescending:
 					return -1 * _downloads.CompareTo(item?._downloads);
 				case ModBrowserSortMode.RecentlyUpdated:
-					return -1 * string.Compare(_timeStamp, item?._timeStamp, StringComparison.Ordinal);
+					// If the downloaded mod doesn't have a timestamp for whatever reason, it should be last.
+					if (item == null)
+						return -1;
+
+					// Mod timestamps are formatted via en-us standard (MM/DD/YYYY H/MM/SS TT).
+					CultureInfo cultureInfo = CultureInfo.GetCultureInfo("en-us");
+
+					DateTime timeStamp = DateTime.Parse(_timeStamp, cultureInfo);
+					DateTime comparedTimeStamp = DateTime.Parse(item?._timeStamp, cultureInfo);
+
+					return -1 * timeStamp.CompareTo(comparedTimeStamp);
 				case ModBrowserSortMode.Hot:
 					return -1 * _hot.CompareTo(item?._hot);
 			}


### PR DESCRIPTION
### What is the bug?
Fix #1682.

### How did you fix the bug?
Changed the way the timestamps are compared. I didn't look much into it, but it seems like the timestamps returned by the Steam Workshop are in a human-readable format, whereas the Mod Browser returned a Unix timestamp, This means the comparison (which was by string ordinal originally) broke when the format changed.

This fix just parses the timestamp into a `DateTime` object so that they can be compared properly.

### Are there alternatives to your fix?
No.