### PR TITLE
[1.4] Minor Tweak to slightly improve rendering performance

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3840,8 +3840,7 @@
  				}
  				else {
 +					//TML: RenderTiles() is quite slow. ~30ms at peak; doesn't change with lighting modes
--					if (renderCount == 3) {
-+					if (renderCount == 3) { 
+ 					if (renderCount == 3) {
  						RenderTiles();
  						sceneTilePos.X = screenPosition.X - (float)offScreenRange;
  						sceneTilePos.Y = screenPosition.Y - (float)offScreenRange;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3835,6 +3835,32 @@
  			}
  		}
  
+@@ -47050,19 +_,22 @@
+ 					renderCount = 99;
+ 				}
+ 				else {
++					//TML: RenderTiles() is quite slow. ~30ms at peak; doesn't change with lighting modes
+-					if (renderCount == 3) {
++					if (renderCount == 3) { 
+ 						RenderTiles();
+ 						sceneTilePos.X = screenPosition.X - (float)offScreenRange;
+ 						sceneTilePos.Y = screenPosition.Y - (float)offScreenRange;
+ 					}
+ 
+-					if (renderCount == 3) {
++					//TML: Remapped from 3 to 2 to flatten per frame load for colour lighting ( ~5ms peak).
++					if (renderCount == (Lighting.LegacyEngine.Mode == 0 ? 2 : 3)) {
+ 						RenderTiles2();
+ 						sceneTile2Pos.X = screenPosition.X - (float)offScreenRange;
+ 						sceneTile2Pos.Y = screenPosition.Y - (float)offScreenRange;
+ 					}
+ 
+-					if (renderCount == 3) {
++					//TML: Remapped from 3 to 0 to flatten per frame load for colour lighting ( ~15ms peak).
++					if (renderCount == (Lighting.LegacyEngine.Mode == 0 ? 0 : 3)) {
+ 						RenderWalls();
+ 						sceneWallPos.X = screenPosition.X - (float)offScreenRange;
+ 						sceneWallPos.Y = screenPosition.Y - (float)offScreenRange;
 @@ -47157,10 +_,13 @@
  			if (gameMenu || netMode == 2)
  				bgTopY = -200;


### PR DESCRIPTION
### What is the bug?
Currently, rendering performance on well lit areas (such as those of the Builder's Workshop map in #1788 ) greatly hammer the frame when renderCount = 3 while in Colour lighting mode. 
This PR spreads out some of that load, saw an up to 15% improvement in average fps from this change in well-lit areas

### How did you fix the bug?
Spread out load away from the frames when renderCount is 3 on Colour lighting.
This brings all frames above 60 fps on release builds, and improves debug build fps by ~10-15%

### Are there alternatives to your fix?
Ideally, I'd like to fix the RenderX methods to be better, but didn't see anything obviously wrong to move forward with such a direction

### Background info from issue
Currently the legacy lighting operates on a 5 frame loop for rendering. Each frame render Count is incremented and than wraps. 
The selection of at which renderCount value at which to call each of RenderTiles, RenderWalls, and related is optimized to be as flat as possible for Legacy Lighting - for the example well lit case on my setup, appx 30ms for each frame on all 5 of the frames. This avoids jitter in frame delivery.

However, the new Colour lighting in 1.4 uses a 4 frame loop with vastly different render times;
As-is for the scenario; frames 0-2 take about 7-10 ms to render, while frame 3 takes 45 ms. This is extremely unbalanced. 
Thus this PR rebalances the load so all frame is closer to 15-20ms at worst case and thus reduces jitter in frame delivery.

### Screenshots of Performance Improvement
![Temp-Rendering](https://user-images.githubusercontent.com/59670736/133136206-877b8509-11d8-4b3d-8e6d-505c435b760b.png)

TopLeft: tModLoader, pre-change, Debug build
TopRight: tModLoader, pre-change, Release Build
BottomLeft: tModLoader, post-change, Debug Build
BottomRight: tModLoader, post-change, Release Build
CenterBottom: Terraria, at 133% zoom due to forced min zoom (so approximately 3/4 of the total tiles to render), assumed Release build, for reference purely
