### PR TITLE
Extend SoundEngine.IsAudioSupported to SoundLoader

### DIFF
--- a/patches/tModLoader/Terraria/Audio/SoundEngine.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/SoundEngine.cs.patch
@@ -1,0 +1,20 @@
+--- src/Terraria/Terraria/Audio/SoundEngine.cs
++++ src/tModLoader/Terraria/Audio/SoundEngine.cs
+@@ -20,6 +_,8 @@
+ 
+ 		public static void Initialize() {
+ 			IsAudioSupported = TestAudioSupport();
++			if (!IsAudioSupported)
++				Utils.ShowFancyErrorMessage(Localization.Language.GetTextValue("tModLoader.AudioNotSupported"), ModLoader.UI.Interface.loadModsID);
+ 		}
+ 
+ 		public static void Load(IServiceProvider services) {
+@@ -324,7 +_,7 @@
+ 				}
+ 			}
+ 			catch (NoAudioHardwareException) {
+-				Console.WriteLine("No audio hardware found. Disabling all audio.");
++				//Console.WriteLine("No audio hardware found. Disabling all audio.");
+ 				return false;
+ 			}
+ 			catch {

--- a/patches/tModLoader/Terraria/Audio/SoundEngine.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/SoundEngine.cs.patch
@@ -14,7 +14,7 @@
  			}
  			catch (NoAudioHardwareException) {
 -				Console.WriteLine("No audio hardware found. Disabling all audio.");
-+				//Console.WriteLine("No audio hardware found. Disabling all audio.");
++				ModLoader.Logging.tML.Warn("No audio hardware found. Disabling all audio.");
  				return false;
  			}
  			catch {

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -16,6 +16,7 @@
 		"FirstLaunchWelcomeMessage": "Welcome to tModLoader.\n\nYou have successfully installed tModLoader. Use the Mod Browser menu to find mods you wish to download. Use the Mods menu to change which mods are currently active. After changing mods, make sure you click the Reload Mods button to reload them.",
 		"tModLoaderSettings": "tModLoader Settings",
 		"ModMenuSwap": "Switch Menu Theme",
+		"AudioNotSupported": "No audio hardware found. Disabling all audio.",
 
 		// Mods Menu
 		"ModsModsList": "Mods List",

--- a/patches/tModLoader/Terraria/ModLoader/SoundLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SoundLoader.cs
@@ -70,6 +70,9 @@ namespace Terraria.ModLoader
 		}
 
 		internal static void ResizeAndFillArrays() {
+			if (!SoundEngine.IsAudioSupported)
+				return;
+
 			customSounds = new Asset<SoundEffect>[nextSound[SoundType.Custom]];
 			customSoundInstances = new SoundEffectInstance[nextSound[SoundType.Custom]];
 			
@@ -115,6 +118,9 @@ namespace Terraria.ModLoader
 		//in Terraria.Main.PlaySound before checking type to play sound add
 		//  if (SoundLoader.PlayModSound(type, num, num2, num3)) { return; }
 		internal static bool PlayModSound(int type, int style, float volume, float pan, ref SoundEffectInstance soundEffectInstance) {
+			if (!SoundEngine.IsAudioSupported)
+				return false;
+
 			SoundType soundType;
 			switch (type) {
 				case 2:
@@ -157,6 +163,9 @@ namespace Terraria.ModLoader
 		}
 
 		internal static Asset<SoundEffect>[] GetSoundArray(SoundType type) {
+			if (!SoundEngine.IsAudioSupported)
+				return null;
+
 			switch (type) {
 				case SoundType.Custom:
 					return customSounds;
@@ -172,6 +181,9 @@ namespace Terraria.ModLoader
 		}
 
 		internal static SoundEffectInstance[] GetSoundInstanceArray(SoundType type) {
+			if (!SoundEngine.IsAudioSupported)
+				return null;
+
 			switch (type) {
 				case SoundType.Custom:
 					return customSoundInstances;


### PR DESCRIPTION
### What is the bug?
Currently, an error isn't shown to user until SoundLoader accesses the null SoundPlayer object. 

### How did you fix the bug?
This PR readjusts the error to be notified when it is first detected (SoundEngine.Initialize) and extend SoundEngine.IsAudioSupported in to SoundLoader to prevent it from throwing errors.

### Are there alternatives to your fix?

