### PR TITLE
[1.4] Make 'ProcessGroupsForText' and 'AcceptedByItemGroups' public

### DIFF
--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -78,35 +78,31 @@
  					if (acceptedGroups[num] == -1)
  						break;
  
-@@ -66,13 +_,9 @@
- 			acceptedGroups[num] = id;
+@@ -67,12 +_,8 @@
  		}
  
--		public bool ProcessGroupsForText(int type, out string theText) {
+ 		public bool ProcessGroupsForText(int type, out string theText) {
 -			for (int i = 0; i < maxRequirements; i++) {
 -				int num = acceptedGroups[i];
 -				if (num == -1)
 -					break;
 -
 -				if (RecipeGroup.recipeGroups[num].ValidItems.Contains(type)) {
-+		internal bool ProcessGroupsForText(int type, out string theText) {
 +			foreach (int num in acceptedGroups) {
 +				if (RecipeGroup.recipeGroups[num].ContainsItem(type)) {
  					theText = RecipeGroup.recipeGroups[num].GetText();
  					return true;
  				}
-@@ -82,35 +_,35 @@
- 			return false;
+@@ -83,34 +_,34 @@
  		}
  
--		public bool AcceptedByItemGroups(int invType, int reqType) {
+ 		public bool AcceptedByItemGroups(int invType, int reqType) {
 -			for (int i = 0; i < maxRequirements; i++) {
 -				int num = acceptedGroups[i];
 -				if (num == -1)
 -					break;
 -
 -				if (RecipeGroup.recipeGroups[num].ValidItems.Contains(invType) && RecipeGroup.recipeGroups[num].ValidItems.Contains(reqType))
-+		internal bool AcceptedByItemGroups(int invType, int reqType) {
 +			foreach (int num in acceptedGroups) {
 +				if (RecipeGroup.recipeGroups[num].ContainsItem(invType) && RecipeGroup.recipeGroups[num].ContainsItem(reqType))
  					return true;


### PR DESCRIPTION
### What is the bug?
Recipe methods 'ProcessGroupsForText' and 'AcceptedByItemGroups' were (mistakenly?) made internal

### How did you fix the bug?
Made them public again

### Are there alternatives to your fix?

