### PR TITLE
[1.4] Fix misleading Set name

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
@@ -36,7 +36,7 @@
  				missingArm = true;
 +			*/
  
-+			missingHand = drawPlayer.body > 0 && ArmorIDs.Body.Sets.HidesHands[drawPlayer.body];
++			missingHand = drawPlayer.body > 0 && ArmorIDs.Body.Sets.DrawHands[drawPlayer.body];
 +			missingArm = drawPlayer.body > 0 && ArmorIDs.Body.Sets.DrawArms[drawPlayer.body];
 +			
  			int type;

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
@@ -37,7 +37,7 @@
 +			*/
  
 +			missingHand = drawPlayer.body > 0 && ArmorIDs.Body.Sets.HidesHands[drawPlayer.body];
-+			missingArm = drawPlayer.body > 0 && ArmorIDs.Body.Sets.HidesArms[drawPlayer.body];
++			missingArm = drawPlayer.body > 0 && ArmorIDs.Body.Sets.DrawArms[drawPlayer.body];
 +			
  			int type;
  			if (drawPlayer.heldProj >= 0 && shadow == 0f) {

--- a/patches/tModLoader/Terraria/ID/ArmorIDs.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ArmorIDs.TML.cs
@@ -39,7 +39,7 @@ namespace Terraria.ID
 				// Created based on 'missingHand' definition in 'PlayerDrawSet.BoringSetup'.
 				public static bool[] HidesHands = Factory.CreateBoolSet(77, 103, 41, 100, 10, 11, 12, 13, 14, 43, 15, 16, 20, 39, 50, 38, 40, 57, 44, 52, 53, 68, 81, 85, 88, 98, 86, 87, 99, 165, 166, 167, 171, 45, 168, 169, 42, 180, 181, 183, 186, 187, 188, 64, 189, 191, 192, 198, 199, 202, 203, 58, 59, 60, 61, 62, 63, 36, 104, 184, 74, 78, 185, 196, 197, 182, 87, 76, 209, 168, 210, 211, 213);
 				// Created based on 'missingArm' definition in 'PlayerDrawSet.BoringSetup'.
-				public static bool[] HidesArms = Factory.CreateBoolSet(true, 83);
+				public static bool[] DrawArms = Factory.CreateBoolSet(true, 83);
 			}
 		}
 

--- a/patches/tModLoader/Terraria/ID/ArmorIDs.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ArmorIDs.TML.cs
@@ -37,7 +37,7 @@ namespace Terraria.ID
 				// Created based on 'hidesBottomSkin' definition in 'PlayerDrawSet.BoringSetup'.
 				public static bool[] HidesBottomSkin = Factory.CreateBoolSet(93);
 				// Created based on 'missingHand' definition in 'PlayerDrawSet.BoringSetup'.
-				public static bool[] HidesHands = Factory.CreateBoolSet(77, 103, 41, 100, 10, 11, 12, 13, 14, 43, 15, 16, 20, 39, 50, 38, 40, 57, 44, 52, 53, 68, 81, 85, 88, 98, 86, 87, 99, 165, 166, 167, 171, 45, 168, 169, 42, 180, 181, 183, 186, 187, 188, 64, 189, 191, 192, 198, 199, 202, 203, 58, 59, 60, 61, 62, 63, 36, 104, 184, 74, 78, 185, 196, 197, 182, 87, 76, 209, 168, 210, 211, 213);
+				public static bool[] DrawHands = Factory.CreateBoolSet(77, 103, 41, 100, 10, 11, 12, 13, 14, 43, 15, 16, 20, 39, 50, 38, 40, 57, 44, 52, 53, 68, 81, 85, 88, 98, 86, 87, 99, 165, 166, 167, 171, 45, 168, 169, 42, 180, 181, 183, 186, 187, 188, 64, 189, 191, 192, 198, 199, 202, 203, 58, 59, 60, 61, 62, 63, 36, 104, 184, 74, 78, 185, 196, 197, 182, 87, 76, 209, 168, 210, 211, 213);
 				// Created based on 'missingArm' definition in 'PlayerDrawSet.BoringSetup'.
 				public static bool[] DrawArms = Factory.CreateBoolSet(true, 83);
 			}


### PR DESCRIPTION
Fix misleading Set names

Renamed `ArmorIDs.Body.Sets.HidesArms` to `ArmorIDs.Body.Sets.DrawArms`
Renamed `ArmorIDs.Body.Sets.HidesHands` to `ArmorIDs.Body.Sets.DrawHands`