### PR TITLE
[1.4] EM ExampleDye shader fix

### DIFF
--- a/ExampleMod/Content/Items/ExampleDye.cs
+++ b/ExampleMod/Content/Items/ExampleDye.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
 using Terraria;
 using Terraria.Graphics.Shaders;
 using Terraria.ID;
@@ -15,7 +16,7 @@ namespace ExampleMod.Content.Items
 				// The following code creates an effect (shader) reference and associates it with this item's type Id.
 				GameShaders.Armor.BindShader(
 					Item.type,
-					new ArmorShaderData(new Ref<Effect>(Mod.Assets.Request<Effect>("Assets/Effects/ExampleEffect").Value), "ExampleDyePass") // Be sure to update the effect path and pass name here.
+					new ArmorShaderData(new Ref<Effect>(Mod.Assets.Request<Effect>("Assets/Effects/ExampleEffect", AssetRequestMode.ImmediateLoad).Value), "ExampleDyePass") // Be sure to update the effect path and pass name here.
 				);
 			}
 


### PR DESCRIPTION
### What is the bug?
ExampleDye shader loading is missing `ImmediateLoad`

### How did you fix the bug?
Added `ImmediateLoad`

### Are there alternatives to your fix?
No
