### PR TITLE
Make SteamApps path check case insensitive

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
@@ -99,7 +99,7 @@ namespace Terraria.ModLoader.Engine
 			}
 
 			// If its clearly a steam install/launch, use Steam API.
-			if (Directory.GetCurrentDirectory().IndexOf("steamapps", StringComparison.OrdinalIgnoreCase) >= 0 || Program.LaunchParameters.ContainsKey("-steam"))
+			if (Directory.GetCurrentDirectory().Contains("steamapps", StringComparison.OrdinalIgnoreCase) || Program.LaunchParameters.ContainsKey("-steam"))
 				return CheckSteam();
 
 			Logging.tML.Info("Checking if GoG or Steam...");

--- a/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
@@ -99,7 +99,7 @@ namespace Terraria.ModLoader.Engine
 			}
 
 			// If its clearly a steam install/launch, use Steam API.
-			if (Directory.GetCurrentDirectory().Contains("steamapps") || Program.LaunchParameters.ContainsKey("-steam"))
+			if (Directory.GetCurrentDirectory().IndexOf("steamapps", StringComparison.OrdinalIgnoreCase) >= 0 || Program.LaunchParameters.ContainsKey("-steam"))
 				return CheckSteam();
 
 			Logging.tML.Info("Checking if GoG or Steam...");


### PR DESCRIPTION
Windows is steamapps
Mac is SteamApps.

This check occurs prior to dealing with GoG pathfinding, so eliminates a large amount of overhead and possible issues for Steam installations
