### PR TITLE
[1.4] Quick fix to minion shots being able to critically strike

### DIFF
--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -258,7 +258,7 @@
  											flag6 = true;
 +										*/
 +
-+										if (!minion && Main.rand.Next(100) < Main.player[owner].GetWeaponCrit(Main.player[owner].HeldItem))
++										if (!(minion || ProjectileID.Sets.MinionShot[type]) && Main.rand.Next(100) < Main.player[owner].GetWeaponCrit(Main.player[owner].HeldItem))
 +											flag6 = true;
  
  										int num12 = type;


### PR DESCRIPTION
technically a holdover fix until I properly set up a system for this but until then have a 2-second fix