### PR TITLE
tModPorter AddParameter Feature, port for new parameter of Main.GetPlayerArmPosition

### DIFF
--- a/ExampleMod/Content/Projectiles/ExampleAdvancedFlailProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleAdvancedFlailProjectile.cs
@@ -433,7 +433,7 @@ namespace ExampleMod.Content.Projectiles
 
 		// PreDraw is used to draw a chain and trail before the projectile is drawn normally.
 		public override bool PreDraw(Player player, ref Color lightColor) {
-			Vector2 playerArmPosition = Main.GetPlayerArmPosition(Projectile);
+			Vector2 playerArmPosition = Main.GetPlayerArmPosition(Projectile, default /* New parameter: Now expects a Player object, try 'player'. */);
 
 			// This fixes a vanilla GetPlayerArmPosition bug causing the chain to draw incorrectly when stepping up slopes. The flail itself still draws incorrectly due to another similar bug. This should be removed once the vanilla bug is fixed.
 			playerArmPosition.Y -= player.gfxOffY;

--- a/ExampleMod/Content/Projectiles/ExampleWhipProjectileAdvanced.cs
+++ b/ExampleMod/Content/Projectiles/ExampleWhipProjectileAdvanced.cs
@@ -50,7 +50,7 @@ namespace ExampleMod.Content.Projectiles
 			Player owner = Main.player[Projectile.owner];
 			Projectile.rotation = Projectile.velocity.ToRotation() + MathHelper.PiOver2; // Without PiOver2, the rotation would be off by 90 degrees counterclockwise.
 
-			Projectile.Center = Main.GetPlayerArmPosition(Projectile) + Projectile.velocity * Timer;
+			Projectile.Center = Main.GetPlayerArmPosition(Projectile, default /* New parameter: Now expects a Player object, try 'player'. */) + Projectile.velocity * Timer;
 			// Vanilla uses Vector2.Dot(Projectile.velocity, Vector2.UnitX) here. Dot Product returns the difference between two vectors, 0 meaning they are perpendicular.
 			// However, the use of UnitX basically turns it into a more complicated way of checking if the projectile's velocity is above or equal to zero on the X axis.
 			Projectile.spriteDirection = Projectile.velocity.X >= 0f ? 1 : -1;

--- a/tModPorter/tModPorter.Tests/TestData/AddParameterTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/AddParameterTest.Expected.cs
@@ -1,0 +1,11 @@
+﻿using Terraria;
+
+public class AddParameterTest
+{
+	void Method()
+	{
+		Projectile projectile = Main.projectile[0];
+		Player owner = Main.player[Projectile.owner];
+		projectile.Center = Main.GetPlayerArmPosition(projectile, default /* tModPorter Note: New parameter: Now expects a Player object, try 'player'. */);
+	}
+}

--- a/tModPorter/tModPorter.Tests/TestData/AddParameterTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/AddParameterTest.cs
@@ -1,0 +1,11 @@
+﻿using Terraria;
+
+public class AddParameterTest
+{
+	void Method()
+	{
+		Projectile projectile = Main.projectile[0];
+		Player owner = Main.player[Projectile.owner];
+		projectile.Center = Main.GetPlayerArmPosition(projectile);
+	}
+}

--- a/tModPorter/tModPorter/Config.Terraria.cs
+++ b/tModPorter/tModPorter/Config.Terraria.cs
@@ -349,6 +349,8 @@ public static partial class Config
 		RefactorInstanceMethodCall("Terraria.NPC", "SpawnWithHigherTime", Removed("No longer used."));
 		RefactorInstanceMethodCall("Terraria.Recipe", "FindRecipes", Removed("No longer used."));
 
+		RefactorInstanceMethodCall("Terraria.Main", "GetPlayerArmPosition", AddParameter(1, "Terraria.Player", "Now expects a Player object, try 'player'."));
+
 		ChangeStaticFieldType("Terraria.Main", "item",        from: "Terraria.Item", to: "Terraria.WorldItem");
 		ChangeStaticFieldType("Terraria.Main", "ActiveItems", from: "Terraria.Item", to: "Terraria.WorldItem");
 	}

--- a/tModPorter/tModPorter/Rewriters/InvokeRewriter.cs
+++ b/tModPorter/tModPorter/Rewriters/InvokeRewriter.cs
@@ -306,5 +306,47 @@ public partial class InvokeRewriter : BaseRewriter
 		var assign = AssignmentExpression(elementAccess, LiteralExpression(SyntaxKind.TrueLiteralExpression)).WithTriviaFrom(invoke);
 		return assign;
 	}
+
+	public static RewriteInvoke AddParameter(int parameterIndex, string parameterType, string comment) => (rw, invoke, methodName) => {
+		var argList = invoke.ArgumentList ?? ArgumentList();
+		var args = argList.Arguments;
+		int existingCount = args.Count;
+
+		// short helper to get short name from a fullname (e.g. "Terraria.Player" -> "Player")
+		static string ShortNameLocal(string fullname)
+		{
+			if (string.IsNullOrEmpty(fullname))
+				return fullname;
+			int i = fullname.LastIndexOf('.');
+			return i == -1 ? fullname : fullname[(i + 1)..];
+		}
+
+		// If the invocation already has an argument at parameterIndex with type already matches the requested type, do nothing.
+		if (existingCount > parameterIndex) {
+			var existingArg = args[parameterIndex];
+			var existingType = rw.model.GetTypeInfo(existingArg.Expression).Type;
+			if (existingType != null) {
+				var paramShort = ShortNameLocal(parameterType);
+				if (existingType.ToString() == parameterType || existingType.Name == parameterType || ShortNameLocal(existingType.ToString()) == paramShort)
+					return invoke;
+			}
+			// If it's null, it's likely the result of this code running previously.
+			if (existingType == null)
+				return invoke;
+		}
+
+		// Build new argument: `/* New parameter: ... */ null`
+		var nullExpr = LiteralExpression(SyntaxKind.DefaultLiteralExpression)
+			.WithLeadingTrivia(SyntaxFactory.Whitespace(" "))
+			.WithTrailingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.Whitespace(" "), SyntaxFactory.Comment($"/* tModPorter Note: New parameter: {comment} */")));
+		var newArg = Argument(nullExpr);
+
+		// Insert new argument at requested position (or append if pos > existingCount)
+		int insertIndex = Math.Min(parameterIndex, existingCount);
+		var newArgs = args.Insert(insertIndex, newArg);
+		var newArgList = argList.WithArguments(newArgs).WithTriviaFrom(argList);
+
+		return invoke.WithArgumentList(newArgList);
+	};
 }
 


### PR DESCRIPTION
Adds `AddParameter` tModPorter code to a new parameter for a changed method, in this case the new `Player` parameter for `Main.GetPlayerArmPosition`.

```diff
-Vector2 playerArmPosition = Main.GetPlayerArmPosition(Projectile);
+Vector2 playerArmPosition = Main.GetPlayerArmPosition(Projectile, default /* New parameter: Now expects a Player object, try 'player'. */);
```

After implementing, I realized this probably isn't necessary or useful, since rather than an error telling the modder to fix the code, the ported fix will actually compile and lead to silent errors. Maybe these sort of changes don't need porting, the compilation error message speaks for itself. 

I've made a branch with the code anyway, since maybe it will prove useful for some other porting we will want to do later. Or, we could keep the comment and remove the `default` parameter, but that might complicate things with how the code will behave when running tModPorter multiple times on the same code.