### PR TITLE
[1.4] Fix ModTileEntity.GlobalUpdate methods not being called

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/TileEntitiesManager.TML.cs
+++ b/patches/tModLoader/Terraria/DataStructures/TileEntitiesManager.TML.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 
 namespace Terraria.DataStructures
@@ -21,7 +20,7 @@ namespace Terraria.DataStructures
 			return (tileEntity = entity as T) != null;
 		}
 
-		public IEnumerable<KeyValuePair<int, TileEntity>> EnumerateEntities() => _types;
+		public IReadOnlyDictionary<int, TileEntity> EnumerateEntities() => _types;
 
 		internal void Reset() {
 			_types.Clear();

--- a/patches/tModLoader/Terraria/DataStructures/TileEntity.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/TileEntity.cs.patch
@@ -31,7 +31,7 @@
  		}
  
  		public static void PlaceEntityNet(int x, int y, int type) {
-@@ -53,34 +_,61 @@
+@@ -53,34 +_,58 @@
  		public virtual void Update() {
  		}
  
@@ -54,9 +54,6 @@
 +
  			byte id = reader.ReadByte();
  			TileEntity tileEntity = manager.GenerateInstance(id);
-+ 			if(tileEntity is null) {
-+				ModTileEntity.ConstructFromType(id);
-+			}
  			tileEntity.type = id;
 -			tileEntity.ReadInner(reader, networkSend);
 +			tileEntity.ReadInner(reader, networkSend, lightSend);

--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -52,13 +52,13 @@ namespace Terraria.ModLoader
 		}
 
 		private static void UpdateStartInternal() {
-			foreach (ModTileEntity tileEntity in manager.EnumerateEntities().Select(pair => pair.Value).OfType<ModTileEntity>()) {
+			foreach (ModTileEntity tileEntity in manager.EnumerateEntities().Values.OfType<ModTileEntity>()) {
 				tileEntity.PreGlobalUpdate();
 			}
 		}
 
 		private static void UpdateEndInternal() {
-			foreach (ModTileEntity tileEntity in manager.EnumerateEntities().Select(pair => pair.Value).OfType<ModTileEntity>()) {
+			foreach (ModTileEntity tileEntity in manager.EnumerateEntities().Values.OfType<ModTileEntity>()) {
 				tileEntity.PostGlobalUpdate();
 			}
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -16,8 +16,7 @@ namespace Terraria.ModLoader
 	{
 		public static readonly int NumVanilla = Assembly.GetExecutingAssembly()
 			.GetTypes()
-			.Where(t => !t.IsAbstract && t.IsSubclassOf(typeof(TileEntity)) && !typeof(ModTileEntity).IsAssignableFrom(t))
-			.Count();
+			.Count(t => !t.IsAbstract && t.IsSubclassOf(typeof(TileEntity)) && !typeof(ModTileEntity).IsAssignableFrom(t));
 
 		// TODO: public bool netUpdate;
 
@@ -44,13 +43,7 @@ namespace Terraria.ModLoader
 		/// Returns the number of modded tile entities that exist in the world currently being played.
 		/// </summary>
 		public static int CountInWorld() {
-			int count = 0;
-			foreach (KeyValuePair<int, TileEntity> pair in ByID) {
-				if (pair.Value.type >= NumVanilla) {
-					count++;
-				}
-			}
-			return count;
+			return ByID.Count(pair => pair.Value.type >= NumVanilla);
 		}
 
 		internal static void Initialize() {
@@ -123,8 +116,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public void Kill(int i, int j) {
 			Point16 pos = new Point16(i, j);
-			if (ByPosition.ContainsKey(pos)) {
-				TileEntity tileEntity = ByPosition[pos];
+			if (ByPosition.TryGetValue(pos, out var tileEntity)) {
 				if (tileEntity.type == Type) {
 					((ModTileEntity)tileEntity).OnKill();
 					ByID.Remove(tileEntity.ID);
@@ -138,8 +130,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public int Find(int i, int j) {
 			Point16 pos = new Point16(i, j);
-			if (ByPosition.ContainsKey(pos)) {
-				TileEntity tileEntity = ByPosition[pos];
+			if (ByPosition.TryGetValue(pos, out var tileEntity)) {
 				if (tileEntity.type == Type) {
 					return tileEntity.ID;
 				}

--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -52,13 +52,13 @@ namespace Terraria.ModLoader
 		}
 
 		private static void UpdateStartInternal() {
-			foreach (ModTileEntity tileEntity in manager.EnumerateEntities().OfType<ModTileEntity>()) {
+			foreach (ModTileEntity tileEntity in manager.EnumerateEntities().Select(pair => pair.Value).OfType<ModTileEntity>()) {
 				tileEntity.PreGlobalUpdate();
 			}
 		}
 
 		private static void UpdateEndInternal() {
-			foreach (ModTileEntity tileEntity in manager.EnumerateEntities().OfType<ModTileEntity>()) {
+			foreach (ModTileEntity tileEntity in manager.EnumerateEntities().Select(pair => pair.Value).OfType<ModTileEntity>()) {
 				tileEntity.PostGlobalUpdate();
 			}
 		}


### PR DESCRIPTION
### What is the bug?
ModTileEntity.PreGlobalUpdate and ModTileEntity.PostGlobalUpdate not being called

### How did you fix the bug?
Fixed a LINQ query

### Are there alternatives to your fix?
No
