### PR TITLE
Fix mono launch script on non-standard LD_LIBRARY_PATH

### DIFF
--- a/solutions/ReleaseExtras/tModLoader-mono
+++ b/solutions/ReleaseExtras/tModLoader-mono
@@ -18,7 +18,7 @@ if [ "$UNAME" == "Darwin" ]; then
 		export DYLD_INSERT_LIBRARIES="$STEAM_DYLD_INSERT_LIBRARIES"
 	fi
 else
-	export LD_LIBRARY_PATH=lib:lib64
+	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:lib:lib64"
 fi
 
 # move all kickstart mono libraries to a sys/ folder to remove conflicts


### PR DESCRIPTION
### What is the bug?

On non-standard `LD_LIBRARY_PATH` environment values (such as NixOS) the provided tModLoader mono launch script will not locate essential libraries (PulseAudio, xinput, etc.) and will be unusable.

### How did you fix the bug?

Instead of forcefully setting `LD_LIBRARY_PATH` to `lib:lib64` (which would load ./lib/, /lib/, ./lib64/ and /lib64/) it's instead added to the path with `$LD_LIBRARY_PATH:lib:lib64`

### Are there alternatives to your fix?

Not that I know of. This is how environment values that contain paths are usually added to in Unix shell scripts, and the current version only works by accident (I wasn't even aware you could load /lib with just `lib`).

This may also need similar fixes on MacOS, but I do not have a Mac PC so I cannot personally test any changes.