### PR TITLE
[1.4] Fix wrong argument to `WallLoader.KillWall`

### DIFF
--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1303,7 +1303,7 @@
  				return;
  
  			fail = KillWall_CheckFailure(fail, tile);
-+			WallLoader.KillWall(i, j, tile.type, ref fail);
++			WallLoader.KillWall(i, j, tile.wall, ref fail);
  			KillWall_PlaySounds(i, j, tile);
  			int num = 10;
  			if (fail)


### PR DESCRIPTION
### What is the bug?
`tile.type` is passed as the wall type insead of `tile.wall`

### How did you fix the bug?
Changed `tile.type` to `tile.wall`

### Are there alternatives to your fix?
Nope
