### PR TITLE
Add Error Logging To Wrap Fatal Unloading of Hooks on Release tML

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -416,10 +416,9 @@ namespace Terraria.ModLoader
 					Console.WriteLine($"Unloading {mod.DisplayName}...");
 				else
 					Interface.loadMods.SetCurrentMod(i++, mod.DisplayName);
-				
-				MonoModHooks.RemoveAll(mod);
-				
+
 				try {
+					MonoModHooks.RemoveAll(mod);
 					mod.Close();
 					mod.UnloadContent();
 				}

--- a/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
@@ -51,14 +51,14 @@ namespace Terraria.ModLoader
 			HookEndpointManager.OnModify += (m, d) => {
 				Logging.tML.Debug($"Hook IL.{StringRep(m)} modified by {GetOwnerName(d)}");
 #if RELEASE
-				throw new NotSupportedException("Hook modification Not Currently Supported on Release Builds As Unloading Fails");
+				Logging.tML.Error("Hook modification Not Currently Supported on Release Builds As Unloading Fails");
 #endif
 				return true;
 			};
 			HookEndpointManager.OnUnmodify += (m, d) => {
 				Logging.tML.Debug($"Hook IL.{StringRep(m)} unmodified by {GetOwnerName(d)}");
 #if RELEASE
-				throw new NotSupportedException("Hook modification Not Currently Supported on Release Builds As Unloading Fails");
+				Logging.tML.Error("Hook modification Not Currently Supported on Release Builds As Unloading Fails");
 #endif
 				return true;
 			};

--- a/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
@@ -50,10 +50,16 @@ namespace Terraria.ModLoader
 			};
 			HookEndpointManager.OnModify += (m, d) => {
 				Logging.tML.Debug($"Hook IL.{StringRep(m)} modified by {GetOwnerName(d)}");
+#if RELEASE
+				throw new NotSupportedException("Hook modification Not Currently Supported on Release Builds As Unloading Fails");
+#endif
 				return true;
 			};
 			HookEndpointManager.OnUnmodify += (m, d) => {
 				Logging.tML.Debug($"Hook IL.{StringRep(m)} unmodified by {GetOwnerName(d)}");
+#if RELEASE
+				throw new NotSupportedException("Hook modification Not Currently Supported on Release Builds As Unloading Fails");
+#endif
 				return true;
 			};
 


### PR DESCRIPTION
Why should this be merged?
- This moves away from a fatal unloading due to random looking error (https://github.com/tModLoader/tModLoader/issues/1809) to instead log an error on mod loading on release versions of tML. This is more practical in terms of isolating the issue to a known location and making clear what is the breaking code included in a mod.

Why isn't this a bug fix?
- No fix could be found for the bug. Its very nature appears too transient and random for my sanity