### PR TITLE
Fix UIModConfig arrows being broken.

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
@@ -227,10 +227,7 @@ namespace Terraria.ModLoader.Config.UI
 
 		// Refreshes the UI to refresh recent changes such as Save/Discard/Restore Defaults/Cycle to next config
 		private void DoMenuModeState() {
-			if (Main.gameMenu)
-				Main.menuMode = Interface.modConfigID;
-			else
-				Main.InGameUI.SetState(Interface.modConfig);
+			OnActivate();
 		}
 
 		private void SaveConfig(UIMouseEvent evt, UIElement listeningElement) {


### PR DESCRIPTION
### What is the bug?
#1589 "ModConfig: changing configs using the "<" and ">" buttons is buggy" 

The arrows were changing the config set correctly, the UI just was not refreshing properly.

### How did you fix the bug?
Ensured the UI is being refreshed properly when these buttons are pressed by calling the `OnActivate()` function.

### Are there alternatives to your fix?
Unsure

