### PR TITLE
Many Misc Tiny Fixes

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -411,16 +411,14 @@ namespace Terraria.ModLoader
 			MenuLoader.Unload(); //do this early, so modded menus won't be active when unloaded
 			
 			int i = 0;
-			
 			foreach (var mod in ModLoader.Mods.Reverse()) {
 				if (Main.dedServ)
 					Console.WriteLine($"Unloading {mod.DisplayName}...");
 				else
 					Interface.loadMods.SetCurrentMod(i++, mod.DisplayName);
-				
-				MonoModHooks.RemoveAll(mod);
-				
+
 				try {
+					MonoModHooks.RemoveAll(mod);
 					mod.Close();
 					mod.UnloadContent();
 				}

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -108,7 +108,7 @@ namespace Terraria.ModLoader.UI
 
 #if RELEASE
 				// Temporary display for the alpha/beta version.
-				if (!betaWelcomed) {
+				if (!betaWelcomed && !ModLoader.ShowFirstLaunchWelcomeMessage) {
 					betaWelcomed = true;
 					infoMessage.Show(Language.GetTextValue("tModLoader.WelcomeMessageBeta"), Main.menuMode);
 				}

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -33,5 +33,12 @@ namespace Terraria
 					RuntimeHelpers.RunClassConstructor(type.TypeHandle);
 			}
 		}
+
+		/// <summary>
+		/// Ensure sufficient stack size (4MB) on MacOS & Windows secondary threads, doesn't hurt for Linux. 16^5 = 1MB, value in hex 
+		/// </summary>
+		private static void EnsureMinimumStackSizeOnThreads() {
+			Environment.SetEnvironmentVariable("COMPlus_DefaultStackSize", "400000");
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -87,7 +87,7 @@
  
  			try {
  				Console.OutputEncoding = Encoding.UTF8;
-@@ -138,32 +_,63 @@
+@@ -138,32 +_,65 @@
  			}
  		}
  
@@ -106,6 +106,8 @@
 +
 +			if (File.Exists("savehere.txt"))
 +				SavePath = "ModLoader"; // Fallback for unresolveable antivirus/onedrive issues. Also makes the game portable I guess.
