### PR TITLE
[Mod-Breaking] Eliminate duplicate override ValidTile in favor of existing IsTileValid

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedTileEntity.cs
@@ -17,7 +17,7 @@ namespace Terraria.ModLoader.Default
 			}
 		}
 
-		public override bool ValidTile(int i, int j) {
+		public override bool IsTileValidForEntity(int i, int j) {
 			Tile tile = Main.tile[i, j];
 			return tile.active() && TileLoader.GetTile(type) is UnloadedTile;
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -75,7 +75,7 @@ namespace Terraria.ModLoader
 		/// You should never use this. It is only included here for completion's sake.
 		/// </summary>
 		public override void NetPlaceEntityAttempt(int i, int j) {
-			if (!manager.TryGetTileEntity(type, out ModTileEntity modTileEntity) || !modTileEntity.ValidTile(i, j)) {
+			if (!manager.TryGetTileEntity(type, out ModTileEntity modTileEntity)) {
 				return;
 			}
 
@@ -193,11 +193,6 @@ namespace Terraria.ModLoader
 		public virtual void Unload(){}
 
 		/// <summary>
-		/// Whether or not this tile entity is allowed to survive at the given coordinates. You should check whether the tile is active, as well as the tile's type and frame.
-		/// </summary>
-		public abstract bool ValidTile(int i, int j);
-
-		/// <summary>
 		/// This method does not get called by tModLoader, and is only included for you convenience so you do not have to cast the result of Mod.GetTileEntity.
 		/// </summary>
 		public virtual int Hook_AfterPlacement(int i, int j, int type, int style, int direction, int alternate) {
@@ -227,5 +222,11 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public virtual void OnKill() {
 		}
+
+		/// <summary>
+		/// Whether or not this tile entity is allowed to survive at the given coordinates. You should check whether the tile is active, as well as the tile's type and frame.
+		/// Defaults to check tile.IsActive.
+		/// </summary>
+		public abstract override bool IsTileValidForEntity(int x, int y);
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -225,7 +225,6 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Whether or not this tile entity is allowed to survive at the given coordinates. You should check whether the tile is active, as well as the tile's type and frame.
-		/// Defaults to check tile.IsActive.
 		/// </summary>
 		public abstract override bool IsTileValidForEntity(int x, int y);
 	}


### PR DESCRIPTION
### What is the bug?
https://github.com/tModLoader/tModLoader/issues/1813

### How did you fix the bug?
Replaced unnecessary ValidTile method with existing IsTileValid method.
This will force mods to override the correct method, and not have two functionally equivalent methods co-exist.

### Are there alternatives to your fix?
