### PR TITLE
fix #1838

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/States/UICharacterCreation.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UICharacterCreation.cs.patch
@@ -13,7 +13,7 @@
  			_player.savedPerPlayerFieldsThatArentInThePlayerClass = new Player.SavedPlayerDataWithAnnoyingRules();
  			CreativePowerManager.Instance.ResetDataForNewPlayer(_player);
 +
-+			PlayerLoader.SetStartInventory(_player, PlayerLoader.GetStartingItems(_player, _player.inventory.Where(item => !item.IsAir)));
++			PlayerLoader.SetStartInventory(_player, PlayerLoader.GetStartingItems(_player, _player.inventory.Where(item => !item.IsAir).Select(x => x.Clone())));
  		}
  
  		private bool GetHexColor(string hexString, out Vector3 hsl) {

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -76,9 +76,19 @@ namespace Terraria.ModLoader
 		}
 
 		public static void SetStartInventory(Player player, IList<Item> items) {
+			// Be careful. The item in the items and the item in the inventory are the same object.
+			// If you empty the inventory in advance, the items will also be empty.
+			// So need to make a deep copy first, then empty the inventory.
+			for (int i = 0; i < items.Count; i++) {
+				items[i] = items[i].Clone();
+			}
+			
 			if (items.Count <= 50) {
-				for (int k = 0; k < items.Count && k < 49; k++)
+				int k;
+				for (k = 0; k < items.Count && k < 50; k++)
 					player.inventory[k] = items[k];
+				for (; k < 50; k++)
+					player.inventory[k].SetDefaults();
 			}
 			else {
 				for (int k = 0; k < 49; k++) {

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -76,19 +76,12 @@ namespace Terraria.ModLoader
 		}
 
 		public static void SetStartInventory(Player player, IList<Item> items) {
-			// Be careful. The item in the items and the item in the inventory are the same object.
-			// If you empty the inventory in advance, the items will also be empty.
-			// So need to make a deep copy first, then empty the inventory.
-			for (int i = 0; i < items.Count; i++) {
-				items[i] = items[i].Clone();
-			}
-			
 			if (items.Count <= 50) {
-				int k;
-				for (k = 0; k < items.Count && k < 50; k++)
-					player.inventory[k] = items[k];
-				for (; k < 50; k++)
-					player.inventory[k].SetDefaults();
+				for (int k = 0; k < 50; k++)
+					if (k < items.Count)
+						player.inventory[k] = items[k];
+					else
+						player.inventory[k].SetDefaults();
 			}
 			else {
 				for (int k = 0; k < 49; k++) {


### PR DESCRIPTION
### What is the bug?

When the items length is shorter than the original length, the items in the inventory will fail to be overwritten.
And when there are just 50 items, the 50th item will be lost.

### How did you fix the bug?

Make a deep copy of items, then overwrite them, and clear all the others.

### Are there alternatives to your fix?

No.
Other methods need to modify the vanilla code.
