### PR TITLE
Update TerrariaHooks to remove Posix Mono error on Mac

### DIFF
--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -86,7 +86,7 @@
 +    <Content Include="Libraries/Native/**" CopyToOutputDirectory="PreserveNewest" />
 +  </ItemGroup>
 +  <ItemGroup>
-+    <PackageReference Include="MonoMod.RuntimeDetour" Version="21.4.21.3" />
++    <PackageReference Include="MonoMod.RuntimeDetour" Version="21.8.19.1" />
 +    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
 +    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.9.0" />
 +    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />

--- a/setup/setup.csproj
+++ b/setup/setup.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.4.0" />
-    <PackageReference Include="MonoMod.RuntimeDetour.HookGen" Version="21.4.2.3" />
+    <PackageReference Include="MonoMod.RuntimeDetour.HookGen" Version="21.8.19.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="PatchReviewer\PatchReviewer.csproj" />


### PR DESCRIPTION
### What is the bug?
MonoMod.Detour was updated after our last update of TerrariaHooks to stop erroring on missing Mono.Posix when not using Mono. This in particular has shown up in every Mac logs, so it would be helpful to eliminate irrelevant errors. 

### How did you fix the bug?

Updated Terraria hooks by arunning a new debug build for 1.4, than updateing the version of both HookGen & Detour in Setup and tmod.csproj respecitvely. Than ran hookgen and  diffed, than rebuilt and checked that a few mods are still working (Better Mod List, Magic Storage, and ExampleMod)

### Are there alternatives to your fix?