++
++			EnsureMinimumStackSizeOnThreads();
 +
 +			bool isServer = LaunchParameters.ContainsKey("-server");
 +			try {

--- a/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.bat
+++ b/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.bat
@@ -3,6 +3,7 @@
 @echo off
 cd /D "%~dp0"
 set LOGFILE=LaunchLogs\install.log
+setlocal EnableDelayedExpansion
 
 if Not exist LaunchLogs (mkdir LaunchLogs)
 
@@ -59,25 +60,25 @@ REM install directories
 set INSTALLDIR=dotnet\%VERSIONSEL%
 
 REM Check if the install for our target NET already exists, and install if not
-if Not exist %INSTALLDIR%\dotnet.exe  (
-	echo Logging to LaunchLogs\install.log
+if Not exist "%~dp0%INSTALLDIR%\dotnet.exe" (
+	echo Logging to LaunchLogs\install.log	
 	call :LOG 1> %LOGFILE% 2>&1
 )
 
 REM If the install failed, provide a link to get the portable directly, and instructions on where to do with it.
-if not exist %INSTALLDIR%\dotnet.exe (
+if not exist "%~dp0%INSTALLDIR%\dotnet.exe" (
 	mkdir %INSTALLDIR%
 
 	echo %ColorRed%It has been detected that your system failed to install the dotnet portables automatically. Will now proceed manually.%ColorDefault%
 	start "" https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-%version%-windows-x64-binaries
 	echo Now manually downloading the x64 .NET portable. Please find it in the opened browser.
 	set /p DUMMY=Press 'ENTER' to proceed to the next step...
-	echo Please extract the downloaded Zip file contents in to "%~dp0\%INSTALLDIR%"
+	echo Please extract the downloaded Zip file contents in to "%~dp0%INSTALLDIR%"
 	set /p DUMMY=Please press Enter when this step is complete.
 	
 	:loop
-	if not exist %INSTALLDIR%\dotnet.exe (
-		set /p DUMMY=%ColorRed%%INSTALLDIR%\dotnet.exe not detected. Please ensure step is complete before continuing with Enter.%ColorDefault%
+	if not exist "%~dp0%INSTALLDIR%\dotnet.exe" (
+		set /p DUMMY=%ColorRed%.%~dp0%INSTALLDIR%\dotnet.exe not detected. Please ensure step is complete before continuing with Enter.%ColorDefault%
 		goto :loop
 	)
 )
@@ -96,4 +97,3 @@ for /d %%i in (dotnet/*) do (
 )
 echo Installing_NewFramework
 powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Channel %CHANNELSEL% -InstallDir %INSTALLDIR%\ -Version %VERSIONSEL% -Runtime %RUNTIMESELECT%"
-

--- a/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
+++ b/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
@@ -31,9 +31,6 @@ if [ -f "$unixSteamworks" ]; then
   mv "$unixSteamworks" "$defaultSteamworks"
 fi
 
-# Ensure sufficient stack size (4MB) on MacOS secondary threads, doesn't hurt for Linux. 16^5 = 1MB, value in hex 
-export COMPlus_DefaultStackSize=400000
-
 #Parse version from runtimeconfig, jq would be a better solution here, but its not installed by default on all distros.
 version=$(sed -n 's/^.*"version": "\(.*\)"/\1/p' <tModLoader.runtimeconfig.json) #sed, go die plskthx
 version=${version%$'\r'} # remove trailing carriage return that sed may leave in variable, producing a bad folder name

--- a/solutions/ReleaseExtras/RuntimeFiles/start-tModLoader.bat
+++ b/solutions/ReleaseExtras/RuntimeFiles/start-tModLoader.bat
@@ -1,11 +1,10 @@
 @echo off
 cd /D "%~dp0"
 set Args=%*
-setlocal EnableDelayedExpansion
 
-call InstallNetFramework.bat
-if exist %INSTALLDIR%\dotnet.exe ( 
-	start dotnet\%VERSIONSEL%\dotnet.exe tModLoader.dll %Args% 
-) else (
+if "%~1"=="-sysdotnet"  ( 
 	dotnet tModLoader.dll %Args%
+) else (
+	call InstallNetFramework.bat
+	start dotnet\%VERSIONSEL%\dotnet.exe tModLoader.dll %Args%
 )

--- a/solutions/ReleaseExtras/RuntimeFiles/start-tModLoaderServer.bat
+++ b/solutions/ReleaseExtras/RuntimeFiles/start-tModLoaderServer.bat
@@ -1,9 +1,6 @@
 @echo off
 cd /D "%~dp0"
 set Args=%* -server -config serverconfig.txt
-setlocal EnableDelayedExpansion
-
-call InstallNetFramework.bat
 
 set /P steam=Use Steam Server [y]/[n] steam:
 if NOT %steam%==y ( goto start )
@@ -14,8 +11,9 @@ if NOT %lobby%==p ( set Args=%Args% -lobby friends )
 if %lobby%==p ( set Args=%Args% -lobby private )
 
 :start
-if exist %INSTALLDIR%\dotnet.exe ( 
-	start dotnet\%VERSIONSEL%\dotnet.exe tModLoader.dll %Args% 
-) else (
+if "%~1"=="-sysdotnet"  ( 
 	dotnet tModLoader.dll %Args%
+) else (
+	call InstallNetFramework.bat
+	start dotnet\%VERSIONSEL%\dotnet.exe tModLoader.dll %Args%
 )


### PR DESCRIPTION
1) Cleanup MonoModHooks file to have less extra stuff going on
2) Improve logging surrounding MonoModHooks
3) Fix Beta Welcome message conflicting with the FirstLaunch Message for first time users
4) Add the COM_Plus variable in to tmodloader instead of start files, fixes #1718
5) Cleanup the manual install .NET instructions a bit
6) Add a "sysdotnet" launch param for start-tmod.bat files so can use a system dotnet in the event that portables just won't work (or w/e other reason).
7) Make InstallNetFramework.bat able to be run independent to start scripts again.
