### PR TITLE
Fix incompatibility with certain IMEs

### DIFF
--- a/patches/TerrariaNetCore/ReLogic/Localization/IME/WinImm32/NativeMethods.cs
+++ b/patches/TerrariaNetCore/ReLogic/Localization/IME/WinImm32/NativeMethods.cs
@@ -5,22 +5,22 @@ namespace ReLogic.Localization.IME.WinImm32;
 
 internal static class NativeMethods
 {
-	[DllImport("Imm32.dll")]
+	[DllImport("imm32.dll")]
 	public static extern bool ImmSetOpenStatus(IntPtr hImc, bool bOpen);
 
-	[DllImport("Imm32.dll", CharSet = CharSet.Unicode)]
+	[DllImport("imm32.dll", CharSet = CharSet.Unicode)]
 	public static extern IntPtr ImmGetContext(IntPtr hWnd);
 
-	[DllImport("Imm32.dll", CharSet = CharSet.Unicode)]
+	[DllImport("imm32.dll", CharSet = CharSet.Unicode)]
 	public static extern bool ImmReleaseContext(IntPtr hWnd, IntPtr hImc);
 
-	[DllImport("Imm32.dll", CharSet = CharSet.Unicode)]
+	[DllImport("imm32.dll", CharSet = CharSet.Unicode)]
 	public static extern IntPtr ImmCreateContext();
 
-	[DllImport("Imm32.dll", CharSet = CharSet.Unicode)]
+	[DllImport("imm32.dll", CharSet = CharSet.Unicode)]
 	public static extern bool ImmDestroyContext(IntPtr hImc);
 
-	[DllImport("Imm32.dll", CharSet = CharSet.Unicode)]
+	[DllImport("imm32.dll", CharSet = CharSet.Unicode)]
 	public static extern IntPtr ImmAssociateContext(IntPtr hWnd, IntPtr hImc);
 
 	[DllImport("imm32.dll", CharSet = CharSet.Unicode)]
@@ -36,6 +36,6 @@ internal static class NativeMethods
 	[DllImport("imm32.dll")]
 	public static extern IntPtr ImmGetDefaultIMEWnd(IntPtr hWnd);
 
-	[DllImport("Imm32.dll", CharSet = CharSet.Unicode)]
+	[DllImport("imm32.dll", CharSet = CharSet.Unicode)]
 	public static extern bool ImmNotifyIME(IntPtr hImc, uint dwAction, uint dwIndex, uint dwValue);
 }

--- a/patches/TerrariaNetCore/ReLogic/Localization/IME/WinImm32Ime.cs
+++ b/patches/TerrariaNetCore/ReLogic/Localization/IME/WinImm32Ime.cs
@@ -18,6 +18,7 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 	private string[] _candList = Array.Empty<string>();
 	private uint _candSelection;
 	private uint _candPageSize;
+	private bool _isCandDirty;
 
 	public uint SelectedPage => _candPageSize == 0 ? 0 : _candSelection / _candPageSize;
 
@@ -27,7 +28,16 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 
 	public override uint SelectedCandidate => _candPageSize == 0 ? 0 : _candSelection % _candPageSize;
 
-	public override uint CandidateCount => Math.Min((uint)_candList.Length - SelectedPage * _candPageSize, _candPageSize);
+	public override uint CandidateCount {
+		get {
+			// Lazily update candidate list at most once per frame to avoid race conditions.
+			// CandidateCount is always read first so we use it.
+			if (_isCandDirty) {
+				UpdateCandidateList();
+			}
+			return Math.Min((uint)_candList.Length - SelectedPage * _candPageSize, _candPageSize);
+		}
+	}
 
 	public WinImm32Ime(WindowsMessageHook wndProcHook, IntPtr hWnd)
 	{
@@ -83,6 +93,7 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 		try {
 			int size = NativeMethods.ImmGetCandidateList(hImc, 0, ref MemoryMarshal.GetReference(Span<byte>.Empty), 0);
 			if (size == 0) {
+				// This usually means candidate list is not ready, wait for next frame
 				_candList = Array.Empty<string>();
 				_candPageSize = 0;
 				_candSelection = 0;
@@ -109,16 +120,31 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 					}
 					end += 2;
 				}
+
 				candStrList[i] = Encoding.Unicode.GetString(buf[start..end]);
 			}
 
