### PR TITLE
WIP: Refresh config ui after save/revert config

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
@@ -227,10 +227,14 @@ namespace Terraria.ModLoader.Config.UI
 
 		// Refreshes the UI to refresh recent changes such as Save/Discard/Restore Defaults/Cycle to next config
 		private void DoMenuModeState() {
-			if (Main.gameMenu)
+			if (Main.gameMenu) {
 				Main.menuMode = Interface.modConfigID;
-			else
+				Main.MenuUI.RefreshState();
+			}
+			else {
 				Main.InGameUI.SetState(Interface.modConfig);
+				Main.InGameUI.RefreshState();
+			}
 		}
 
 		private void SaveConfig(UIMouseEvent evt, UIElement listeningElement) {
@@ -333,7 +337,8 @@ namespace Terraria.ModLoader.Config.UI
 				DoMenuModeState();
 				netUpdate = false;
 			}
-			if (!updateNeeded) return;
+			if (!updateNeeded)
+				return;
 			updateNeeded = false;
 			mainConfigList.Clear();
 			mainConfigList.AddRange(mainConfigItems.Where(item => {
@@ -341,7 +346,7 @@ namespace Terraria.ModLoader.Config.UI
 					return configElement.TextDisplayFunction().IndexOf(filterTextField.CurrentString, StringComparison.OrdinalIgnoreCase) != -1;
 				}
 				return true;
-			}).Select(x=>x.Item1));
+			}).Select(x => x.Item1));
 			Recalculate();
 		}
 
@@ -574,7 +579,7 @@ namespace Terraria.ModLoader.Config.UI
 					parent.Height.Set(top, 0);
 				}
 				var tuple = new Tuple<UIElement, UIElement>(container, e);
-				if(parent == Interface.modConfig.mainConfigList) {
+				if (parent == Interface.modConfig.mainConfigList) {
 					Interface.modConfig.mainConfigItems.Add(tuple);
 				}
 


### PR DESCRIPTION
WIP: Refresh ui after save/revert config.

At present, the button still exists after clicking the button, no good interactive feedback.

Now will be refresh feedback after clicking the save or revert button.

<!--
We recommend using one of our pull request templates if you want your PR taken seriously.

You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.
If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:

Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->
