### PR TITLE
Add keybind to 1.4 ExampleMod

### DIFF
--- a/ExampleMod/Common/Players/ExampleKeybindPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleKeybindPlayer.cs
@@ -11,6 +11,7 @@ namespace ExampleMod.Common.Players
 			if (ExampleMod.RandomBuffKeybind.JustPressed) {
 				int buff = Main.rand.Next(BuffID.Count);
 				Player.AddBuff(buff, 600);
+				Main.NewText($"ExampleMod's ModKeybind was just pressed. The {Lang.GetBuffName(buff)} buff was given to the player.");
 			}
 		}
 	}

--- a/ExampleMod/Common/Players/ExampleKeybindPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleKeybindPlayer.cs
@@ -1,0 +1,17 @@
+using Terraria;
+using Terraria.ID;
+using Terraria.GameInput;
+using Terraria.ModLoader;
+
+namespace ExampleMod.Common.Players
+{
+	public class ExampleKeybindPlayer : ModPlayer
+	{
+		public override void ProcessTriggers(TriggersSet triggersSet) {
+			if (ExampleMod.RandomBuffKeybind.JustPressed) {
+				int buff = Main.rand.Next(BuffID.Count);
+				Player.AddBuff(buff, 600);
+			}
+		}
+	}
+}

--- a/ExampleMod/ExampleMod.cs
+++ b/ExampleMod/ExampleMod.cs
@@ -10,10 +10,18 @@ namespace ExampleMod
 	public class ExampleMod : Mod
 	{
 		public const string AssetPath = "ExampleMod/Assets/";
+		public static ModKeybind RandomBuffKeybind;
 
 		public override void AddRecipes() => ExampleRecipes.Load(this);
 
-		public override void Unload() => ExampleRecipes.Unload();
+		public override void Load() {
+			RandomBuffKeybind = KeybindLoader.RegisterKeybind(this, "Random Buff", "P");
+		}
+
+		public override void Unload() {
+			ExampleRecipes.Unload();
+			RandomBuffKeybind = null;
+		}
 
 		//TODO: Introduce OOP packets into tML, to avoid this god-class level hardcode.
 		public override void HandlePacket(BinaryReader reader, int whoAmI) {

--- a/ExampleMod/Old/ExampleMod.cs
+++ b/ExampleMod/Old/ExampleMod.cs
@@ -23,7 +23,6 @@ namespace ExampleMod
 {
 	public class ExampleMod : Mod
 	{
-		public static ModHotKey RandomBuffHotKey;
 		public static int FaceCustomCurrencyId;
 		// With the new fonts in 1.3.5, font files are pretty big now so you need to generate the font file before building the mod.
 		// You can use https://forums.terraria.org/index.php?threads/dynamicspritefontgenerator-0-4-generate-fonts-without-xna-game-studio.57127/ to make dynamicspritefonts
@@ -58,9 +57,6 @@ namespace ExampleMod
 			Logger.InfoFormat("{0} example logging", Name);
 			// In older tModLoader versions we used: ErrorLogger.Log("blabla");
 			// Replace that with above
-
-			// Registers a new hotkey
-			RandomBuffHotKey = RegisterHotKey("Random Buff", "P"); // See https://docs.microsoft.com/en-us/previous-versions/windows/xna/bb197781(v=xnagamestudio.41) for special keys
 
 			// Registers a new custom currency
 			FaceCustomCurrencyId = CustomCurrencyManager.RegisterCurrency(new ExampleCustomCurrency(ModContent.ItemType<Items.Face>(), 999L));
@@ -153,7 +149,6 @@ namespace ExampleMod
 			// Unload static references
 			// You need to clear static references to assets (Texture2D, SoundEffects, Effects). 
 			// In addition to that, if you want your mod to completely unload during unload, you need to clear static references to anything referencing your Mod class
-			RandomBuffHotKey = null;
 			NPCs.ExampleTravelingMerchant.shopItems.Clear();
 		}
 

--- a/ExampleMod/Old/ExamplePlayer.cs
+++ b/ExampleMod/Old/ExamplePlayer.cs
@@ -238,13 +238,6 @@ namespace ExampleMod
 			}
 		}
 
-		public override void ProcessTriggers(TriggersSet triggersSet) {
-			if (ExampleMod.RandomBuffHotKey.JustPressed) {
-				int buff = Main.rand.Next(BuffID.Count);
-				player.AddBuff(buff, 600);
-			}
-		}
-
 		public override void PreUpdateBuffs() {
 			if (heroLives > 0) {
 				bool flag = false;


### PR DESCRIPTION
This commit adds the random buff keybind that was present in 1.3 ExampleMod to 1.4 ExampleMod

I've taken the approach to create a separate player class for this as has been done for luck and inventory, let me know if this is not desirable.

I'm not sure if I should create a separate class for registering the keybind that would also have an unload method that would set the static field to null, kind of like what is currently done for the recipes.

As a side note, I'm getting the warning that ExampleMod did not fully unload whenever I reload the mods, but I was getting this warning even before my commit so I'm not sure if I should be concerned about that.

This is my first PR on this project so please be kind if I've forgotten anything or missed the mark on some of these changes, and advise as to any changes that are needed. Thank you for your time!