### PR TITLE
[1.4] Summon damage fixes + new DamageClass hook

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/DamageClass.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DamageClass.cs
@@ -52,9 +52,14 @@ namespace Terraria.ModLoader
 		public virtual bool CountsAs(DamageClass damageClass) => false;
 
 		/// <summary> 
-		/// This lets you define default buffs for all items of this class (eg, base crit)
+		/// This lets you define default buffs for all items of this class (e.g. base critical strike chance).
 		/// </summary>
 		public virtual void SetDefaultStats(Player player) {}
+
+		/// <summary>
+		/// This lets you enable or disable standard crits from items and projectiles associated with this DamageClass.
+		/// </summary>
+		public virtual bool AllowStandardCrits() => true;
 
 		protected sealed override void Register() {
 			ClassName = LocalizationLoader.GetOrCreateTranslation(Mod, $"DamageClassName.{Name}");

--- a/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
+++ b/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
@@ -56,6 +56,8 @@ namespace Terraria.ModLoader
 		protected override string LangKey => "LegacyTooltip.53";
 
 		protected override float GetBenefitFrom(DamageClass damageClass) => damageClass == Generic ? 1f : 0f;
+
+		public override bool AllowStandardCrits() => false;
 	}
 
 	public class ThrowingDamageClass : VanillaDamageClass

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -258,7 +258,7 @@
  											flag6 = true;
 +										*/
 +
-+										if (!(minion || ProjectileID.Sets.MinionShot[type]) && Main.rand.Next(100) < Main.player[owner].GetWeaponCrit(Main.player[owner].HeldItem))
++										if (DamageType.AllowStandardCrits() && Main.rand.Next(100) < Main.player[owner].GetWeaponCrit(Main.player[owner].HeldItem))
 +											flag6 = true;
  
  										int num12 = type;

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -138,7 +138,7 @@
 -				active = false;
 -			}
 +
-+			// tML: Tell all summon class projectiles to actually use the corresponding DamageClass.
++			// tML: Tell all vanilla summon class projectiles to actually use the corresponding DamageClass.
 +			if (type < ProjectileID.Count && (minion || sentry || ProjectileID.Sets.MinionShot[type] || ProjectileID.Sets.SentryShot[type] || ProjectileID.Sets.IsAWhip[type]))
 +				DamageType = DamageClass.Summon;
 +

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -130,7 +130,7 @@
  			ownerHitCheckDistance = 1000f;
  			counterweight = false;
  			sentry = false;
-@@ -7916,9 +_,11 @@
+@@ -7916,9 +_,12 @@
  				light = 1f;
  				ranged = true;
  			}
@@ -138,21 +138,14 @@
 -				active = false;
 -			}
 +
-+			if (type < ProjectileID.Count && (minion || sentry || ProjectileID.Sets.MinionShot[type] || ProjectileID.Sets.SentryShot[type]))
++			// tML: Tell all summon class projectiles to actually use the corresponding DamageClass.
++			if (type < ProjectileID.Count && (minion || sentry || ProjectileID.Sets.MinionShot[type] || ProjectileID.Sets.SentryShot[type] || ProjectileID.Sets.IsAWhip[type]))
 +				DamageType = DamageClass.Summon;
 +
 +			ProjectileLoader.SetDefaults(this);
  
  			width = (int)((float)width * scale);
  			height = (int)((float)height * scale);
-@@ -7937,6 +_,7 @@
- 			extraUpdates = 1;
- 			usesLocalNPCImmunity = true;
- 			localNPCHitCooldown = -1;
-+			DamageType = DamageClass.Summon;
- 		}
- 
- 		public static int GetNextSlot() {
 @@ -7951,6 +_,10 @@
  			return result;
  		}

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -130,7 +130,7 @@
  			ownerHitCheckDistance = 1000f;
  			counterweight = false;
  			sentry = false;
-@@ -7916,9 +_,8 @@
+@@ -7916,9 +_,11 @@
  				light = 1f;
  				ranged = true;
  			}
@@ -138,10 +138,21 @@
 -				active = false;
 -			}
 +
++			if (type < ProjectileID.Count && (minion || sentry || ProjectileID.Sets.MinionShot[type] || ProjectileID.Sets.SentryShot[type]))
++				DamageType = DamageClass.Summon;
++
 +			ProjectileLoader.SetDefaults(this);
  
  			width = (int)((float)width * scale);
  			height = (int)((float)height * scale);
+@@ -7937,6 +_,7 @@
+ 			extraUpdates = 1;
+ 			usesLocalNPCImmunity = true;
+ 			localNPCHitCooldown = -1;
++			DamageType = DamageClass.Summon;
+ 		}
+ 
+ 		public static int GetNextSlot() {
 @@ -7951,6 +_,10 @@
  			return result;
  		}


### PR DESCRIPTION
Added a new hook in DamageClass allows you to enable or disable standard crit calcs for all items/projectiles of a given damage type. This hook is also used for DamageClass.Summon, which all vanilla summon class projectiles are now set to use.

TO-DO: Investigate potential incorrect damage multipliers for summons.