### PR TITLE
1.4 NeedSaving removal

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedGlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedGlobalItem.cs
@@ -17,12 +17,8 @@ namespace Terraria.ModLoader.Default
 			return clone;
 		}
 
-		public override bool NeedsSaving(Item item) {
-			return data.Count > 0;
-		}
-
 		public override TagCompound Save(Item item) {
-			return new TagCompound { ["modData"] = data };
+			return data.Count == 0 ? null : new TagCompound { ["modData"] = data };
 		}
 
 		public override void Load(Item item, TagCompound tag) {

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -846,14 +846,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Whether or not the given item needs to save custom data. Returning false will save on the memory used in saving an item, but returning true is necessary in order to save data across all items or vanilla items. Returns false by default. Note that the return value of this hook must be deterministic (randomness is not allowed).
-		/// </summary>
-		public virtual bool NeedsSaving(Item item) {
-			return false;
-		}
-
-		/// <summary>
-		/// Allows you to save custom data for the given item. Only called when NeedsCustomSaving returns true. Returns false by default.
+		/// Allows you to save custom data for the given item. Returns null by default.
 		/// </summary>
 		public virtual TagCompound Save(Item item) {
 			return null;

--- a/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
@@ -119,13 +119,14 @@ namespace Terraria.ModLoader.IO
 			var list = new List<TagCompound>();
 			foreach (var globalItem in ItemLoader.globalItems) {
 				var globalItemInstance = globalItem.Instance(item);
-				if (globalItemInstance == null || !globalItemInstance.NeedsSaving(item))
+				TagCompound data = globalItemInstance?.Save(item);
+				if(data == null)
 					continue;
 
 				list.Add(new TagCompound {
 					["mod"] = globalItemInstance.Mod.Name,
 					["name"] = globalItemInstance.Name,
-					["data"] = globalItemInstance.Save(item)
+					["data"] = data
 				});
 			}
 			return list.Count > 0 ? list : null;

--- a/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
@@ -32,7 +32,9 @@ namespace Terraria.ModLoader.IO
 		internal static void WriteByteVanillaPrefix(int prefix, BinaryWriter writer)
 			=> writer.Write((byte)(prefix >= PrefixID.Count ? 0 : prefix));
 
-		public static TagCompound Save(Item item) {
+		public static TagCompound Save(Item item) => Save(item, SaveGlobals(item));
+
+		public static TagCompound Save(Item item, List<TagCompound> globalData) {
 			var tag = new TagCompound();
 			if (item.type <= 0)
 				return tag;
@@ -65,7 +67,7 @@ namespace Terraria.ModLoader.IO
 			if (item.favorited)
 				tag.Set("fav", true);
 
-			tag.Set("globalData", SaveGlobals(item));
+			tag.Set("globalData", globalData);
 
 			return tag;
 		}

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -86,7 +86,7 @@ namespace Terraria.ModLoader.IO
 			var list = new List<TagCompound>();
 			for (int k = 0; k < inv.Length; k++) {
 				var globalData = ItemIO.SaveGlobals(inv[k]);
-				if (globalData != null && ItemLoader.NeedsModSaving(inv[k])) {
+				if (globalData != null || ItemLoader.NeedsModSaving(inv[k])) {
 					var tag = ItemIO.Save(inv[k], globalData);
 					if (tag.Count != 0) {
 						tag.Set("slot", (short)k);

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -85,10 +85,13 @@ namespace Terraria.ModLoader.IO
 		public static List<TagCompound> SaveInventory(Item[] inv) {
 			var list = new List<TagCompound>();
 			for (int k = 0; k < inv.Length; k++) {
-				if (ItemLoader.NeedsModSaving(inv[k])) {
-					var tag = ItemIO.Save(inv[k]);
-					tag.Set("slot", (short)k);
-					list.Add(tag);
+				var globalData = ItemIO.SaveGlobals(inv[k]);
+				if (globalData != null && ItemLoader.NeedsModSaving(inv[k])) {
+					var tag = ItemIO.Save(inv[k], globalData);
+					if (tag.Count != 0) {
+						tag.Set("slot", (short)k);
+						list.Add(tag);
+					}
 				}
 			}
 			return list.Count > 0 ? list : null;

--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Annequin.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Annequin.cs
@@ -49,8 +49,6 @@ namespace Terraria.ModLoader.IO
 			ISet<int> headSlots = new HashSet<int>();
 			ISet<int> bodySlots = new HashSet<int>();
 			ISet<int> legSlots = new HashSet<int>();
-			IDictionary<int, (int itemFrameId, List<TagCompound> globalData)> itemFrames = 
-				new Dictionary<int, (int, List<TagCompound>)>();
 			for (int i = 0; i < Main.maxTilesX; i++) {
 				for (int j = 0; j < Main.maxTilesY; j++) {
 					Tile tile = Main.tile[i, j];
@@ -74,11 +72,15 @@ namespace Terraria.ModLoader.IO
 				}
 			}
 			int tileEntity = 0;
+			List<TagCompound> itemFrames = new List<TagCompound>();
 			foreach (KeyValuePair<int, TileEntity> entity in TileEntity.ByID) {
 				if (entity.Value is TEItemFrame itemFrame) {
 					var globalData = ItemIO.SaveGlobals(itemFrame.item);
 					if (globalData != null || ItemLoader.NeedsModSaving(itemFrame.item)) {
-						itemFrames.Add(itemFrame.ID, (tileEntity, globalData));
+						itemFrames.Add(new TagCompound {
+							["id"] = tileEntity,
+							["item"] = ItemIO.Save(itemFrame.item, globalData)
+						});
 						//flags[0] |= 2; legacy
 						numFlags = 1;
 					}
@@ -119,12 +121,7 @@ namespace Terraria.ModLoader.IO
 			tag.Set("data", ms.ToArray());
 
 			if (itemFrames.Count > 0) {
-				tag.Set("itemFrames", itemFrames.Select(entry =>
-					new TagCompound {
-						["id"] = entry.Value.itemFrameId,
-						["item"] = ItemIO.Save(((TEItemFrame)TileEntity.ByID[entry.Key]).item, entry.Value.globalData)
-					}
-				).ToList());
+				tag.Set("itemFrames", itemFrames);
 			}
 			return tag;
 		}

--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Annequin.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Annequin.cs
@@ -71,6 +71,7 @@ namespace Terraria.ModLoader.IO
 					}
 				}
 			}
+			
 			int tileEntity = 0;
 			List<TagCompound> itemFrames = new List<TagCompound>();
 			foreach (KeyValuePair<int, TileEntity> entity in TileEntity.ByID) {
@@ -88,6 +89,7 @@ namespace Terraria.ModLoader.IO
 				if(!(entity.Value is ModTileEntity))
 					tileEntity++;
 			}
+			
 			if (numFlags == 0) {
 				return null;
 			}

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1848,11 +1848,10 @@ namespace Terraria.ModLoader
 		internal static void VerifyGlobalItem(GlobalItem item) {
 			var type = item.GetType();
 			int saveMethods = 0;
-			if (HasMethod(type, "NeedsSaving", typeof(Item))) saveMethods++;
 			if (HasMethod(type, "Save", typeof(Item))) saveMethods++;
 			if (HasMethod(type, "Load", typeof(Item), typeof(TagCompound))) saveMethods++;
-			if (saveMethods > 0 && saveMethods < 3)
-				throw new Exception(type + " must override all of (NeedsSaving/Save/Load) or none");
+			if (saveMethods == 1)
+				throw new Exception(type + " must override all of (Save/Load) or none");
 
 			int netMethods = 0;
 			if (HasMethod(type, "NetSend", typeof(Item), typeof(BinaryWriter))) netMethods++;

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1815,19 +1815,13 @@ namespace Terraria.ModLoader
 
 			return tooltips;
 		}
-
-		private static HookList HookNeedsSaving = AddHook<Func<Item, bool>>(g => g.NeedsSaving);
+		
 		public static bool NeedsModSaving(Item item) {
 			if (item.type <= ItemID.None)
 				return false;
 
 			if (item.ModItem != null || item.prefix >= PrefixID.Count)
 				return true;
-
-			foreach (var g in HookNeedsSaving.Enumerate(item.globalItems)) {
-				if (g.NeedsSaving(item))
-					return true;
-			}
 
 			return false;
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1816,7 +1816,7 @@ namespace Terraria.ModLoader
 			return tooltips;
 		}
 		
-		public static bool NeedsModSaving(Item item) {
+		internal static bool NeedsModSaving(Item item) {
 			if (item.type <= ItemID.None)
 				return false;
 


### PR DESCRIPTION
### What is the removed feature?
On GlobalItem, there's a method, NeedSaving and following a discussion on Discord, it was said that it should be removed

### Why should this be part of tModLoader?
Essentially, you can easily achieve the same thing by making saving null do the same, it removes the useless NeedSaving => true as they can simply do this check at the start of Save() and return null if it doesn't need saving.

### ExampleMod updates
Surprisingly, there's no GlobalItem Save/Load on ExampleMod, so nothing to update

Note : I didn't test this code with item saving yet