### PR TITLE
[1.4] Fix modded walls not appearing on the map

### DIFF
--- a/patches/tModLoader/Terraria/Map/MapHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Map/MapHelper.cs.patch
@@ -27,6 +27,15 @@
  			snowTypes = new ushort[6];
  			snowTypes[0] = tileLookup[147];
  			snowTypes[1] = tileLookup[161];
+@@ -1555,7 +_,7 @@
+ 					int num4 = tile.liquidType();
+ 					num3 = liquidPosition + num4;
+ 				}
+-				else if (tile.wall > 0 && tile.wall < 316) {
++				else if (tile.wall > 0 && tile.wall < WallLoader.WallCount) {
+ 					int wall = tile.wall;
+ 					num3 = wallLookup[wall];
+ 					num = tile.wallColor();
 @@ -1626,7 +_,9 @@
  				}
  			}


### PR DESCRIPTION
1.4 added a `wall < 316` check where wall map data is calculated, causing modded walls to never appear on the map, as per #1938. This PR fixes it by changing it to the tml upper bound instead.