### PR TITLE
Add Error Handling 'no callback received' Failure Mode

### DIFF
--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -3,6 +3,7 @@ using Steamworks;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -491,9 +492,10 @@ namespace Terraria.Social.Steam
 
 					_queryHook.Set(call);
 
-					int counter = 0;
+					var stopwatch = Stopwatch.StartNew();
+
 					do {
-						if (++counter > 2000) // 10 seconds maximum allotted time before assumed no connection
+						if (stopwatch.Elapsed.TotalSeconds >= 10) // 10 seconds maximum allotted time before no connection is assumed
 							_primaryQueryResult = EResult.k_EResultTimeout;
 
 						ForceCallbacks();
@@ -647,8 +649,12 @@ namespace Terraria.Social.Steam
 
 					_queryHook.Set(call);
 
+					var stopwatch = Stopwatch.StartNew();
+
 					do {
-						// Do Pretty Stuff if want here
+						if (stopwatch.Elapsed.TotalSeconds >= 10) // 10 seconds maximum allotted time before no connection is assumed
+							_primaryQueryResult = EResult.k_EResultTimeout;
+
 						ForceCallbacks();
 					}
 					while (_primaryQueryResult == EResult.k_EResultNone);

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -493,7 +493,7 @@ namespace Terraria.Social.Steam
 
 					int counter = 0;
 					do {
-						if (++counter > 2000) // 10 seconds maximum alotted time before assumed no connection
+						if (++counter > 2000) // 10 seconds maximum allotted time before assumed no connection
 							_primaryQueryResult = EResult.k_EResultTimeout;
 
 						ForceCallbacks();


### PR DESCRIPTION
### What is the bug?
There is currently a gap where if no callback is received (which shouldn't happen as either Game Server API or SteamAPI will have initialized if its reaching such a code point, and thus callbacks must be delivered), but nevertheless, doesn't hurt to make sure the failure mode is caught instead of an infinite loop.