### PR TITLE
Repair MinStackSize on Mac

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -61,11 +61,9 @@ namespace Terraria.ModLoader
 				tML.InfoFormat("Parsed Launch Parameters: {0}", string.Join(' ', Program.LaunchParameters.Select(p => ($"{p.Key} {p.Value}").Trim())));
 			}
 
-			/* We set this internally, was previously used when set in InstallNetFramework scripts
 			string stackLimit = Environment.GetEnvironmentVariable("COMPlus_DefaultStackSize");
 			if (!string.IsNullOrEmpty(stackLimit))
 				tML.InfoFormat("Override Default Thread Stack Size Limit: {0}", stackLimit);
-			*/
 
 			if (ModCompile.DeveloperMode)
 				tML.Info("Developer mode enabled");

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -36,6 +36,7 @@ namespace Terraria
 
 		/// <summary>
 		/// Ensure sufficient stack size (4MB) on MacOS & Windows secondary threads, doesn't hurt for Linux. 16^5 = 1MB, value in hex 
+		/// Doesn't appear to work on .NET5, despite it being on the docs saying it should, so currently done in the Unix .sh script only
 		/// </summary>
 		private static void EnsureMinimumStackSizeOnThreads() {
 			Environment.SetEnvironmentVariable("COMPlus_DefaultStackSize", "400000");

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -87,7 +87,7 @@
  
  			try {
  				Console.OutputEncoding = Encoding.UTF8;
-@@ -138,32 +_,65 @@
+@@ -138,32 +_,63 @@
  			}
  		}
  
@@ -106,8 +106,6 @@
 +
 +			if (File.Exists("savehere.txt"))
 +				SavePath = "ModLoader"; // Fallback for unresolveable antivirus/onedrive issues. Also makes the game portable I guess.
-+
-+			EnsureMinimumStackSizeOnThreads();
 +
 +			bool isServer = LaunchParameters.ContainsKey("-server");
 +			try {

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -87,7 +87,7 @@
  
  			try {
  				Console.OutputEncoding = Encoding.UTF8;
-@@ -138,32 +_,63 @@
+@@ -138,32 +_,65 @@
  			}
  		}
  
@@ -106,6 +106,8 @@
 +
 +			if (File.Exists("savehere.txt"))
 +				SavePath = "ModLoader"; // Fallback for unresolveable antivirus/onedrive issues. Also makes the game portable I guess.
++
++			//EnsureMinimumStackSizeOnThreads();
 +
 +			bool isServer = LaunchParameters.ContainsKey("-server");
 +			try {

--- a/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
+++ b/solutions/ReleaseExtras/RuntimeFiles/InstallNetFramework.sh
@@ -31,6 +31,9 @@ if [ -f "$unixSteamworks" ]; then
   mv "$unixSteamworks" "$defaultSteamworks"
 fi
 
+# Ensure sufficient stack size (4MB) on MacOS secondary threads, doesn't hurt for Linux. 16^5 = 1MB, value in hex 
+export COMPlus_DefaultStackSize=400000
+
 #Parse version from runtimeconfig, jq would be a better solution here, but its not installed by default on all distros.
 version=$(sed -n 's/^.*"version": "\(.*\)"/\1/p' <tModLoader.runtimeconfig.json) #sed, go die plskthx
 version=${version%$'\r'} # remove trailing carriage return that sed may leave in variable, producing a bad folder name


### PR DESCRIPTION
.NET doesn't appear to respect its own environment variable when set after launch using the SetEnvironmentVariable method its docs recommend.
Neat.

EDIT----------------------------------------------
Thanks to DarioDaf, the following info explicitly shows that it this env var has to be set pre-launch:
https://github1s.com/dotnet/runtime/blob/HEAD/src/coreclr/pal/src/init/pal.cpp#L271 
![image](https://user-images.githubusercontent.com/59670736/134429534-b02c43bc-3a88-4918-acc7-639bc9f5dcbe.png)

