### PR TITLE
Actually use the headless argument added to XNA.Game()

### DIFF
--- a/patches/Terraria/Terraria/Main.cs.patch
+++ b/patches/Terraria/Terraria/Main.cs.patch
@@ -193,7 +193,12 @@
  			}
  			else {
  				Console.Title = "Terraria Server " + versionNumber2;
-@@ -4731,6 +_,9 @@
+@@ -4727,10 +_,13 @@
+ 			}
+ 		}
+ 
+-		public Main() {
++		public Main() : base(dedServ) {
  			instance = this;
  			UnpausedUpdateSeed = (ulong)Guid.NewGuid().GetHashCode();
  			base.Exiting += Main_Exiting;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -826,7 +826,7 @@
  			}
  
  			bool enabled = CreativePowerManager.Instance.GetPower<CreativePowers.FreezeTime>().Enabled;
-@@ -4769,13 +_,20 @@
+@@ -4769,10 +_,17 @@
  
  			dayRate = num;
  			desiredWorldTilesUpdateRate = num;
@@ -843,11 +843,7 @@
 +				dayRate = 86400;
  		}
  
--		public Main() {
-+		public Main() : base (Main.dedServ) {
- 			instance = this;
- 			UnpausedUpdateSeed = (ulong)Guid.NewGuid().GetHashCode();
- 			base.Exiting += Main_Exiting;
+ 		public Main() : base(dedServ) {
 @@ -4784,7 +_,50 @@
  
  			Configuration.Load();

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -826,7 +826,7 @@
  			}
  
  			bool enabled = CreativePowerManager.Instance.GetPower<CreativePowers.FreezeTime>().Enabled;
-@@ -4769,10 +_,17 @@
+@@ -4769,13 +_,20 @@
  
  			dayRate = num;
  			desiredWorldTilesUpdateRate = num;
@@ -843,7 +843,11 @@
 +				dayRate = 86400;
  		}
  
- 		public Main() {
+-		public Main() {
++		public Main() : base (Main.dedServ) {
+ 			instance = this;
+ 			UnpausedUpdateSeed = (ulong)Guid.NewGuid().GetHashCode();
+ 			base.Exiting += Main_Exiting;
 @@ -4784,7 +_,50 @@
  
  			Configuration.Load();


### PR DESCRIPTION
Previously, a commit was made against our fork of FNA to add a "headlessMode" bool to the Game constructor. (https://github.com/FNA-XNA/FNA/commit/3907b989a7b3494cc974618b9128b9772009bc1f)

This actually implements its use on our side, as it seems that was missed.

Whether the headlessMode is functional in FNA end, I can't say, but this helps to get in right direction at least.
