### PR TITLE
[1.4] Avoid wipe of mod data on SaveData/LoadData

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1749,7 +1749,10 @@ namespace Terraria.ModLoader
 		}
 
 		private static bool HasMethod(Type t, string method, params Type[] args) {
-			return t.GetMethod(method, args).DeclaringType != typeof(GlobalItem);
+			var methodInfo = t.GetMethod(method, args);
+			if (methodInfo == null)
+				return false;
+			return methodInfo.DeclaringType != typeof(GlobalItem);
 		}
 
 		internal static void VerifyGlobalItem(GlobalItem item) {
@@ -1764,6 +1767,11 @@ namespace Terraria.ModLoader
 
 			if (saveMethods == 1)
 				throw new Exception($"{type} must override both of ({nameof(GlobalItem.SaveData)}/{nameof(GlobalItem.LoadData)}) or none");
+
+			// @TODO: Remove on release
+			if ((saveMethods == 0) && HasMethod(type, "Save", typeof(Item)))
+				throw new Exception($"{type} has old Load/Save callbacks but not new LoadData/SaveData ones, not loading the mod to avoid wiping mod data");
+			// @TODO: END Remove on release
 
 			int netMethods = 0;
 

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -10,6 +10,7 @@ using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.Localization;
+using Terraria.ModLoader.Core;
 using Terraria.ModLoader.IO;
 using Terraria.Utilities;
 
@@ -48,15 +49,9 @@ namespace Terraria.ModLoader
 			ModTypeLookup<ModItem>.Register(this);
 
 			// @TODO: Remove on release
-			static bool HasMethod(Type t, string method, params Type[] args) {
-				var methodInfo = t.GetMethod(method, args);
-				if (methodInfo == null)
-					return false;
-				return methodInfo.DeclaringType != typeof(ModItem);
-			}
+			var type = GetType();
 
-			var type = this.GetType();
-			if (!HasMethod(type, "SaveData", typeof(TagCompound)) && HasMethod(this.GetType(), "Save"))
+			if (!LoaderUtils.HasMethod(type, typeof(ModItem), nameof(SaveData), typeof(TagCompound)) && LoaderUtils.HasMethod(type, typeof(ModItem), "Save"))
 				throw new Exception($"{type} has old Load/Save callbacks but not new LoadData/SaveData ones, not loading the mod to avoid wiping mod data");
 			// @TODO: END Remove on release
 

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -47,6 +47,19 @@ namespace Terraria.ModLoader
 		protected sealed override void Register() {
 			ModTypeLookup<ModItem>.Register(this);
 
+			// @TODO: Remove on release
+			static bool HasMethod(Type t, string method, params Type[] args) {
+				var methodInfo = t.GetMethod(method, args);
+				if (methodInfo == null)
+					return false;
+				return methodInfo.DeclaringType != typeof(ModItem);
+			}
+
+			var type = this.GetType();
+			if (!HasMethod(type, "SaveData", typeof(TagCompound)) && HasMethod(this.GetType(), "Save"))
+				throw new Exception($"{type} has old Load/Save callbacks but not new LoadData/SaveData ones, not loading the mod to avoid wiping mod data");
+			// @TODO: END Remove on release
+
 			DisplayName = LocalizationLoader.GetOrCreateTranslation(Mod, $"ItemName.{Name}");
 			Tooltip = LocalizationLoader.GetOrCreateTranslation(Mod, $"ItemTooltip.{Name}", true);
 

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -17,6 +17,19 @@ namespace Terraria.ModLoader
 	public abstract partial class ModSystem : ModType
 	{
 		protected override void Register() {
+			// @TODO: Remove on release
+			static bool HasMethod(Type t, string method, params Type[] args) {
+				var methodInfo = t.GetMethod(method, args);
+				if (methodInfo == null)
+					return false;
+				return methodInfo.DeclaringType != typeof(ModSystem);
+			}
+
+			var type = this.GetType();
+			if (!HasMethod(type, "SaveWorldData", typeof(TagCompound)) && HasMethod(this.GetType(), "SaveWorldData"))
+				throw new Exception($"{type} has old SaveData callback with no arguments but not new SaveData with TagCompound, not loading the mod to avoid wiping mod data");
+			// @TODO: END Remove on release
+
 			SystemLoader.Add(this);
 			ModTypeLookup<ModSystem>.Register(this);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using Terraria.Graphics;
 using Terraria.Localization;
+using Terraria.ModLoader.Core;
 using Terraria.ModLoader.IO;
 using Terraria.UI;
 using Terraria.WorldBuilding;
@@ -18,15 +19,9 @@ namespace Terraria.ModLoader
 	{
 		protected override void Register() {
 			// @TODO: Remove on release
-			static bool HasMethod(Type t, string method, params Type[] args) {
-				var methodInfo = t.GetMethod(method, args);
-				if (methodInfo == null)
-					return false;
-				return methodInfo.DeclaringType != typeof(ModSystem);
-			}
+			var type = GetType();
 
-			var type = this.GetType();
-			if (!HasMethod(type, "SaveWorldData", typeof(TagCompound)) && HasMethod(this.GetType(), "SaveWorldData"))
+			if (!LoaderUtils.HasMethod(type, typeof(ModSystem), nameof(SaveWorldData), typeof(TagCompound)) && LoaderUtils.HasMethod(type, typeof(ModSystem), "SaveWorldData"))
 				throw new Exception($"{type} has old SaveData callback with no arguments but not new SaveData with TagCompound, not loading the mod to avoid wiping mod data");
 			// @TODO: END Remove on release
 

--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -177,15 +177,9 @@ namespace Terraria.ModLoader
 				throw new Exception("AddTileEntity can only be called from Mod.Load or Mod.Autoload");
 
 			// @TODO: Remove on release
-			static bool HasMethod(Type t, string method, params Type[] args) {
-				var methodInfo = t.GetMethod(method, args);
-				if (methodInfo == null)
-					return false;
-				return methodInfo.DeclaringType != typeof(ModTileEntity);
-			}
-
 			var type = this.GetType();
-			if (!HasMethod(type, "SaveData", typeof(TagCompound)) && HasMethod(this.GetType(), "Save"))
+
+			if (!LoaderUtils.HasMethod(type, typeof(ModTileEntity), nameof(ModTileEntity.SaveData), typeof(TagCompound)) && LoaderUtils.HasMethod(type, typeof(ModTileEntity), this.GetType(), "Save"))
 				throw new Exception($"{type} has old Load/Save callbacks but not new LoadData/SaveData ones, not loading the mod to avoid wiping mod data");
 			// @TODO: END Remove on release
 

--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Terraria.DataStructures;
+using Terraria.ModLoader.Core;
 using Terraria.ModLoader.IO;
 
 namespace Terraria.ModLoader
@@ -177,9 +178,9 @@ namespace Terraria.ModLoader
 				throw new Exception("AddTileEntity can only be called from Mod.Load or Mod.Autoload");
 
 			// @TODO: Remove on release
-			var type = this.GetType();
+			var type = GetType();
 
-			if (!LoaderUtils.HasMethod(type, typeof(ModTileEntity), nameof(ModTileEntity.SaveData), typeof(TagCompound)) && LoaderUtils.HasMethod(type, typeof(ModTileEntity), this.GetType(), "Save"))
+			if (!LoaderUtils.HasMethod(type, typeof(ModTileEntity), nameof(ModTileEntity.SaveData), typeof(TagCompound)) && LoaderUtils.HasMethod(type, typeof(ModTileEntity), "Save"))
 				throw new Exception($"{type} has old Load/Save callbacks but not new LoadData/SaveData ones, not loading the mod to avoid wiping mod data");
 			// @TODO: END Remove on release
 

--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -176,6 +176,19 @@ namespace Terraria.ModLoader
 			if (!Mod.loading)
 				throw new Exception("AddTileEntity can only be called from Mod.Load or Mod.Autoload");
 
+			// @TODO: Remove on release
+			static bool HasMethod(Type t, string method, params Type[] args) {
+				var methodInfo = t.GetMethod(method, args);
+				if (methodInfo == null)
+					return false;
+				return methodInfo.DeclaringType != typeof(ModTileEntity);
+			}
+
+			var type = this.GetType();
+			if (!HasMethod(type, "SaveData", typeof(TagCompound)) && HasMethod(this.GetType(), "Save"))
+				throw new Exception($"{type} has old Load/Save callbacks but not new LoadData/SaveData ones, not loading the mod to avoid wiping mod data");
+			// @TODO: END Remove on release
+
 			manager.Register(this);
 			ModTypeLookup<ModTileEntity>.Register(this);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -1134,10 +1134,6 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		private static bool HasMethod(Type t, string method, params Type[] args) {
-			return t.GetMethod(method, args).DeclaringType != typeof(GlobalNPC);
-		}
-
 		internal static void VerifyGlobalNPC(GlobalNPC npc) {
 			var type = npc.GetType();
 

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -927,7 +927,10 @@ namespace Terraria.ModLoader
 		}
 
 		private static bool HasMethod(Type t, string method, params Type[] args) {
-			return t.GetMethod(method, args).DeclaringType != typeof(ModPlayer);
+			var methodInfo = t.GetMethod(method, args);
+			if (methodInfo == null)
+				return false;
+			return methodInfo.DeclaringType != typeof(ModPlayer);
 		}
 
 		internal static void VerifyModPlayer(ModPlayer player) {
@@ -959,6 +962,11 @@ namespace Terraria.ModLoader
 
 			if (saveMethods == 1)
 				throw new Exception($"{type} must override both of ({nameof(ModPlayer.SaveData)}/{nameof(ModPlayer.LoadData)}) or none");
+
+			// @TODO: Remove on release
+			if ((saveMethods == 0) && HasMethod(type, "Save"))
+				throw new Exception($"{type} has old Load/Save callbacks but not new LoadData/SaveData ones, not loading the mod to avoid wiping mod data");
+			// @TODO: END Remove on release
 		}
 
 		private static HookList HookPostSellItem = AddHook<Action<NPC, Item[], Item>>(p => p.PostSellItem);

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using Terraria.DataStructures;
 using Terraria.GameInput;
 using Terraria.ID;
+using Terraria.ModLoader.Core;
 using Terraria.ModLoader.Default;
 using Terraria.ModLoader.IO;
 

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -689,10 +689,6 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		private static bool HasMethod(Type t, string method, params Type[] args) {
-			return t.GetMethod(method, args).DeclaringType != typeof(GlobalProjectile);
-		}
-
 		internal static void VerifyGlobalProjectile(GlobalProjectile projectile) {
 			var type = projectile.GetType();
 


### PR DESCRIPTION

Temporary patch to avoid loading mods with Save and Load "the old way" because this will result in data being not saved on unload and so mod data being removed
