### PR TITLE
[1.4 Alpha] Fix Steam Connect_Lobby argument

### DIFF
--- a/patches/Terraria/Terraria/Net/Sockets/SocialSocket.cs.patch
+++ b/patches/Terraria/Terraria/Net/Sockets/SocialSocket.cs.patch
@@ -1,0 +1,32 @@
+--- src/decompiled/Terraria/Net/Sockets/SocialSocket.cs
++++ src/Terraria/Terraria/Net/Sockets/SocialSocket.cs
+@@ -1,4 +_,5 @@
+ using System.Threading;
++using System.Threading.Tasks;
+ using Terraria.Social;
+ 
+ namespace Terraria.Net.Sockets
+@@ -32,7 +_,11 @@
+ 
+ 		void ISocket.AsyncSend(byte[] data, int offset, int size, SocketSendCallback callback, object state) {
+ 			SocialAPI.Network.Send(_remoteAddress, data, size);
++#if NETCORE
++			Task.Run(() => callback.Invoke(state));
++#else
+ 			callback.BeginInvoke(state, null, null);
++#endif
+ 		}
+ 
+ 		private void ReadCallback(byte[] data, int offset, int size, SocketReceiveCallback callback, object state) {
+@@ -45,7 +_,11 @@
+ 		}
+ 
+ 		void ISocket.AsyncReceive(byte[] data, int offset, int size, SocketReceiveCallback callback, object state) {
++#if NETCORE
++			Task.Run(() => new InternalReadCallback(ReadCallback).Invoke(data, offset, size, callback, state));
++#else
+ 			new InternalReadCallback(ReadCallback).BeginInvoke(data, offset, size, callback, state, null, null);
++#endif
+ 		}
+ 
+ 		void ISocket.SendQueuedPackets() {

--- a/patches/tModLoader/Terraria/Social/Steam/NetClientSocialModule.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/NetClientSocialModule.cs.patch
@@ -1,0 +1,22 @@
+--- src/Terraria/Terraria/Social/Steam/NetClientSocialModule.cs
++++ src/tModLoader/Terraria/Social/Steam/NetClientSocialModule.cs
+@@ -27,12 +_,17 @@
+ 			_gameLobbyJoinRequested = Callback<GameLobbyJoinRequested_t>.Create(OnLobbyJoinRequest);
+ 			_p2pSessionRequest = Callback<P2PSessionRequest_t>.Create(OnP2PSessionRequest);
+ 			_p2pSessionConnectfail = Callback<P2PSessionConnectFail_t>.Create(OnSessionConnectFail);
+-			Main.OnEngineLoad += CheckParameters;
++			if (Program.LaunchParameters.ContainsKey("+connect_lobby"))
++				ModLoader.ModLoader.OnSuccessfulLoad += CheckParameters; // Main.OnEngineLoad is too early, earlier than ModLoaderMod.
+ 		}
+ 
+ 		private void CheckParameters() {
+-			if (Program.LaunchParameters.ContainsKey("+connect_lobby") && ulong.TryParse(Program.LaunchParameters["+connect_lobby"], out ulong result))
++			if (ulong.TryParse(Program.LaunchParameters["+connect_lobby"], out ulong result))
+ 				ConnectToLobby(result);
++			else {
++				Main.menuMode = 0;
++				ModLoader.Logging.tML.Error("The provided lobby ID was invalid: " + result);
++			}
+ 		}
+ 
+ 		public void ConnectToLobby(ulong lobbyId) {

--- a/patches/tModLoader/Terraria/Social/Steam/NetServerSocialModule.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/NetServerSocialModule.cs.patch
@@ -1,0 +1,14 @@
+--- src/Terraria/Terraria/Social/Steam/NetServerSocialModule.cs
++++ src/tModLoader/Terraria/Social/Steam/NetServerSocialModule.cs
+@@ -107,8 +_,10 @@
+ 		}
+ 
+ 		private void OnLobbyCreated(LobbyCreated_t result, bool failure) {
+-			if (!failure)
++			if (!failure) {
+ 				SteamFriends.SetRichPresence("status", Language.GetTextValue("Social.StatusInGame"));
++				Utils.LogAndConsoleInfoMessage("Currently Hosting LobbyID: " + GetLobbyId());
++			}
+ 		}
+ 
+ 		private bool OnPacketRead(byte[] data, int length, CSteamID userId) {

--- a/patches/tModLoader/Terraria/Utils.cs.patch
+++ b/patches/tModLoader/Terraria/Utils.cs.patch
@@ -17,6 +17,16 @@
  	{
  		public delegate bool TileActionAttempt(int x, int y);
  
+@@ -190,7 +_,8 @@
+ 			ArrayList arrayList = new ArrayList();
+ 			string text = "";
+ 			for (int i = 0; i < brokenArgs.Length; i++) {
+-				if (brokenArgs[i].StartsWith("-")) {
++				//TML: Steam uses +connect_lobby as an argument, so had to add == "+" so this wouldn't break that argument.
++				if (brokenArgs[i].StartsWith("-") || brokenArgs[i].StartsWith("+")) {
+ 					if (text != "") {
+ 						arrayList.Add(text);
+ 						text = "";
 @@ -253,6 +_,12 @@
  								num2 -= 16;
  


### PR DESCRIPTION
### What is the bug?
1) Fix Platform not supported Error from BeginInvoke
2) Fix Steam 'connect_lobby' argument for both when called, and passing argument
3) Add logging of what the LobbyID is/was for Servers

This does NOT mean that Steam Multiplayer is working, but is an improvement in terms of fixing some of the bugs around it.

### How did you fix the bug?

### Are there alternatives to your fix?
A future PR will still be needed to fix Steam Multiplayer