### PR TITLE
TmodFile.GetFileNames() and Mod.GetFileNames()

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
@@ -90,6 +90,8 @@ namespace Terraria.ModLoader.Core
 				return stream.ReadBytes(entry.Length);
 		}
 
+		public List<string> GetFileNames() => files.Keys.ToList();
+
 		public byte[] GetBytes(string fileName) => files.TryGetValue(Sanitize(fileName), out var entry) ? GetBytes(entry) : null;
 
 		public Stream GetStream(FileEntry entry, bool newFileStream = false) {

--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -320,6 +320,13 @@ namespace Terraria.ModLoader
 		public LegacySoundStyle GetLegacySoundSlot(SoundType type, string name) => SoundLoader.GetLegacySoundSlot(type, Name + '/' + name);
 
 		/// <summary>
+		/// Retrieves the names of every file packaged into this mod.
+		/// Note that this includes extensions, and for images the extension will always be <c>.rawimg</c>.
+		/// </summary>
+		/// <returns></returns>
+		public List<string> GetFileNames() => File?.GetFileNames();
+
+		/// <summary>
 		/// Retrieve contents of files within the tmod file
 		/// </summary>
 		/// <param name="name">The name.</param>


### PR DESCRIPTION
### What is the new feature?
The `TmodFile.GetFileNames()` and `Mod.GetFileNames()` methods.

### Why should this be part of tModLoader?
Currently, there is no way to get the name of every file in your mods `TmodFile`. Getting and querying every file name is invaluable for dynamic file reading, and lets you avoid having to hardcode every file path you want to read.

### Are there alternative designs?
No. `Mod.Assets` and every other asset loading related method only cares about files it considers assets - that is, files with an existing asset reader. This is used to get every file name in the `TmodFIle`, not every asset file name.

### Sample usage for the new feature
Any custom data driven feature - say, data driven simple material items - requires you to know the name of every file with the data that you need to load. This could be done by hardcoding a list of file paths, but it's much more elegant to autoload all the files in a certain directory.

### ExampleMod updates
N/A
