### PR TITLE
[1.4] `Player.QuickSpawnItem` return item index

### DIFF
--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -74,13 +74,6 @@ namespace Terraria
 
 		public int QuickSpawnItem(Item item, int stack = 1) => QuickSpawnItem(item.type, stack);
 
-		public int QuickSpawnItem(int type, int stack = 1) {
-			int number = Item.NewItem((int)position.X, (int)position.Y, width, height, type, stack, noBroadcast: false, -1);
-			if (Main.netMode == 1)
-				NetMessage.SendData(21, -1, -1, null, number, 1f);
-			return number;
-		}
-
 		/// <inheritdoc cref="QuickSpawnClonedItem"/>
 		public Item QuickSpawnClonedItemDirect(Item item, int stack = 1) => Main.item[QuickSpawnClonedItem(item, stack)];
 

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace Terraria
@@ -51,6 +52,34 @@ namespace Terraria
 			return result != null;
 		}
 		*/
+
+		/// <summary>
+		/// Will spawn an item like QuickSpawnItem, but clones it (handy when you need to retain item infos)
+		/// </summary>
+		/// <param name="item">The item you want to be cloned</param>
+		/// <param name="stack">The stack to give the item. Note that this will override maxStack if it's higher.</param>
+		public int QuickSpawnClonedItem(Item item, int stack = 1) {
+			int index = Item.NewItem((int)position.X, (int)position.Y, width, height, item.type, stack, false, -1, false, false);
+			Item clone = Main.item[index] = item.Clone();
+			clone.whoAmI = index;
+			clone.position = position;
+			clone.stack = stack;
+
+			// Sync the item for mp
+			if (Main.netMode == NetmodeID.MultiplayerClient)
+				NetMessage.SendData(MessageID.SyncItem, -1, -1, null, index, 1f, 0f, 0f, 0, 0, 0);
+
+			return index;
+		}
+
+		public int QuickSpawnItem(Item item, int stack = 1) => QuickSpawnItem(item.type, stack);
+
+		public int QuickSpawnItem(int type, int stack = 1) {
+			int number = Item.NewItem((int)position.X, (int)position.Y, width, height, type, stack, noBroadcast: false, -1);
+			if (Main.netMode == 1)
+				NetMessage.SendData(21, -1, -1, null, number, 1f);
+			return number;
+		}
 
 		/// <summary> Returns whether or not this Player currently has a (de)buff of the provided type. </summary>
 		public bool HasBuff(int type) => FindBuffIndex(type) != -1;

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -81,6 +81,13 @@ namespace Terraria
 			return number;
 		}
 
+		/// <inheritdoc cref="QuickSpawnClonedItem"/>
+		public Item QuickSpawnClonedItemDirect(Item item, int stack = 1) => Main.item[QuickSpawnClonedItem(item, stack)];
+
+		public Item QuickSpawnItemDirect(Item item, int stack = 1) => Main.item[QuickSpawnItem(item.type, stack)];
+
+		public Item QuickSpawnItemDirect(int type, int stack = 1) => Main.item[QuickSpawnItem(type, stack)];
+
 		/// <summary> Returns whether or not this Player currently has a (de)buff of the provided type. </summary>
 		public bool HasBuff(int type) => FindBuffIndex(type) != -1;
 

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -739,7 +739,7 @@
  			if (Main.rand.Next(15) == 0 && Main.hardMode) {
  				int number = Item.NewItem((int)position.X, (int)position.Y, width, height, 602);
  				if (Main.netMode == 1)
-@@ -3942,15 +_,34 @@
+@@ -3942,15 +_,33 @@
  						break;
  					}
  			}
@@ -747,13 +747,13 @@
 +			// TODO: return statements above probably break this.
  		}
  
-+		/*
- 		public void QuickSpawnItem(int item, int stack = 1) {
+-		public void QuickSpawnItem(int item, int stack = 1) {
++		public int QuickSpawnItem(int item, int stack = 1) {
  			int number = Item.NewItem((int)position.X, (int)position.Y, width, height, item, stack, noBroadcast: false, -1);
  			if (Main.netMode == 1)
  				NetMessage.SendData(21, -1, -1, null, number, 1f);
++			return number;
  		}
-+		*/
  
  		public void OpenBossBag(int type) {
 +			if (!ItemLoader.PreOpenVanillaBag("bossBag", this, type))

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -739,40 +739,21 @@
  			if (Main.rand.Next(15) == 0 && Main.hardMode) {
  				int number = Item.NewItem((int)position.X, (int)position.Y, width, height, 602);
  				if (Main.netMode == 1)
-@@ -3942,7 +_,31 @@
+@@ -3942,15 +_,34 @@
  						break;
  					}
  			}
 +			NPCLoader.blockLoot.Clear(); // clear blockloot
 +			// TODO: return statements above probably break this.
  		}
