### PR TITLE
[1.4] Patch Steam Multiplayer

### DIFF
--- a/patches/tModLoader/Terraria/Netplay.cs.patch
+++ b/patches/tModLoader/Terraria/Netplay.cs.patch
@@ -67,15 +67,25 @@
  				Main.menuMode = 0;
  			}
  			else {
-@@ -421,6 +_,7 @@
+@@ -421,6 +_,12 @@
  		}
  
  		private static void ClientLoopSetup(RemoteAddress address) {
-+			Logging.Terraria.InfoFormat("Connecting to {0}", address.GetFriendlyName());
++			string friendlyName = address.GetFriendlyName();
++			if (string.IsNullOrEmpty(friendlyName))
++				Utils.ShowFancyErrorMessage("Unable to find Steam Hosted Multiplayer server.", 0);
++
++			Logging.Terraria.InfoFormat("Connecting to {0}", friendlyName);
++			
  			Connection.ResetSpecialFlags();
  			ResetNetDiag();
  			Main.ServerSideCharacter = false;
-@@ -441,9 +_,11 @@
+@@ -437,13 +_,15 @@
+ 			Main.netMode = 1;
+ 			Main.menuMode = 14;
+ 			if (!Main.autoPass)
+-				Main.statusText = Language.GetTextValue("Net.ConnectingTo", address.GetFriendlyName());
++				Main.statusText = Language.GetTextValue("Net.ConnectingTo", friendlyName);
  
  			Disconnect = false;
  			Connection = new RemoteServer();

--- a/patches/tModLoader/Terraria/Properties/launchSettings.json.patch
+++ b/patches/tModLoader/Terraria/Properties/launchSettings.json.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/Properties/launchSettings.json
 +++ src/tModLoader/Terraria/Properties/launchSettings.json
-@@ -2,14 +_,21 @@
+@@ -2,14 +_,27 @@
    "profiles": {
      "Terraria": {
        "commandName": "Executable",
@@ -21,6 +21,12 @@
 +      "commandName": "Executable",
 +      "executablePath": "dotnet",
 +      "commandLineArgs": "$(OutputName).dll -nosteam",
++      "workingDirectory": "$(tModLoaderSteamPath)"
++    },
++    "Terraria Steam Server": {
++      "commandName": "Executable",
++      "executablePath": "dotnet",
++      "commandLineArgs": "$(OutputName).dll -server -steam -lobby friends -friendsoffriends",
 +      "workingDirectory": "$(tModLoaderSteamPath)"
      }
    }

--- a/patches/tModLoader/Terraria/Social/Steam/NetServerSocialModule.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/NetServerSocialModule.cs.patch
@@ -12,3 +12,13 @@
  		}
  
  		private bool OnPacketRead(byte[] data, int length, CSteamID userId) {
+@@ -177,6 +_,9 @@
+ 
+ 				_connectionStateMap[steamIDRemote] = ConnectionState.Authenticating;
+ 				_connectionAcceptedCallback(new SocialSocket(new SteamAddress(steamIDRemote)));
++			}
++			else {
++				Utils.LogAndConsoleInfoMessage("User " + SteamFriends.GetFriendPersonaName(steamIDRemote) + "connection rejected. Not a friend of lobby Owner.\nSet allow Friends of Friends to accept non-Friends of Host.");
+ 			}
+ 		}
+ 	}

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -92,7 +92,7 @@ namespace Terraria.Social.Steam
 
 			internal static void Initialize() {
 				// Non-steam tModLoader will use the SteamGameServer to perform Browsing & Downloading
-				if (ModLoader.Engine.InstallVerifier.IsSteam) {
+				if (SocialMode.Steam == SocialAPI.Mode) {
 					SteamUser = true;
 					return;
 				}


### PR DESCRIPTION
Bug #1707 fix

- Remove influence of InstallVerifier so the GameServer doesn't accidentally init on Steam Server
- Add error-handling where logging/errors should have been handled in vanilla
- Add a correctly configured Steam Server launch configuration for testing purposes
