### PR TITLE
[1.4] Fixing hair frame missing on HeadOnly setups

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawHeadSet.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawHeadSet.cs.patch
@@ -57,7 +57,7 @@
  			colorEyeWhites = Main.quickAlpha(Color.White, Alpha);
  			colorEyes = Main.quickAlpha(drawPlayer.eyeColor, Alpha);
  			colorHair = Main.quickAlpha(drawPlayer.GetHairColor(useLighting: false), Alpha);
-@@ -95,14 +_,38 @@
+@@ -95,14 +_,23 @@
  				playerEffect = SpriteEffects.FlipHorizontally;
  
  			headVect = new Vector2((float)drawPlayer.legFrame.Width * 0.5f, (float)drawPlayer.legFrame.Height * 0.4f);
@@ -73,22 +73,7 @@
  			Position.Y -= 4f;
  			Position.Y -= drawPlayer.HeightMapOffset;
 +
-+			// Taken from boring setup to prepare hair frames
-+			Rectangle bodyFrame = drawPlayer.bodyFrame;
-+			bodyFrame.Y -= 336;
-+			if (bodyFrame.Y < 0)
-+				bodyFrame.Y = 0;
-+
-+			hairFrontFrame = bodyFrame;
-+			hairBackFrame = bodyFrame;
-+			if (hideHair) {
-+				hairFrontFrame.Height = 0;
-+				hairBackFrame.Height = 0;
-+			}
-+			else if (backHairDraw) {
-+				int height = 26;
-+				hairFrontFrame.Height = height;
-+			}
++			SetupHairFrames(); // Important fix for baldness.
 +
 +			// Workaround for movement bobbing affecting head-only rendering.
 +			Position -= Main.OffsetsPlayerHeadgear[drawPlayer.bodyFrame.Y / drawPlayer.bodyFrame.Height];

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawHeadSet.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawHeadSet.cs.patch
@@ -57,7 +57,7 @@
  			colorEyeWhites = Main.quickAlpha(Color.White, Alpha);
  			colorEyes = Main.quickAlpha(drawPlayer.eyeColor, Alpha);
  			colorHair = Main.quickAlpha(drawPlayer.GetHairColor(useLighting: false), Alpha);
-@@ -95,14 +_,21 @@
+@@ -95,14 +_,38 @@
  				playerEffect = SpriteEffects.FlipHorizontally;
  
  			headVect = new Vector2((float)drawPlayer.legFrame.Width * 0.5f, (float)drawPlayer.legFrame.Height * 0.4f);
@@ -72,6 +72,23 @@
  			Position.X -= 6f;
  			Position.Y -= 4f;
  			Position.Y -= drawPlayer.HeightMapOffset;
++
++			// Taken from boring setup to prepare hair frames
++			Rectangle bodyFrame = drawPlayer.bodyFrame;
++			bodyFrame.Y -= 336;
++			if (bodyFrame.Y < 0)
++				bodyFrame.Y = 0;
++
++			hairFrontFrame = bodyFrame;
++			hairBackFrame = bodyFrame;
++			if (hideHair) {
++				hairFrontFrame.Height = 0;
++				hairBackFrame.Height = 0;
++			}
++			else if (backHairDraw) {
++				int height = 26;
++				hairFrontFrame.Height = height;
++			}
 +
 +			// Workaround for movement bobbing affecting head-only rendering.
 +			Position -= Main.OffsetsPlayerHeadgear[drawPlayer.bodyFrame.Y / drawPlayer.bodyFrame.Height];

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.tML.cs
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.tML.cs
@@ -99,7 +99,7 @@ namespace Terraria.DataStructures
 		public static readonly PlayerDrawLayer Head = new VanillaPlayerDrawLayer(nameof(Head), DrawPlayer_21_Head, TorsoGroup, isHeadLayer: true);
 
 		/// <summary> Draws a finch nest on the player's head, if the player has a finch summoned. </summary>
-		public static readonly PlayerDrawLayer FinchNest = new VanillaPlayerDrawLayer(nameof(FinchNest), DrawPlayer_21_2_FinchNest, TorsoGroup, isHeadLayer: true);
+		public static readonly PlayerDrawLayer FinchNest = new VanillaPlayerDrawLayer(nameof(FinchNest), DrawPlayer_21_2_FinchNest, TorsoGroup, isHeadLayer: false);
 
 		/// <summary> Draws the player's face accessory. </summary>
 		public static readonly PlayerDrawLayer FaceAcc = new VanillaPlayerDrawLayer(nameof(FaceAcc), DrawPlayer_22_FaceAcc, TorsoGroup);

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
@@ -43,10 +43,28 @@
  					colorEyeWhites = drawPlayer.GetImmuneAlpha(Color.White, shadow);
  					colorEyes = drawPlayer.GetImmuneAlpha(drawPlayer.eyeColor, shadow);
  					colorHair = drawPlayer.GetImmuneAlpha(drawPlayer.GetHairColor(useLighting: false), shadow);
-@@ -1309,8 +_,14 @@
- 				hairFrontFrame.Height = height;
+@@ -1292,8 +_,13 @@
+ 				drawPlayer.headRotation = 0f;
  			}
  
++			SetupHairFrames();
++			BoringSetup_End();
++		}
++
++		// A split to be used in HeadOnlySetup()
++		private void SetupHairFrames() {
+ 			Rectangle bodyFrame = drawPlayer.bodyFrame;
+-			bodyFrame = drawPlayer.bodyFrame;
+ 			bodyFrame.Y -= 336;
+ 			if (bodyFrame.Y < 0)
+ 				bodyFrame.Y = 0;
+@@ -1308,9 +_,17 @@
+ 				int height = 26;
+ 				hairFrontFrame.Height = height;
+ 			}
++		}
+ 
++		private void BoringSetup_End() {
 +			/*
  			hidesTopSkin = (drawPlayer.body == 82 || drawPlayer.body == 83 || drawPlayer.body == 93 || drawPlayer.body == 21 || drawPlayer.body == 22);
  			hidesBottomSkin = (drawPlayer.body == 93 || drawPlayer.legs == 20 || drawPlayer.legs == 21);


### PR DESCRIPTION
### What is the bug?

Player head is drawn bald as in issue: https://github.com/tModLoader/tModLoader/issues/1657
This behaviour happens every time a head only player is drawn

### How did you fix the bug?

Added to `PlayerDrawSet.HeadOnlySetup` the hair frame setup like in `PlayerDrawSet.BoringSetup`.

### Are there alternatives to your fix?

The fix could be better "included" as having a `HeadOnlySetup` being called at the beginning of `BoringSetup` forcing every update on head rendering setup will propagate to both and have less code.
But atm it is not reasonable because the functions seems to be in a way that makes it "edit intensive", need more research on vanilla decompiled code to figure out if it is feasible.