+			_isCandDirty = false;
 			_candList = candStrList;
 			_candPageSize = candList.dwPageSize;
 			_candSelection = candList.dwSelection;
 		}
+		catch (Exception e) when (e is ArgumentOutOfRangeException or IndexOutOfRangeException) {
+			// Some IME occasionally send malformed candidate buffers due to race conditions.
+			// Ignore them until next correct buffer is available.
+			Console.WriteLine($"Failed to parse candidate list: {e}");
+		}
 		finally {
 			NativeMethods.ImmReleaseContext(_hWnd, hImc);
 		}
+	}
+
+	private void ClearCandidateList()
+	{
+		_isCandDirty = false;
+		_candList = Array.Empty<string>();
+		_candPageSize = 0;
+		_candSelection = 0;
 	}
 
 	public override string GetCandidate(uint index)
@@ -144,31 +170,31 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 
 	public bool PreFilterMessage(ref Message message)
 	{
-		if (message.Msg == Msg.WM_KILLFOCUS) {
-			SetEnabled(bEnable: false);
-			_isFocused = false;
-			return true;
+		switch (message.Msg) {
+			case Msg.WM_KILLFOCUS:
+				SetEnabled(bEnable: false);
+				_isFocused = false;
+				return true;
+
+			case Msg.WM_SETFOCUS:
+				if (IsEnabled)
+					SetEnabled(bEnable: true);
+				_isFocused = true;
+				return true;
+
+			case Msg.WM_IME_SETCONTEXT:
+				// Hides the system IME. Should always be called on application startup.
+				message.LParam = IntPtr.Zero;
+				return false;
 		}
 
-		if (message.Msg == Msg.WM_SETFOCUS) {
-			if (base.IsEnabled)
-				SetEnabled(bEnable: true);
-
-			_isFocused = true;
-			return true;
-		}
-
-		// Hides the system IME. Should always be called on application startup.
-		if (message.Msg == Msg.WM_IME_SETCONTEXT) {
-			message.LParam = IntPtr.Zero;
-			return false;
-		}
-
-		if (!base.IsEnabled)
+		if (!IsEnabled)
 			return false;
 
 		switch (message.Msg) {
 			case Msg.WM_INPUTLANGCHANGE:
+				_compString = "";
+				ClearCandidateList();
 				return true;
 
 			case Msg.WM_IME_STARTCOMPOSITION:
@@ -176,24 +202,28 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 				return true;
 
 			case Msg.WM_IME_COMPOSITION:
+				_isCandDirty = true;
 				_compString = GetCompositionString();
 				break;
 
 			case Msg.WM_IME_ENDCOMPOSITION:
 				_compString = "";
-				UpdateCandidateList();
+				ClearCandidateList();
 				break;
 
 			case Msg.WM_IME_NOTIFY:
 				switch (message.WParam.ToInt32()) {
 					case Imm.IMN_OPENCANDIDATE:
 					case Imm.IMN_CHANGECANDIDATE:
+						_isCandDirty = true;
+						return true;
+
 					case Imm.IMN_CLOSECANDIDATE:
-						UpdateCandidateList();
-						break;
+						ClearCandidateList();
+						return true;
 				}
 
-				return true;
+				break;
 
 			case Msg.WM_CHAR:
 				OnKeyPress((char)message.WParam.ToInt32());

--- a/patches/TerrariaNetCore/ReLogic/Localization/IME/WinImm32Ime.cs
+++ b/patches/TerrariaNetCore/ReLogic/Localization/IME/WinImm32Ime.cs
@@ -17,16 +17,15 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 	private string _compString;
 	private string[] _candList = Array.Empty<string>();
 	private uint _candSelection;
+	private uint _candPageStart;
 	private uint _candPageSize;
 	private bool _isCandDirty;
-
-	public uint SelectedPage => _candPageSize == 0 ? 0 : _candSelection / _candPageSize;
 
 	public override string CompositionString => _compString;
 
 	public override bool IsCandidateListVisible => CandidateCount > 0;
 
-	public override uint SelectedCandidate => _candPageSize == 0 ? 0 : _candSelection % _candPageSize;
+	public override uint SelectedCandidate => _candSelection - _candPageStart;
 
 	public override uint CandidateCount {
 		get {
@@ -35,7 +34,7 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 			if (_isCandDirty) {
 				UpdateCandidateList();
 			}
-			return Math.Min((uint)_candList.Length - SelectedPage * _candPageSize, _candPageSize);
+			return Math.Min((uint)_candList.Length - _candPageStart, _candPageSize);
 		}
 	}
 
@@ -95,6 +94,7 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 			if (size == 0) {
 				// This usually means candidate list is not ready, wait for next frame
 				_candList = Array.Empty<string>();
+				_candPageStart = 0;
 				_candPageSize = 0;
 				_candSelection = 0;
 				return;
@@ -126,6 +126,7 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 
 			_isCandDirty = false;
 			_candList = candStrList;
+			_candPageStart = candList.dwPageStart;
 			_candPageSize = candList.dwPageSize;
 			_candSelection = candList.dwSelection;
 		}
@@ -143,6 +144,7 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 	{
 		_isCandDirty = false;
 		_candList = Array.Empty<string>();
+		_candPageStart = 0;
 		_candPageSize = 0;
 		_candSelection = 0;
 	}
@@ -150,7 +152,7 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 	public override string GetCandidate(uint index)
 	{
 		if (index < CandidateCount) {
-			return _candList[index + SelectedPage * _candPageSize];
+			return _candList[index + _candPageStart];
 		}
 
 		return "";
@@ -236,7 +238,7 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 	protected override void Dispose(bool disposing)
 	{
 		if (!_disposedValue) {
-			if (base.IsEnabled)
+			if (IsEnabled)
 				Disable();
 
 			_wndProcHook.RemoveMessageFilter(this);

--- a/patches/TerrariaNetCore/ReLogic/Localization/IME/WinImm32Ime.cs
+++ b/patches/TerrariaNetCore/ReLogic/Localization/IME/WinImm32Ime.cs
@@ -224,7 +224,7 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 			case Msg.WM_IME_ENDCOMPOSITION:
 				_compString = "";
 				ClearCandidateList();
-				break;
+				return true;
 
 			case Msg.WM_IME_NOTIFY:
 				switch (message.WParam.ToInt32()) {

--- a/patches/TerrariaNetCore/ReLogic/Localization/IME/WinImm32Ime.cs
+++ b/patches/TerrariaNetCore/ReLogic/Localization/IME/WinImm32Ime.cs
@@ -25,7 +25,7 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 
 	public override bool IsCandidateListVisible => CandidateCount > 0;
 
-	public override uint SelectedCandidate => _candSelection % _candPageSize;
+	public override uint SelectedCandidate => _candPageSize == 0 ? 0 : _candSelection % _candPageSize;
 
 	public override uint CandidateCount => Math.Min((uint)_candList.Length - SelectedPage * _candPageSize, _candPageSize);
 
@@ -96,12 +96,20 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 			var offsets = MemoryMarshal.CreateReadOnlySpan(ref candList.dwOffset, (int)candList.dwCount);
 
 			string[] candStrList = new string[candList.dwCount];
-			int next = buf.Length;
-			for (int i = (int)candList.dwCount-1; i >= 0; i--) {
+
+			for (int i = 0; i < (int)candList.dwCount; i++) {
 				int start = (int)offsets[i];
-				// Assume all strings are fully packed, with 2 byte null char at the end
-				candStrList[i] = Encoding.Unicode.GetString(buf[start..(next-2)]);
-				next = start;
+				int end = start;
+
+				// Note that strings are not always fully packed, we need to search from each offset
+				// for a UTF-16 null terminator (0x00 0x00). Length of UTF-16 sequences are always even.
+				while (end < buf.Length - 1) {
+					if (buf[end] == 0 && buf[end + 1] == 0) {
+						break;
+					}
+					end += 2;
+				}
+				candStrList[i] = Encoding.Unicode.GetString(buf[start..end]);
 			}
 
 			_candList = candStrList;

--- a/patches/TerrariaNetCore/ReLogic/Localization/IME/WinImm32Ime.cs
+++ b/patches/TerrariaNetCore/ReLogic/Localization/IME/WinImm32Ime.cs
@@ -34,6 +34,7 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 			if (_isCandDirty) {
 				UpdateCandidateList();
 			}
+
 			return Math.Min((uint)_candList.Length - _candPageStart, _candPageSize);
 		}
 	}
@@ -67,17 +68,18 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 		}
 	}
 
-	private string GetCompositionString()
+	private string GetCompositionString(uint dwIndex)
 	{
 		IntPtr hImc = NativeMethods.ImmGetContext(_hWnd);
 		try {
-			int size = NativeMethods.ImmGetCompositionString(hImc, Imm.GCS_COMPSTR, ref MemoryMarshal.GetReference(Span<byte>.Empty), 0);
+			int size = NativeMethods.ImmGetCompositionString(hImc, dwIndex,
+				ref MemoryMarshal.GetReference(Span<byte>.Empty), 0);
 			if (size == 0) {
 				return "";
 			}
 
 			Span<byte> buf = stackalloc byte[size];
-			NativeMethods.ImmGetCompositionString(hImc, Imm.GCS_COMPSTR, ref MemoryMarshal.GetReference(buf), size);
+			NativeMethods.ImmGetCompositionString(hImc, dwIndex, ref MemoryMarshal.GetReference(buf), size);
 
 			return Encoding.Unicode.GetString(buf.ToArray());
 		}
@@ -118,6 +120,7 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 					if (buf[end] == 0 && buf[end + 1] == 0) {
 						break;
 					}
+
 					end += 2;
 				}
 
@@ -204,9 +207,19 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 				return true;
 
 			case Msg.WM_IME_COMPOSITION:
-				_isCandDirty = true;
-				_compString = GetCompositionString();
-				break;
+				if ((message.LParam.ToInt32() & Imm.GCS_RESULTSTR) != 0) {
+					var resultString = GetCompositionString(Imm.GCS_RESULTSTR);
+					foreach (var c in resultString) {
+						OnKeyPress(c);
+					}
+				}
+
+				if ((message.LParam.ToInt32() & Imm.GCS_COMPSTR) != 0) {
+					_compString = GetCompositionString(Imm.GCS_COMPSTR);
+					_isCandDirty = true;
+				}
+
+				return true;
 
 			case Msg.WM_IME_ENDCOMPOSITION:
 				_compString = "";
@@ -218,14 +231,14 @@ internal class WinImm32Ime : PlatformIme, IMessageFilter
 					case Imm.IMN_OPENCANDIDATE:
 					case Imm.IMN_CHANGECANDIDATE:
 						_isCandDirty = true;
-						return true;
+						break;
 
 					case Imm.IMN_CLOSECANDIDATE:
 						ClearCandidateList();
-						return true;
+						break;
 				}
 
-				break;
+				return true;
 
 			case Msg.WM_CHAR:
 				OnKeyPress((char)message.WParam.ToInt32());


### PR DESCRIPTION
### What is the bug?
#3635 (partially), #5114 ,delayed candidate list update for some IMEs

### How did you fix the bug?
The cause of #3635 is that Windows 10 versions of Microsoft Pinyin that use the new TSF interface instead of old Imm32 framework, do not behave well on the Windows TSF-Imm32 compatibility layer. By consuming `WM_IME_COMPOSITION` messages, incompatible IMEs will properly draw their own candidate lists and in-game candidate lists are hidden, which is a valid fallback.
There are two causes for #5114 :
- The previous WinImm32Ime implementation made an incorrect assumption that strings are tightly packed in candidate lists. Certain IMEs do not follow this convention and the previous implementation will throw an OOB error in this case. The new implementation does not make this assumption and instead searches for UTF-16 null terminators from each offset start.
- The previous implementation updates candidate lists as soon as a `IMN_CHANGECANDIDATE` message is received. Some IMEs trigger multiple `IMN_CHANGECANDIDATE` messages in one frame, and some of them contain corrupted buffer. Delaying the update to the next frame fixes this problem. This also fixes candidate window getting delayed updates in some IMEs.

### Are there alternatives to your fix?
There is an ongoing experimentation on reimplementing ReLogic.Native.dll in 64-bit, and would support a full vanilla-like IME experience.
