### PR TITLE
[1.4] Reusing only locally empty TagCompounds that are not assigned anywhere

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
@@ -128,11 +128,11 @@ namespace Terraria.ModLoader.IO
 
 			var list = new List<TagCompound>();
 
+			var saveData = new TagCompound();
+
 			foreach (var globalItem in ItemLoader.globalItems) {
 				var globalItemInstance = globalItem.Instance(item);
 				
-				var saveData = new TagCompound();
-
 				globalItemInstance?.SaveData(item, saveData);
 
 				if (saveData.Count == 0)
@@ -143,6 +143,7 @@ namespace Terraria.ModLoader.IO
 					["name"] = globalItemInstance.Name,
 					["data"] = saveData
 				});
+				saveData = new TagCompound();
 			}
 
 			return list.Count > 0 ? list : null;

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -164,9 +164,9 @@ namespace Terraria.ModLoader.IO
 		internal static List<TagCompound> SaveModData(Player player) {
 			var list = new List<TagCompound>();
 
-			foreach (var modPlayer in player.modPlayers) {
-				var saveData = new TagCompound();
+			var saveData = new TagCompound();
 
+			foreach (var modPlayer in player.modPlayers) {
 				modPlayer.SaveData(saveData);
 
 				if (saveData.Count == 0)
@@ -177,6 +177,7 @@ namespace Terraria.ModLoader.IO
 					["name"] = modPlayer.Name,
 					["data"] = saveData
 				});
+				saveData = new TagCompound();
 			}
 
 			return list;

--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_TEs.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_TEs.cs
@@ -12,11 +12,11 @@ namespace Terraria.ModLoader.IO
 		internal static List<TagCompound> SaveTileEntities() {
 			var list = new List<TagCompound>();
 
+			var saveData = new TagCompound();
+
 			foreach (KeyValuePair<int, TileEntity> pair in TileEntity.ByID) {
 				var tileEntity = pair.Value;
 				var modTileEntity = tileEntity as ModTileEntity;
-
-				var saveData = new TagCompound();
 
 				tileEntity.SaveData(saveData);
 
@@ -29,6 +29,7 @@ namespace Terraria.ModLoader.IO
 
 				if (saveData.Count != 0) {
 					tag["data"] = saveData;
+					saveData = new TagCompound();
 				}
 
 				list.Add(tag);

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -360,9 +360,9 @@ namespace Terraria.ModLoader.IO
 		internal static List<TagCompound> SaveModData() {
 			var list = new List<TagCompound>();
 
-			foreach (var system in SystemLoader.Systems) {
-				var saveData = new TagCompound();
+			var saveData = new TagCompound();
 
+			foreach (var system in SystemLoader.Systems) {
 				system.SaveWorldData(saveData);
 
 				if (saveData.Count == 0)
@@ -373,6 +373,7 @@ namespace Terraria.ModLoader.IO
 					["name"] = system.Name,
 					["data"] = saveData
 				});
+				saveData = new TagCompound();
 			}
 
 			return list;


### PR DESCRIPTION

Made foreach loop reuse Tag when never used outside and assigned to the parent tag
