### PR TITLE
1.4 RecipeIndex fix (again)

### DIFF
--- a/patches/tModLoader/Terraria/Recipe.Extensions.cs
+++ b/patches/tModLoader/Terraria/Recipe.Extensions.cs
@@ -127,6 +127,8 @@ namespace Terraria
 		public bool RemoveCondition(Condition condition) => Conditions.Remove(condition);
 
 		public bool RemoveRecipe() {
+			if (!RecipeLoader.setupRecipes)
+				throw new RecipeException("A Recipe can only be deleted inside recipe related methods");
 			if (Main.recipe[RecipeIndex] != this)
 				return false;
 			for (int j = RecipeIndex; j < numRecipes - 1; j++) {

--- a/patches/tModLoader/Terraria/Recipe.Extensions.cs
+++ b/patches/tModLoader/Terraria/Recipe.Extensions.cs
@@ -127,19 +127,17 @@ namespace Terraria
 		public bool RemoveCondition(Condition condition) => Conditions.Remove(condition);
 
 		public bool RemoveRecipe() {
-			for (int k = 0; k < numRecipes; k++) {
-				if (Main.recipe[k] == this) {
-					for (int j = k; j < numRecipes - 1; j++) {
-						Main.recipe[j] = Main.recipe[j + 1];
-					}
-
-					Main.recipe[numRecipes - 1] = new Recipe();
-					numRecipes--;
-					return true;
-				}
+			if (Main.recipe[RecipeIndex] == this)
+				return false;
+			for (int j = RecipeIndex; j < numRecipes - 1; j++) {
+				Recipe recipe = Main.recipe[j + 1];
+				Main.recipe[j] = recipe;
+				recipe.RecipeIndex--;
 			}
 
-			return false;
+			Main.recipe[numRecipes - 1] = new Recipe();
+			numRecipes--;
+			return true;
 		}
 		#endregion
 

--- a/patches/tModLoader/Terraria/Recipe.Extensions.cs
+++ b/patches/tModLoader/Terraria/Recipe.Extensions.cs
@@ -127,7 +127,7 @@ namespace Terraria
 		public bool RemoveCondition(Condition condition) => Conditions.Remove(condition);
 
 		public bool RemoveRecipe() {
-			if (Main.recipe[RecipeIndex] == this)
+			if (Main.recipe[RecipeIndex] != this)
 				return false;
 			for (int j = RecipeIndex; j < numRecipes - 1; j++) {
 				Recipe recipe = Main.recipe[j + 1];

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -157,24 +157,6 @@
  				if (num <= 0)
  					continue;
  
-@@ -137,7 +_,7 @@
- 					if (num <= 0)
- 						break;
- 
--					if (item.IsTheSameAs(item2) || useWood(item.type, item2.type) || useSand(item.type, item2.type) || useFragment(item.type, item2.type) || useIronBar(item.type, item2.type) || usePressurePlate(item.type, item2.type) || AcceptedByItemGroups(item.type, item2.type)) {
-+					if (item.IsTheSameAs(item2) || AcceptedByItemGroups(item.type, item2.type)) {
- 						if (item.stack > num) {
- 							item.stack -= num;
- 							num = 0;
-@@ -168,7 +_,7 @@
- 					if (num <= 0)
- 						break;
- 
--					if (!item.IsTheSameAs(item2) && !useWood(item.type, item2.type) && !useSand(item.type, item2.type) && !useIronBar(item.type, item2.type) && !usePressurePlate(item.type, item2.type) && !useFragment(item.type, item2.type) && !AcceptedByItemGroups(item.type, item2.type))
-+					if (!item.IsTheSameAs(item2) && !AcceptedByItemGroups(item.type, item2.type))
- 						continue;
- 
- 					if (item.stack > num) {
 @@ -192,7 +_,7 @@
  			FindRecipes();
  		}
@@ -220,17 +202,15 @@
  			if (!anyPressurePlate)
  				return false;
  
-@@ -309,8 +_,8 @@
+@@ -309,7 +_,7 @@
  			Main.numAvailableRecipes = 0;
  			if (Main.guideItem.type > 0 && Main.guideItem.stack > 0 && Main.guideItem.Name != "") {
  				for (int j = 0; j < maxRecipes && Main.recipe[j].createItem.type != 0; j++) {
 -					for (int k = 0; k < maxRequirements && Main.recipe[j].requiredItem[k].type != 0; k++) {
--						if (Main.guideItem.IsTheSameAs(Main.recipe[j].requiredItem[k]) || Main.recipe[j].useWood(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].useSand(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].useIronBar(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].useFragment(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].AcceptedByItemGroups(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].usePressurePlate(Main.guideItem.type, Main.recipe[j].requiredItem[k].type)) {
 +					for (int k = 0; k < Main.recipe[j].requiredItem.Count; k++) {
-+						if (Main.guideItem.IsTheSameAs(Main.recipe[j].requiredItem[k]) || Main.recipe[j].AcceptedByItemGroups(Main.guideItem.type, Main.recipe[j].requiredItem[k].type)) {
+ 						if (Main.guideItem.IsTheSameAs(Main.recipe[j].requiredItem[k]) || Main.recipe[j].useWood(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].useSand(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].useIronBar(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].useFragment(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].AcceptedByItemGroups(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].usePressurePlate(Main.guideItem.type, Main.recipe[j].requiredItem[k].type)) {
  							Main.availableRecipe[Main.numAvailableRecipes] = j;
  							Main.numAvailableRecipes++;
- 							break;
 @@ -359,7 +_,7 @@
  				for (int n = 0; n < maxRecipes && Main.recipe[n].createItem.type != 0; n++) {
  					bool flag = true;
@@ -240,7 +220,7 @@
  							if (!Main.player[Main.myPlayer].adjTile[Main.recipe[n].requiredTile[num3]]) {
  								flag = false;
  								break;
-@@ -368,15 +_,13 @@
+@@ -368,10 +_,8 @@
  					}
  
  					if (flag) {
@@ -252,12 +232,6 @@
  
  							int num5 = item.stack;
  							bool flag2 = false;
- 							foreach (int key in dictionary.Keys) {
--								if (Main.recipe[n].useWood(key, item.type) || Main.recipe[n].useSand(key, item.type) || Main.recipe[n].useIronBar(key, item.type) || Main.recipe[n].useFragment(key, item.type) || Main.recipe[n].AcceptedByItemGroups(key, item.type) || Main.recipe[n].usePressurePlate(key, item.type)) {
-+								if (Main.recipe[n].AcceptedByItemGroups(key, item.type)) {
- 									num5 -= dictionary[key];
- 									flag2 = true;
- 								}
 @@ -393,7 +_,7 @@
  					}
  

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -157,6 +157,24 @@
  				if (num <= 0)
  					continue;
  
+@@ -137,7 +_,7 @@
+ 					if (num <= 0)
+ 						break;
+ 
+-					if (item.IsTheSameAs(item2) || useWood(item.type, item2.type) || useSand(item.type, item2.type) || useFragment(item.type, item2.type) || useIronBar(item.type, item2.type) || usePressurePlate(item.type, item2.type) || AcceptedByItemGroups(item.type, item2.type)) {
++					if (item.IsTheSameAs(item2) || AcceptedByItemGroups(item.type, item2.type)) {
+ 						if (item.stack > num) {
+ 							item.stack -= num;
+ 							num = 0;
+@@ -168,7 +_,7 @@
+ 					if (num <= 0)
+ 						break;
+ 
+-					if (!item.IsTheSameAs(item2) && !useWood(item.type, item2.type) && !useSand(item.type, item2.type) && !useIronBar(item.type, item2.type) && !usePressurePlate(item.type, item2.type) && !useFragment(item.type, item2.type) && !AcceptedByItemGroups(item.type, item2.type))
++					if (!item.IsTheSameAs(item2) && !AcceptedByItemGroups(item.type, item2.type))
+ 						continue;
+ 
+ 					if (item.stack > num) {
 @@ -192,7 +_,7 @@
  			FindRecipes();
  		}
@@ -202,15 +220,17 @@
  			if (!anyPressurePlate)
  				return false;
  
-@@ -309,7 +_,7 @@
+@@ -309,8 +_,8 @@
  			Main.numAvailableRecipes = 0;
  			if (Main.guideItem.type > 0 && Main.guideItem.stack > 0 && Main.guideItem.Name != "") {
  				for (int j = 0; j < maxRecipes && Main.recipe[j].createItem.type != 0; j++) {
 -					for (int k = 0; k < maxRequirements && Main.recipe[j].requiredItem[k].type != 0; k++) {
+-						if (Main.guideItem.IsTheSameAs(Main.recipe[j].requiredItem[k]) || Main.recipe[j].useWood(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].useSand(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].useIronBar(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].useFragment(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].AcceptedByItemGroups(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].usePressurePlate(Main.guideItem.type, Main.recipe[j].requiredItem[k].type)) {
 +					for (int k = 0; k < Main.recipe[j].requiredItem.Count; k++) {
- 						if (Main.guideItem.IsTheSameAs(Main.recipe[j].requiredItem[k]) || Main.recipe[j].useWood(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].useSand(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].useIronBar(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].useFragment(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].AcceptedByItemGroups(Main.guideItem.type, Main.recipe[j].requiredItem[k].type) || Main.recipe[j].usePressurePlate(Main.guideItem.type, Main.recipe[j].requiredItem[k].type)) {
++						if (Main.guideItem.IsTheSameAs(Main.recipe[j].requiredItem[k]) || Main.recipe[j].AcceptedByItemGroups(Main.guideItem.type, Main.recipe[j].requiredItem[k].type)) {
  							Main.availableRecipe[Main.numAvailableRecipes] = j;
  							Main.numAvailableRecipes++;
+ 							break;
 @@ -359,7 +_,7 @@
  				for (int n = 0; n < maxRecipes && Main.recipe[n].createItem.type != 0; n++) {
  					bool flag = true;
@@ -220,7 +240,7 @@
  							if (!Main.player[Main.myPlayer].adjTile[Main.recipe[n].requiredTile[num3]]) {
  								flag = false;
  								break;
-@@ -368,10 +_,8 @@
+@@ -368,15 +_,13 @@
  					}
  
  					if (flag) {
@@ -232,6 +252,12 @@
  
  							int num5 = item.stack;
  							bool flag2 = false;
+ 							foreach (int key in dictionary.Keys) {
+-								if (Main.recipe[n].useWood(key, item.type) || Main.recipe[n].useSand(key, item.type) || Main.recipe[n].useIronBar(key, item.type) || Main.recipe[n].useFragment(key, item.type) || Main.recipe[n].AcceptedByItemGroups(key, item.type) || Main.recipe[n].usePressurePlate(key, item.type)) {
++								if (Main.recipe[n].AcceptedByItemGroups(key, item.type)) {
+ 									num5 -= dictionary[key];
+ 									flag2 = true;
+ 								}
 @@ -393,7 +_,7 @@
  					}
  

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -95,7 +95,7 @@
  					theText = RecipeGroup.recipeGroups[num].GetText();
  					return true;
  				}
-@@ -82,35 +_,34 @@
+@@ -82,35 +_,35 @@
  			return false;
  		}
  
@@ -133,6 +133,7 @@
 +
 +		internal Recipe(Mod mod = null) {
 +			Mod = mod;
++			RecipeIndex = -1;
  		}
  
  		public void Create() {
@@ -287,7 +288,7 @@
  				Item item = new Item();
  				item.SetDefaults(i, noMatCheck: true);
  				item.checkMat();
-@@ -14185,14 +_,12 @@
+@@ -14185,22 +_,23 @@
  		private static void CreateReversePlatformRecipes() {
  			int num = numRecipes;
  			for (int i = 0; i < num; i++) {
@@ -304,7 +305,19 @@
  
  					AddRecipe();
  					Recipe recipe = Main.recipe[numRecipes - 1];
-@@ -14208,14 +_,12 @@
+ 					for (int num2 = numRecipes - 2; num2 > i; num2--) {
+-						Main.recipe[num2 + 1] = Main.recipe[num2];
++						Recipe switchedRecipe = Main.recipe[num2];
++						Main.recipe[num2 + 1] = switchedRecipe;
++						switchedRecipe.RecipeIndex = num2 + 1;
+ 					}
+ 
+ 					Main.recipe[i + 1] = recipe;
++					recipe.RecipeIndex = i + 1;
+ 				}
+ 			}
+ 		}
+@@ -14208,27 +_,29 @@
  		private static void CreateReverseWallRecipes() {
  			int num = numRecipes;
  			for (int i = 0; i < num; i++) {
@@ -321,7 +334,15 @@
  
  					AddRecipe();
  					Recipe recipe = Main.recipe[numRecipes - 1];
-@@ -14227,8 +_,9 @@
+ 					for (int num2 = numRecipes - 2; num2 > i; num2--) {
+-						Main.recipe[num2 + 1] = Main.recipe[num2];
++						Recipe switchedRecipe = Main.recipe[num2];
++						Main.recipe[num2 + 1] = switchedRecipe;
++						switchedRecipe.RecipeIndex = num2 + 1;
+ 					}
+ 
+ 					Main.recipe[i + 1] = recipe;
++					recipe.RecipeIndex = i + 1;
  				}
  			}
  		}
@@ -333,7 +354,7 @@
  			if (ingridients.Length == 1) {
  				ingridients = new int[2] {
  					ingridients[0],
-@@ -14246,18 +_,59 @@
+@@ -14246,19 +_,59 @@
  			}
  		}
  
@@ -384,6 +405,7 @@
  			Main.recipe[numRecipes] = currentRecipe;
 -			currentRecipe = new Recipe();
 +			currentRecipe.RecipeIndex = numRecipes;
+ 			numRecipes++;
 +			
 +			// The following resets the currentRecipe field
 +			currentRecipe = new Recipe {
@@ -394,7 +416,6 @@
 +
 +			for (int i = 0; i < maxVanillaRequirements; i++)
 +				currentRecipe.requiredItem.Add(new Item());
-+
- 			numRecipes++;
  		}
  
+ 		public static int GetRequiredTileStyle(int tileID) {

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -380,7 +380,7 @@
  			if (ingridients.Length == 1) {
  				ingridients = new int[2] {
  					ingridients[0],
-@@ -14246,19 +_,59 @@
+@@ -14246,18 +_,59 @@
  			}
  		}
  
@@ -431,7 +431,6 @@
  			Main.recipe[numRecipes] = currentRecipe;
 -			currentRecipe = new Recipe();
 +			currentRecipe.RecipeIndex = numRecipes;
- 			numRecipes++;
 +			
 +			// The following resets the currentRecipe field
 +			currentRecipe = new Recipe {
@@ -442,6 +441,7 @@
 +
 +			for (int i = 0; i < maxVanillaRequirements; i++)
 +				currentRecipe.requiredItem.Add(new Item());
++
+ 			numRecipes++;
  		}
  
- 		public static int GetRequiredTileStyle(int tileID) {


### PR DESCRIPTION
### What is the bug?
RecipeIndex was inaccurate, this PR aims to fix it (and I think this time will be the one).

### How did you fix the bug?
Added the RecipeIndex shift in the three methods switching the recipes.

### Also
Some part of the code was hard to read so I removed all the parts using the now useless UseX.
As RecipeIndex allows to directly find the Recipe, I used it in the Recipe.RemoveRecipe instead of checking every recipe to find it.