### PR TITLE
[1.4] (ExampeMod) Remove Acid Venom immunity from MinionBossBody and MinionBossMinion

### DIFF
--- a/ExampleMod/Content/NPCs/MinionBoss/MinionBossBody.cs
+++ b/ExampleMod/Content/NPCs/MinionBoss/MinionBossBody.cs
@@ -113,7 +113,6 @@ namespace ExampleMod.Content.NPCs.MinionBoss
 			NPCDebuffImmunityData debuffData = new NPCDebuffImmunityData {
 				SpecificallyImmuneTo = new int[] {
 					BuffID.Poisoned,
-					BuffID.Venom, // If you make it immune to Poisoned, also make it immune to Venom
 
 					BuffID.Confused // Most NPCs have this
 				}

--- a/ExampleMod/Content/NPCs/MinionBoss/MinionBossMinion.cs
+++ b/ExampleMod/Content/NPCs/MinionBoss/MinionBossMinion.cs
@@ -53,7 +53,6 @@ namespace ExampleMod.Content.NPCs.MinionBoss
 			NPCDebuffImmunityData debuffData = new NPCDebuffImmunityData {
 				SpecificallyImmuneTo = new int[] {
 					BuffID.Poisoned,
-					BuffID.Venom, // If you make it immune to Poisoned, also make it immune to Venom
 
 					BuffID.Confused // Most NPCs have this
 				}


### PR DESCRIPTION
### What are the changes to ExampleMod?
In MinionBossBody.cs and MinionBossMinion.cs, it is falsely stated that if an enemy is immune to poison, it should also be immune to venom. This is not the case in 1.4.1, since venom was renamed to 'Acid Venom', and a significant amount of enemies had their immunity to it removed.
This PR simply removes the immunity from MinionBossBody and MinionBossMinion.

### Do these changes need additional documentation?
I don't think so.