### PR TITLE
[1.4.5] Make NPC.TryAddingRepeatedBuff public and document it

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -16,7 +16,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - Mount.Dismount now has a ignoreEffect parameter, this might duplicate the skipDust variable used in MountLoader.Dismount. Adjust patches (and docs) accordingly if they should be the same. When is it set? Do modded mounts need to care about when ignoreEffect was true or false?
 - Check for any remaining TML added ID sets that aren't in TML.cs files.
 - BuffLoader.ReApply (NPC) logic seems changed, likely to fix desync issues. The server sync for MessageID.NPCBuffs when !quiet now happens after the reapply logic. Modded ReApply will need doc updates or maybe new parameters to properly adjust to these changes. Maybe a ref time parameter instead?
-- NPC.TryAddingRepeatedBuff added. Might be useful to document and make public.
 - Recipe.requiredTile no longer supports multiple tiles. Only a single crafting station is the new approach. In theory it is possible to restore multiple required tiles, but we'd have to rule that recipes can show in the filtered crafting station UI if _any_ of their required tiles meet the filter.
 - Zone calculations seem to have been reorganized a bit. Verify functionality of hooks (TileCountsAvailable, ResetNearbyTileEffects, UpdateSceneEffect)
 - FileUtilities.Copy and Move no longer have an `overwrite` parameter.

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2697,14 +2697,15 @@
  	public static int FindFirstNPC(int Type)
  	{
  		for (int i = 0; i < Main.maxNPCs; i++) {
-@@ -75514,6 +_,14 @@
+@@ -75514,6 +_,15 @@
  		return -1;
  	}
  
 +	/// <summary>
-+	/// Gives this NPC the provided buff. This accounts for if the NPC is immune to the buff.
-+	/// <br/> If the NPC already has the buff, the re-apply logic will happen. Vanilla buff types are found in <see cref="BuffID"/> and modded buffs are typically retrieved using <see cref="ModContent.BuffType{T}"/>.
-+	/// <br/> The quiet parameter will determine if the network sync message should happen. This should always stay false.
++	/// Gives this NPC the provided buff for the provided duration. This accounts for if the NPC is immune to the buff.
++	/// <para/> If the NPC already has the buff, the re-apply logic will happen. Vanilla buff types are found in <see cref="BuffID"/> and modded buffs are typically retrieved using <see cref="ModContent.BuffType{T}"/>.
++	/// <para/> The quiet parameter will determine if the network sync message should be skipped. This should always stay false.
++	/// <para/> For buffs that apply constantly or potentially each game update, such as a buff applied by nearby tiles, consider using <see cref="TryAddingRepeatedBuff(int, int, int)"/> instead to reduce network spam.
 +	/// </summary>
 +	/// <param name="type">The buff type</param>
 +	/// <param name="time">The desired buff time in ticks. 60 ticks is 1 second</param>
@@ -3004,18 +3005,19 @@
  		bool result = false;
  		if (type == 2 || type == -43 || type == 190 || type == 191 || type == 192 || type == 193 || type == 194 || type == 317 || type == 318 || type == 133)
  			result = true;
-@@ -78332,7 +_,13 @@
+@@ -78332,7 +_,14 @@
  		}
  	}
  
 -	private void TryAddingRepeatedBuff(int buffId, int timeToGive, int lowThresholdUndeathToAllowBuff = 10)
 +	/// <summary>
-+	/// Adds <paramref name="buffId"/> for <paramref name="timeToGive"/> ticks if the NPC doesn't already have it or if its remaining duration is at or below <paramref name="lowThresholdUndeathToAllowBuff"/>. Useful for town NPC comfort buffs, such as the Campfire buff.
++	/// Gives this NPC the provided buff, but only if the NPC doesn't already have it or if its remaining duration is at or below <paramref name="lowThresholdUndeathToAllowBuff"/>.
++	/// <para/> This is useful for buffs that could potentially be constantly applied to an NPC each game update. By using this method rather than <see cref="AddBuff(int, int, bool)"/>, the buff will not trigger network syncing to happen every game update as the buff is constantly re-applied. For example, <see cref="BuffID.Stinky"/> and <see cref="BuffID.Shimmer"/> are both applied in this manner.
 +	/// </summary>
 +	/// <param name="buffId">The buff type</param>
 +	/// <param name="timeToGive">The desired buff time in ticks. 60 ticks is 1 second</param>
 +	/// <param name="lowThresholdUndeathToAllowBuff">The remaining duration under which the buff will be reapplied.</param>
-+	public void TryAddingRepeatedBuff(int buffId, int timeToGive, int lowThresholdUndeathToAllowBuff = 10) // TML: Made public so mods can use it for town NPC or other repeated buffs
++	public void TryAddingRepeatedBuff(int buffId, int timeToGive, int lowThresholdUndeathToAllowBuff = 10) // TML: Made public
  	{
  		if (!buffImmune[buffId]) {
  			int num = FindBuffIndex(buffId);

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -3004,6 +3004,21 @@
  		bool result = false;
  		if (type == 2 || type == -43 || type == 190 || type == 191 || type == 192 || type == 193 || type == 194 || type == 317 || type == 318 || type == 133)
  			result = true;
+@@ -78332,7 +_,13 @@
+ 		}
+ 	}
+ 
+-	private void TryAddingRepeatedBuff(int buffId, int timeToGive, int lowThresholdUndeathToAllowBuff = 10)
++	/// <summary>
++	/// Adds <paramref name="buffId"/> for <paramref name="timeToGive"/> ticks if the NPC doesn't already have it or if its remaining duration is at or below <paramref name="lowThresholdUndeathToAllowBuff"/>. Useful for town NPC comfort buffs, such as the Campfire buff.
++	/// </summary>
++	/// <param name="buffId">The buff type</param>
++	/// <param name="timeToGive">The desired buff time in ticks. 60 ticks is 1 second</param>
++	/// <param name="lowThresholdUndeathToAllowBuff">The remaining duration under which the buff will be reapplied.</param>
++	public void TryAddingRepeatedBuff(int buffId, int timeToGive, int lowThresholdUndeathToAllowBuff = 10) // TML: Made public so mods can use it for town NPC or other repeated buffs
+ 	{
+ 		if (!buffImmune[buffId]) {
+ 			int num = FindBuffIndex(buffId);
 @@ -78423,6 +_,9 @@
  		if (IsABestiaryIconDummy)
  			newColor = Color.White;


### PR DESCRIPTION
### Summary
Makes the new 1.4.5 vanilla helper `NPC.TryAddingRepeatedBuff` public and documents it. Resolves the corresponding PortingNotes_1.4.5.md item.

### Why
1.4.5 added this helper for town NPC comfort buffs (e.g. campfire/heart lantern style reapplication). It implements a common pattern - reapply a buff only when missing or nearly expired - that mods currently have to reimplement.

### Behavior
No change to vanilla behavior; the method is unchanged except for visibility and documentation.

### Testing
Doc-only + visibility change; no behavioral test applicable. Full build validated by CI.

### Related
PortingNotes_1.4.5.md: "NPC.TryAddingRepeatedBuff added. Might be useful to document and make public." (removed in this PR).