### PR TITLE
parentVal translation fix

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
@@ -228,7 +228,8 @@ namespace Terraria.ModLoader
 					if (!modTranslationDictionary.TryGetValue(key, out ModTranslation mt)) {
 						// removing instances of .$parentVal is an easy way to make this special key assign its value
 						//  to the parent key instead (needed for some cases of .lang -> .hjson auto-conversion)
-						modTranslationDictionary[key.Replace(".$parentVal", "")] = mt = CreateTranslation(key.Replace(".$parentVal", ""));
+						string effectiveKey = key.Replace(".$parentVal", "");
+						modTranslationDictionary[effectiveKey] = mt = CreateTranslation(effectiveKey);
 					}
 
 					mt.AddTranslation(culture, value);

--- a/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
@@ -228,7 +228,7 @@ namespace Terraria.ModLoader
 					if (!modTranslationDictionary.TryGetValue(key, out ModTranslation mt)) {
 						// removing instances of .$parentVal is an easy way to make this special key assign its value
 						//  to the parent key instead (needed for some cases of .lang -> .hjson auto-conversion)
-						modTranslationDictionary[key.Replace(".$parentVal", "")] = mt = CreateTranslation(key);
+						modTranslationDictionary[key.Replace(".$parentVal", "")] = mt = CreateTranslation(key.Replace(".$parentVal", ""));
 					}
 
 					mt.AddTranslation(culture, value);


### PR DESCRIPTION
### What is the bug?
hjson translation with $parentVal doesn't work

### How did you fix the bug?
I added the replacement from ".$parentVal" to "" on the translation creation

### Are there alternatives to your fix?
The implementation could maybe be a bit cleaner but that's the simplest
