### PR TITLE
Checking case of known stale assets

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Engine/TMLContentManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/TMLContentManager.cs
@@ -15,43 +15,7 @@ namespace Terraria.ModLoader.Engine
 		private int loadedAssets = 0;
 
 		public TMLContentManager(IServiceProvider serviceProvider, string rootDirectory, TMLContentManager alternateContentManager) : base(serviceProvider, rootDirectory) {
-
-			// Windows stale resource file case workaround
-			if (Platform.IsWindows) {
-				// The file listed below will be checked and fixed for case on disk
-				// this method does not work on UNC paths (don't think remote path Terraria
-				// installs will be present in a long time, but good to keep this logged)
-				// and will only find/change FILE case, not all the directory tree.
-				// A full implementation for search of actual name can be found at:
-				// https://stackoverflow.com/questions/325931/getting-actual-file-name-with-proper-casing-on-windows-with-net
-				string[] problematicAssets = {
-					"Images/NPC_517.xnb",
-					"Images/Gore_240.xnb",
-					"Images/Projectile_179.xnb",
-					"Images/Projectile_618.xnb"
-				};
-				foreach (var problematicAsset in problematicAssets) {
-					var expectedName = Path.GetFileName(problematicAsset);
-					var expectedFullPath = Path.Combine(rootDirectory, problematicAsset);
-					var faultyAssetInfo = new FileInfo(Path.Combine(rootDirectory, problematicAsset));
-					// faultyAssetInfo.Name should be the system file cased name, but this is not the case
-					// don't relay to that either way to be sure
-					if (faultyAssetInfo.Exists) {
-						var assetInfo = faultyAssetInfo.Directory.EnumerateFileSystemInfos(faultyAssetInfo.Name).First();
-						// This assetInfo is correct cased (but only the name, need recursive if you want full case,
-						// nothing more is needed in this case though
-						var realName = assetInfo.Name;
-						if (expectedName != realName) {
-							// The asset is wrongfully cased, fix that,
-							// changing a vanilla file name is something to log for sure
-							var relativeRealPath = Path.GetRelativePath(rootDirectory, assetInfo.FullName);
-							Logging.tML.Info($"Found vanilla asset with wrong case, renaming: (from {rootDirectory}) {relativeRealPath} -> {problematicAsset}");
-							File.Move(assetInfo.FullName, expectedFullPath);
-							// Programmatically move with different case works
-						}
-					}
-				}
-			}
+			TryFixFileCasings(rootDirectory);
 
 			this.alternateContentManager = alternateContentManager;
 
@@ -117,5 +81,54 @@ namespace Terraria.ModLoader.Engine
 		}
 
 		public bool ImageExists(string assetName) => ExistingImages.Contains(assetName);
+
+		private static void TryFixFileCasings(string rootDirectory) {
+			// Windows stale resource file case workaround
+			if (!Platform.IsWindows) {
+				return;
+			}
+
+			// The file listed below will be checked and fixed for case on disk
+			// this method does not work on UNC paths (don't think remote path Terraria
+			// installs will be present in a long time, but good to keep this logged)
+			// and will only find/change FILE case, not all the directory tree.
+			// A full implementation for search of actual name can be found at:
+			// https://stackoverflow.com/questions/325931/getting-actual-file-name-with-proper-casing-on-windows-with-net
+			string[] problematicAssets = {
+				"Images/NPC_517.xnb",
+				"Images/Gore_240.xnb",
+				"Images/Projectile_179.xnb",
+				"Images/Projectile_618.xnb"
+			};
+
+			foreach (string problematicAsset in problematicAssets) {
+				string expectedName = Path.GetFileName(problematicAsset);
+				string expectedFullPath = Path.Combine(rootDirectory, problematicAsset);
+				var faultyAssetInfo = new FileInfo(Path.Combine(rootDirectory, problematicAsset));
+
+				// faultyAssetInfo.Name should be the system file cased name, but this is not the case
+				// don't rely to that either way to be sure
+				if (!faultyAssetInfo.Exists) {
+					continue;
+				}
+
+				// This assetInfo is correct cased (but only the name, need recursive if you want full case,
+				// nothing more is needed in this case though
+				var assetInfo = faultyAssetInfo.Directory.EnumerateFileSystemInfos(faultyAssetInfo.Name).First();
+				string realName = assetInfo.Name;
+
+				if (expectedName == realName) {
+					continue;
+				}
+
+				// The asset is wrongfully cased, fix that,
+				// changing a vanilla file name is something to log for sure
+				string relativeRealPath = Path.GetRelativePath(rootDirectory, assetInfo.FullName);
+
+				Logging.tML.Info($"Found vanilla asset with wrong case, renaming: (from {rootDirectory}) {relativeRealPath} -> {problematicAsset}");
+				// Programmatically move with different case works
+				File.Move(assetInfo.FullName, expectedFullPath);
+			}
+		}
 	}
 }


### PR DESCRIPTION
### What is the bug?
https://github.com/tModLoader/tModLoader/issues/1691

### How did you fix the bug?
Fixing it before `Main` instantiation was not reasonable because asset direcotries are not calculated yet (Steam Terraria needs it's own identification etc...).
So in `TMLContentManager` before any operation I added a Windows only check and move in-place of the files cases.

### Things to check
The fix contains a constant array (not "really" constant because C#...) of possible stale assets (with extension) in their valid expexted cases, it worked for me, and was all described in the issue, if any new stale case issue arises there will be additions to this array.

`gore_240` is present in `ResourcePacksDefaultInfo.tsv` so it's probably still shipped as lowercase? (probably not used or some pre build script was not run in the vanilla build, sure if used the case is upper due to how they are loaded).
