### PR TITLE
[1.4] Fix ModTileEntities not being placeable in MP

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -68,7 +68,7 @@ namespace Terraria.ModLoader
 		/// You should never use this. It is only included here for completion's sake.
 		/// </summary>
 		public override void NetPlaceEntityAttempt(int i, int j) {
-			if (!manager.TryGetTileEntity(type, out ModTileEntity modTileEntity)) {
+			if (!manager.TryGetTileEntity(Type, out ModTileEntity modTileEntity)) {
 				return;
 			}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -107,8 +107,11 @@ namespace Terraria.ModLoader
 			newEntity.Position = new Point16(i, j);
 			newEntity.ID = AssignNewID();
 			newEntity.type = (byte)Type;
-			ByID[newEntity.ID] = newEntity;
-			ByPosition[newEntity.Position] = newEntity;
+			lock (EntityCreationLock) {
+				ByID[newEntity.ID] = newEntity;
+				ByPosition[newEntity.Position] = newEntity;
+			}
+
 			return newEntity.ID;
 		}
 


### PR DESCRIPTION
### What is the bug?
ModTileEntities don't get placed in MP

`Type` is functionally equivalent to `_myEntityID` of vanilla TileEntities and only gets assigned once per TileEntity
`type` is the id of a placed TIleEntity
Before a TE is placed `type` is by default 0, which isn't a valid ModTileEntity id

### How did you fix the bug?
Fixed the typo

### Are there alternatives to your fix?
Voodoo
