### PR TITLE
[1.4 Support bugs] Many Batch and Workshop Cleanup

### DIFF
--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -39,6 +39,15 @@ namespace Terraria.Social.Steam
 			GameServer.Shutdown();
 		}
 
+		internal static void ForceCallbacks() {
+			Thread.Sleep(5);
+
+			if (ModManager.SteamUser)
+				SteamAPI.RunCallbacks();
+			else
+				GameServer.RunCallbacks();
+		}
+
 		internal class ModManager
 		{
 			internal static bool SteamUser { get; set; } = false;
@@ -98,7 +107,7 @@ namespace Terraria.Social.Steam
 				var mod = new ModManager(new PublishedFileId_t(ulong.Parse(item.PublishId)));
 				
 				uiProgress?.PrepUIForDownload(item.DisplayName);
-				mod.InnerDownload(uiProgress);
+				mod.InnerDownload(uiProgress, item.HasUpdate);
 
 				if (counter == items.Count)
 					uiProgress?.Leave();
@@ -111,10 +120,10 @@ namespace Terraria.Social.Steam
 			/// <summary>
 			/// Updates and/or Downloads the Item specified when generating the ModManager Instance.
 			/// </summary>
-			private bool InnerDownload(UIWorkshopDownload uiProgress) {
+			private bool InnerDownload(UIWorkshopDownload uiProgress, bool mbHasUpdate) {
 				downloadResult = EResult.k_EResultOK;
 
-				if (NeedsUpdate()) {
+				if (NeedsUpdate() || mbHasUpdate) {
 					downloadResult = EResult.k_EResultNone;
 
 					if (SteamUser)
@@ -404,18 +413,7 @@ namespace Terraria.Social.Steam
 						}
 
 						// Calculate the Mod Browser Version
-						System.Version cVersion = new System.Version(metadata["version"].Substring(1));
-
-						/* This doesn't work, or make sense.
-						// Prioritize version information found in the display name, for automation purposes.
-						int findVersion = displayname.LastIndexOf("v") + 1;
-						if (findVersion > 0) {
-							string possibleVersion = displayname.Substring(findVersion);
-							if (possibleVersion.Contains(".")) {
-								cVersion = new System.Version(possibleVersion);
-							}
-						}
-						*/
+						System.Version cVersion = new System.Version(metadata["version"].Replace("v", ""));
 
 						// Check against installed mods
 						bool update = false;
@@ -466,12 +464,7 @@ namespace Terraria.Social.Steam
 
 				do {
 					// Do Pretty Stuff if want here
-					Thread.Sleep(5);
-
-					if (ModManager.SteamUser) 
-						SteamAPI.RunCallbacks();
-					else
-						GameServer.RunCallbacks();
+					ForceCallbacks();
 				}
 				while (_primaryQueryResult == EResult.k_EResultNone);
 			}

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -244,7 +244,13 @@ namespace Terraria.Social.Steam
 					return SteamGameServerUGC.GetItemState(itemID);
 			}
 
-			public bool IsInstalled() => (GetState() & (uint)EItemState.k_EItemStateInstalled) != 0;
+			public bool IsInstalled() {
+				var currState = GetState();
+				
+				bool installed = (currState & (uint)(EItemState.k_EItemStateInstalled)) != 0;
+				bool downloading = (currState & ((uint)EItemState.k_EItemStateDownloading + (uint)EItemState.k_EItemStateDownloadPending)) != 0;
+				return installed && !downloading;
+			}
 
 			public bool NeedsUpdate() {
 				var currState = GetState();

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -125,7 +125,7 @@
  					ERemoteStoragePublishedFileVisibility visibility = GetVisibility(publicity);
  					_entryData = new SteamWorkshopItem {
  						Title = itemTitle,
-@@ -171,19 +_,31 @@
+@@ -171,19 +_,32 @@
  						ContentFolderPath = contentFolderPath,
  						Tags = tags,
  						PreviewImagePath = previewImagePath,
@@ -147,7 +147,9 @@
  					if (AWorkshopEntry.TryReadingManifest(contentFolderPath + Path.DirectorySeparatorChar + "workshop.json", out FoundWorkshopEntryInfo info))
  						num = info.workshopEntryId;
  
- 					if (num.HasValue && finder.HasItemOfId(num.Value)) {
++					// If it has a publish ID, it has to be yours. Removing vanilla finder check to avoid dupes - Solxan
+-					if (num.HasValue && finder.HasItemOfId(num.Value)) {
++					if (num.HasValue /* finder.HasItemOfId(num.Value)*/) {
  						_publishedFileID = new PublishedFileId_t(num.Value);
 +						if (buildData == null) {
 -						PreventUpdatingCertainThings();
@@ -160,7 +162,43 @@
  						CreateItem();
  					}
  				}
-@@ -240,10 +_,10 @@
+@@ -205,6 +_,8 @@
+ 				}
+ 
+ 				private void CreateItem() {
++					Logging.tML.Info("Creating Item " + _entryData.Title);
++
+ 					CoreSocialModule.SetSkipPulsing(shouldSkipPausing: true);
+ 					SteamAPICall_t hAPICall = SteamUGC.CreateItem(SteamUtils.GetAppID(), EWorkshopFileType.k_EWorkshopFileTypeFirst);
+ 					_createItemHook.Set(hAPICall, CreateItemResult);
+@@ -212,11 +_,13 @@
+ 				}
+ 
+ 				private void CreateItemResult(CreateItemResult_t param, bool bIOFailure) {
++					// This call can lead to creating a bunch of empty items due to failing to write the Manifest.json contents. Removing it here minimizes duplicates on rapid/repeated errored publishing - Solxan
+-					if (param.m_bUserNeedsToAcceptWorkshopLegalAgreement) {
++					/* if (param.m_bUserNeedsToAcceptWorkshopLegalAgreement) {
+ 						_issueReporter.ReportDelayedUploadProblem("Workshop.ReportIssue_FailedToPublish_UserDidNotAcceptWorkshopTermsOfService");
+ 						_endAction(this);
+ 					}
++					else */
+-					else if (param.m_eResult == EResult.k_EResultOK) {
++					if (param.m_eResult == EResult.k_EResultOK) {
+ 						_publishedFileID = param.m_nPublishedFileId;
+ 						UpdateItem();
+ 					}
+@@ -233,17 +_,19 @@
+ 				private void UpdateItem() {
+ 					string headerText = GetHeaderText();
+ 					if (!TryWritingManifestToFolder(_entryData.ContentFolderPath, headerText)) {
+-						_endAction(this);
+-						return;
++						// If this fails to write, any future attempts to publish the item will always create a new item. We don't want that, so give clear message that something is wrong. - Solxan
++						Logging.tML.Fatal("Failed to write critical publishing information to the item content folder. Ending user interactions with the Workshop immediately to preserve integrity.");
++						Main.instance.Exit();
+ 					}
+ 
++					Logging.tML.Info("Updating Item " + _entryData.Title);
  					PrepareContentForUpdate();
  					UGCUpdateHandle_t uGCUpdateHandle_t = SteamUGC.StartItemUpdate(SteamUtils.GetAppID(), _publishedFileID);
  					if (_entryData.Title != null)

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -125,7 +125,7 @@
  					ERemoteStoragePublishedFileVisibility visibility = GetVisibility(publicity);
  					_entryData = new SteamWorkshopItem {
  						Title = itemTitle,
-@@ -171,19 +_,32 @@
+@@ -171,19 +_,35 @@
  						ContentFolderPath = contentFolderPath,
  						Tags = tags,
  						PreviewImagePath = previewImagePath,
@@ -134,6 +134,7 @@
 +						BuildData = buildData
  					};
  
+-					ulong? num = null;
 +					if (!File.Exists(previewImagePath)) {
 +						_issueReporter.ReportInstantUploadProblem("Workshop.ReportIssue_FailedToPublish_CouldNotFindFolderToUpload" + " NoPreviewImage");
 +						return;
@@ -143,16 +144,22 @@
 +						return;
 +					}
 +
- 					ulong? num = null;
++					_publishedFileID = new PublishedFileId_t(0);
  					if (AWorkshopEntry.TryReadingManifest(contentFolderPath + Path.DirectorySeparatorChar + "workshop.json", out FoundWorkshopEntryInfo info))
- 						num = info.workshopEntryId;
- 
-+					// If it has a publish ID, it has to be yours. Removing vanilla finder check to avoid dupes - Solxan
+-						num = info.workshopEntryId;
+-
 -					if (num.HasValue && finder.HasItemOfId(num.Value)) {
-+					if (num.HasValue /* finder.HasItemOfId(num.Value)*/) {
- 						_publishedFileID = new PublishedFileId_t(num.Value);
-+						if (buildData == null) {
+-						_publishedFileID = new PublishedFileId_t(num.Value);
 -						PreventUpdatingCertainThings();
++						_publishedFileID = new PublishedFileId_t(info.workshopEntryId);
++
++					// Verify can write to the manifest before running creating any items.
++					if (!WrappedWriteManifest())
++						return;
++
++					// If it has a publish ID, it has to be yours. Removing vanilla finder check to avoid dupes - Solxan
++					if (_publishedFileID.m_PublishedFileId != 0 /* finder.HasItemOfId(num.Value)*/) {
++						if (buildData == null) {
 +							PreventUpdatingCertainThings();
 +						}
  						UpdateItem();
@@ -162,7 +169,7 @@
  						CreateItem();
  					}
  				}
-@@ -205,6 +_,8 @@
+@@ -205,13 +_,34 @@
  				}
  
  				private void CreateItem() {
@@ -171,34 +178,54 @@
  					CoreSocialModule.SetSkipPulsing(shouldSkipPausing: true);
  					SteamAPICall_t hAPICall = SteamUGC.CreateItem(SteamUtils.GetAppID(), EWorkshopFileType.k_EWorkshopFileTypeFirst);
  					_createItemHook.Set(hAPICall, CreateItemResult);
-@@ -212,11 +_,13 @@
+ 					CoreSocialModule.SetSkipPulsing(shouldSkipPausing: false);
  				}
  
++				// Rewrote to reduce duplicate publishing in the event that user needs to accept workshop agreement.
  				private void CreateItemResult(CreateItemResult_t param, bool bIOFailure) {
-+					// This call can lead to creating a bunch of empty items due to failing to write the Manifest.json contents. Removing it here minimizes duplicates on rapid/repeated errored publishing - Solxan
--					if (param.m_bUserNeedsToAcceptWorkshopLegalAgreement) {
-+					/* if (param.m_bUserNeedsToAcceptWorkshopLegalAgreement) {
++					if (param.m_eResult != EResult.k_EResultOK) {
++						_issueReporter.ReportDelayedUploadProblemWithoutKnownReason("Workshop.ReportIssue_FailedToPublish_WithoutKnownReason", param.m_eResult.ToString());
++						_endAction(this);
++						return;
++					}
++
++					_publishedFileID = param.m_nPublishedFileId;
++					WrappedWriteManifest();
++
++					if (param.m_bUserNeedsToAcceptWorkshopLegalAgreement) {
++						_issueReporter.ReportDelayedUploadProblem("Workshop.ReportIssue_FailedToPublish_UserDidNotAcceptWorkshopTermsOfService");
++						_endAction(this);
++						return;
++					}
++
++					UpdateItem();
++
++					/*
+ 					if (param.m_bUserNeedsToAcceptWorkshopLegalAgreement) {
  						_issueReporter.ReportDelayedUploadProblem("Workshop.ReportIssue_FailedToPublish_UserDidNotAcceptWorkshopTermsOfService");
  						_endAction(this);
- 					}
-+					else */
--					else if (param.m_eResult == EResult.k_EResultOK) {
-+					if (param.m_eResult == EResult.k_EResultOK) {
- 						_publishedFileID = param.m_nPublishedFileId;
- 						UpdateItem();
- 					}
-@@ -233,17 +_,19 @@
+@@ -223,7 +_,8 @@
+ 					else {
+ 						_issueReporter.ReportDelayedUploadProblemWithoutKnownReason("Workshop.ReportIssue_FailedToPublish_WithoutKnownReason", param.m_eResult.ToString());
+ 						_endAction(this);
+-					}
++					} 
++					*/
+ 				}
+ 
+ 				protected abstract string GetHeaderText();
+@@ -231,19 +_,16 @@
+ 				protected abstract void PrepareContentForUpdate();
+ 
  				private void UpdateItem() {
- 					string headerText = GetHeaderText();
- 					if (!TryWritingManifestToFolder(_entryData.ContentFolderPath, headerText)) {
+-					string headerText = GetHeaderText();
+-					if (!TryWritingManifestToFolder(_entryData.ContentFolderPath, headerText)) {
 -						_endAction(this);
 -						return;
-+						// If this fails to write, any future attempts to publish the item will always create a new item. We don't want that, so give clear message that something is wrong. - Solxan
-+						Logging.tML.Fatal("Failed to write critical publishing information to the item content folder. Ending user interactions with the Workshop immediately to preserve integrity.");
-+						Main.instance.Exit();
- 					}
- 
+-					}
++					WrappedWriteManifest();
 +					Logging.tML.Info("Updating Item " + _entryData.Title);
+ 
  					PrepareContentForUpdate();
  					UGCUpdateHandle_t uGCUpdateHandle_t = SteamUGC.StartItemUpdate(SteamUtils.GetAppID(), _publishedFileID);
  					if (_entryData.Title != null)
@@ -249,3 +276,18 @@
  					_updateHandle = uGCUpdateHandle_t;
  					_updateItemHook.Set(hAPICall, UpdateItemResult);
  					CoreSocialModule.SetSkipPulsing(shouldSkipPausing: false);
+@@ -305,6 +_,14 @@
+ 						_issueReporter.ReportManifestCreationProblem("Workshop.ReportIssue_CouldNotCreateResourcePackManifestFile", exception);
+ 						return false;
+ 					}
++				}
++
++				private bool WrappedWriteManifest() {
++					if (TryWritingManifestToFolder(_entryData.ContentFolderPath, GetHeaderText()))
++						return true;
++						
++					_endAction(this);
++					return false;
+ 				}
+ 
+ 				public bool TryGetProgress(out float progress) {

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -41,6 +41,7 @@ namespace Terraria.Social.Steam
 			var existing = Interface.modBrowser.FindModDownloadItem(buildData["name"]);
 
 			if (existing != null) {
+				
 				ulong existingID = UIModBrowser.SteamWorkshop.GetSteamOwner(existing.QueryIndex);
 				var currID = Steamworks.SteamUser.GetSteamID();
 
@@ -52,7 +53,7 @@ namespace Terraria.Social.Steam
 				if (new Version(buildData["version"].Replace("v", "")) <= new Version(existing.Version.Replace("v", ""))) {
 					IssueReporter.ReportInstantUploadProblem("tModLoader.ModVersionInfoUnchanged");
 					return false;
-				} 
+				}
 			}
 
 			string name = buildData["displaynameclean"];

--- a/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.bat
+++ b/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.bat
@@ -58,12 +58,26 @@ set RUNTIMESELECT=dotnet
 REM install directories
 set INSTALLDIR=dotnet\%VERSIONSEL%
 
-REM Skip install check if runtime.log exists due to install having previously failed.
-if Not exist LaunchLogs\runtime.log (
-	REM Check if the install for our target NET already exists, and install if not
-	if Not exist %INSTALLDIR%\dotnet.exe  (
-		echo Logging to LaunchLogs\install.log
-		call :LOG 1> %LOGFILE% 2>&1
+REM Check if the install for our target NET already exists, and install if not
+if Not exist %INSTALLDIR%\dotnet.exe  (
+	echo Logging to LaunchLogs\install.log
+	call :LOG 1> %LOGFILE% 2>&1
+)
+
+REM If the install failed, provide a link to get the portable directly, and instructions on where to do with it.
+if Not exist %INSTALLDIR%\dotnet.exe  (
+	mkdir %InstallDir%
+	echo %ColorRed%It has been detected that your system failed to install the dotnet portables automatically. Will now proceed manually.%ColorDefault%
+	start "" https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-%version%-windows-x64-binaries
+	echo Now manually downloading the x64 .NET portable. Please find it in the opened browser.
+	set /p DUMMY=Press 'ENTER' to proceed to the next step...
+	echo Please extract the downloaded Zip file contents in to %~dp0\%InstallDir% 
+	set /p DUMMY=Please press Enter when this step is complete.
+	
+	:loop
+	if Not exist %INSTALLDIR%\dotnet.exe (
+		set /p DUMMY=%ColorRed%%INSTALLDIR%\dotnet.exe not detected. Please ensure step is complete before continuing with Enter.%ColorDefault%
+		goto :loop
 	)
 )
 

--- a/solutions/ReleaseExtras/RuntimeFiles/start-tModLoader.bat
+++ b/solutions/ReleaseExtras/RuntimeFiles/start-tModLoader.bat
@@ -7,12 +7,5 @@ call InstallNetFramework.bat
 if exist %INSTALLDIR%\dotnet.exe ( 
 	start dotnet\%VERSIONSEL%\dotnet.exe tModLoader.dll %Args% 
 ) else (
-	echo Installation of dotnet portable failed. Launching manual installed Net runtimes.
-	echo Logs for manual install are located in LaunchLogs\runtime.log
-	call :LOG_R 3> LaunchLogs\runtime.log 2>&3
+	dotnet tModLoader.dll %Args%
 )
-exit /B
-
-:LOG_R
-echo Attempting Launch..
-dotnet tModLoader.dll %Args%

--- a/solutions/ReleaseExtras/RuntimeFiles/start-tModLoaderServer.bat
+++ b/solutions/ReleaseExtras/RuntimeFiles/start-tModLoaderServer.bat
@@ -17,12 +17,5 @@ if %lobby%==p ( set Args=%Args% -lobby private )
 if exist %INSTALLDIR%\dotnet.exe ( 
 	start dotnet\%VERSIONSEL%\dotnet.exe tModLoader.dll %Args% 
 ) else (
-	echo Installation of dotnet portable failed. Launching manual installed Net runtimes.
-	echo Logs for manual install are located in LaunchLogs\runtime.log
-	call :LOG_R 3> LaunchLogs\runtime.log 2>&3
+	dotnet tModLoader.dll %Args%
 )
-exit /B
-
-:LOG_R
-echo Attempting Launch..
-dotnet tModLoader.dll %Args%


### PR DESCRIPTION
1) Batch files will now step people through manual portables installation when it fails to install.
2) Removed dependency on Vanilla finder.HasItem to determine if CreateItem() vs. UpdateItem(). We won't create new items if the item has already a publish ID assigned (reduces dupes)
3) added a few lines of logging around create and update
4) removed ending CreateItem result if WorkshopAgreement not done so that UpdateItem runs.
5) Reworked dependency on writing to manifest out of UpdateItem to be checked before doing anything.
6) Removed defunct code, refactored ForceCallbacks method to simplify for later.
7) Passed the HasUpdate bool to try and force downloading the Workshop Item again, even if Steam doesn't think there is an update.