-+
-+		/// <summary>
-+		/// Will spawn an item like QuickSpawnItem, but clones it (handy when you need to retain item infos)
-+		/// </summary>
-+		/// <param name="item">The item you want to be cloned</param>
-+		/// <param name="stack">The stack to give the item. Note that this will override maxStack if it's higher.</param>
-+		public void QuickSpawnClonedItem(Item item, int stack = 1) {
-+			int index = Item.NewItem((int)position.X, (int)position.Y, width, height, item.type, stack, false, -1, false, false);
-+			Main.item[index] = item.Clone();
-+			Main.item[index].whoAmI = index;
-+			Main.item[index].position = position;
-+			if (stack != Main.item[index].stack)
-+				Main.item[index].stack = stack;
-+
-+			// Sync the item for mp
-+			if (Main.netMode == NetmodeID.MultiplayerClient)
-+				NetMessage.SendData(MessageID.SyncItem, -1, -1, null, index, 1f, 0f, 0f, 0, 0, 0);
-+		}
-+
-+		public void QuickSpawnItem(Item item, int stack = 1) {
-+			QuickSpawnItem(item.type, stack);
-+ 		}
  
++		/*
  		public void QuickSpawnItem(int item, int stack = 1) {
  			int number = Item.NewItem((int)position.X, (int)position.Y, width, height, item, stack, noBroadcast: false, -1);
-@@ -3951,6 +_,21 @@
+ 			if (Main.netMode == 1)
+ 				NetMessage.SendData(21, -1, -1, null, number, 1f);
  		}
++		*/
  
  		public void OpenBossBag(int type) {
 +			if (!ItemLoader.PreOpenVanillaBag("bossBag", this, type))

--- a/patches/tModLoader/Terraria/Projectile.TML.cs
+++ b/patches/tModLoader/Terraria/Projectile.TML.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Terraria.DataStructures;
 using Terraria.ModLoader;
 
 namespace Terraria
@@ -11,6 +13,9 @@ namespace Terraria
 		internal Instanced<GlobalProjectile>[] globalProjectiles = Array.Empty<Instanced<GlobalProjectile>>();
 
 		public RefReadOnlyArray<Instanced<GlobalProjectile>> Globals => new RefReadOnlyArray<Instanced<GlobalProjectile>>(globalProjectiles);
+
+		public static Projectile NewProjectileDirect(IProjectileSource spawnSource, Vector2 position, Vector2 velocity, int type, int damage, float knockback, int owner = 255, float ai0 = 0f, float ai1 = 0f)
+			=> Main.projectile[NewProjectile(spawnSource, position.X, position.Y, velocity.X, velocity.Y, type, damage, knockback, owner, ai0, ai1)];
 
 		private DamageClass _damageClass = DamageClass.Generic;
 		/// <summary>

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -142,17 +142,6 @@
  
  			width = (int)((float)width * scale);
  			height = (int)((float)height * scale);
-@@ -7951,6 +_,10 @@
- 			return result;
- 		}
- 
-+		//TODO: TML addition, must be moved to a partial.
-+		public static Projectile NewProjectileDirect(IProjectileSource spawnSource, Vector2 position, Vector2 velocity, int Type, int Damage, float KnockBack, int Owner = 255, float ai0 = 0f, float ai1 = 0f)
-+			=> Main.projectile[Projectile.NewProjectile(spawnSource, position.X, position.Y, velocity.X, velocity.Y, Type, Damage, KnockBack, Owner, ai0, ai1)];
-+
- 		public static int NewProjectile(IProjectileSource spawnSource, Vector2 position, Vector2 velocity, int Type, int Damage, float KnockBack, int Owner = 255, float ai0 = 0f, float ai1 = 0f) => NewProjectile(spawnSource, position.X, position.Y, velocity.X, velocity.Y, Type, Damage, KnockBack, Owner, ai0, ai1);
- 
- 		public static int FindOldestProjectile() {
 @@ -8031,7 +_,7 @@
  				projectile.ai[1] = projectile.position.Y;
  			}


### PR DESCRIPTION
### What is the new feature?
`Player.QuickSpawnItem` now returns the index of the spawned item
Added Direct variants to `Player.QuickSpawnItem`

### Why should this be part of tModLoader?
Allows modifying the data of the spawned item

### Are there alternative designs?
Add more arguments to `Player.QuickSpawnItem`

### Sample usage for the new feature
```cs
Item item = player.QuickSpawnItemDirect(ItemID.Zenith); // or `Main.item[Player.QuickSpawnItem(ItemID.Zenith)]`
item.prefix = PrefixID.Legendary;
```

### ExampleMod updates
None
<!-- If you also updated ExampleMod for your new feature, let us know here -->

