### PR TITLE
[1.4] Forgotten breaking change in tagCompound

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/IO/TagCompound.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TagCompound.cs
@@ -29,9 +29,6 @@ namespace Terraria.ModLoader.IO
 					$"entry={TagPrinter.Print(new KeyValuePair<string, object>(key, tag))})", e);
 			}
 		}
-
-		// adding default param to Set overload is a breaking changefor now.
-		public void Set(string key, object value) => Set(key, value, false);
 		
 		//if value is null, calls RemoveTag, also performs type checking
 		public void Set(string key, object value, bool replace = false) {


### PR DESCRIPTION
The Set method got an overload in 1.3, but the old method wasn't removed to prevent breaking mods, but in 1.4 we can do this change so the sooner this method is removed, the less mods it will break (if it breaks any)