### PR TITLE
[1.4] Document/publicise some weather methods

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Events/Sandstorm.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Events/Sandstorm.cs.patch
@@ -45,3 +45,25 @@
  					}
  				}
  
+@@ -81,13 +_,19 @@
+ 				Severity = IntendedSeverity;
+ 		}
+ 
++		/// <summary>
++		/// Starts sandstorm for a random amount of time. Should be called on the server (netMode != client) - the method syncs it automatically.
++		/// </summary>
+-		private static void StartSandstorm() {
++		public static void StartSandstorm() {
+ 			Happening = true;
+ 			TimeLeft = Main.rand.Next(28800, 86401);
+ 			ChangeSeverityIntentions();
+ 		}
+ 
++		/// <summary>
++		/// Stops sandstorm. Should be called on the server (netMode != client) - the method syncs it automatically.
++		/// </summary>
+-		private static void StopSandstorm() {
++		public static void StopSandstorm() {
+ 			Happening = false;
+ 			TimeLeft = 0;
+ 			ChangeSeverityIntentions();

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -104,5 +104,19 @@ namespace Terraria
 					spriteBatch.Draw(TextureAssets.InfoIcon[13].Value, buttonPosition - Vector2.One * 2f, null, OurFavoriteColor, 0f, default, 1f, SpriteEffects.None, 0f);
 			}
 		}
+
+		//Mirrors code used in UpdateTime
+		/// <summary>
+		/// Syncs rain state if <see cref="StartRain"/> or <see cref="StopRain"/> were called in the same tick and caused a change to <seealso cref="maxRaining"/>.
+		/// <br>Can be called on any side, but only the server will actually sync it.</br>
+		/// </summary>
+		public static void SyncRain() {
+			if (maxRaining != oldMaxRaining) {
+				if (netMode == 2)
+					NetMessage.SendData(7);
+
+				oldMaxRaining = maxRaining;
+			}
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -4174,6 +4174,27 @@
  		public static void NewText(string newText, byte R = byte.MaxValue, byte G = byte.MaxValue, byte B = byte.MaxValue) {
  			chatMonitor.NewText(newText, R, G, B);
  			SoundEngine.PlaySound(12);
+@@ -49273,12 +_,20 @@
+ 			SoundEngine.PlaySound(12);
+ 		}
+ 
++		/// <summary>
++		/// Stops rain. Should be called on the server (netMode != client) - vanilla syncs it using <see cref="SyncRain"/>.
++		/// <br>You can also call this on the client to update visuals immediately, assuming it was called serverside aswell (Journey Mode rain slider does this).</br>
++		/// </summary>
+ 		public static void StopRain() {
+ 			rainTime = 0;
+ 			raining = false;
+ 			maxRaining = 0f;
+ 		}
+ 
++		/// <summary>
++		/// Starts rain for a random amount of time. Should be called on the server (netMode != client) - vanilla syncs it using <see cref="SyncRain"/>.
++		/// <br>You can also call this on the client to update visuals immediately, assuming it was/will be called serverside aswell (Journey Mode rain slider does this).</br>
++		/// </summary>
+ 		public static void StartRain() {
+ 			int num = 86400;
+ 			int num2 = num / 24;
 @@ -49390,7 +_,7 @@
  			}
  


### PR DESCRIPTION
### What is the new feature?
1. Make `Sandstorm.Start/StopSandstorm` public, add documentation
2. Document `Main.Start/StopRain`, add helper method (`Main.SyncRain`)

### Why should this be part of tModLoader?
1. Modders will not need to use reflection to invoke the sandstorm methods
2. Documentation is always nice, the added method does not modify vanilla in any way either, only exists for modder convenience to use alongside `Main.Start/StopRain`

### Are there alternative designs?
Mirsario suggested directly modifying the `Main.Start/StopRain` to automatically sync when invoked. This however would require more changes to be made, especially regarding how the journey mode rain slider works.

### Sample usage for the new feature
```cs
if (!Sandstorm.Happening) {
    Sandstorm.StartSandstorm();
}

if (Main.netMode == 2 && Main.maxRaining == 0) {
    Main.StartRain();
    Main.SyncRain();
}
```

### ExampleMod updates
No

