### PR TITLE
[1.4.5] Document UIScrollbar.AutoHide and UIScrollbar.CanScroll

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -148,7 +148,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - TileEntity.Read now has a gameversion parameter. For modded tiles, I don't think this affects anything. Vanilla TEs have updated save and load code, need to verify poses and other changes work with modded items.
 - UserInterface.MouseCaptured -> could be useful
 - FlexibleTileWand is now used to place many other tiles that used to rely solely on RandomStyleRange. We should add an example of a custom FlexibleTileWand item/tile and document when to use it.
-- UIScrollbar.AutoHide and CanScroll
 - NPC.DelBuff has new quiet parameter
 - TileID.Sets.DontDrawTileSlopes.
 - Player.selectedItem is not a getter property instead of a field. We might need to document selectedItemState and other related new fields.

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIScrollbar.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIScrollbar.cs.patch
@@ -9,6 +9,26 @@
  {
  	public enum ColorTheme
  	{
+@@ -20,6 +_,9 @@
+ 	private bool _isDragging;
+ 	private bool _isHoveringOverHandle;
+ 	private float _dragYOffset;
++	/// <summary>
++	/// If <see langword="true"/>, the scrollbar is hidden while it cannot be scrolled (<see cref="CanScroll"/> is <see langword="false"/>).
++	/// </summary>
+ 	public bool AutoHide;
+ 	private Asset<Texture2D> _texture;
+ 	private Asset<Texture2D> _innerTexture;
+@@ -34,6 +_,9 @@
+ 		}
+ 	}
+ 
++	/// <summary>
++	/// Whether the scrollbar can currently be scrolled, i.e. whether the view size is smaller than the max view size.
++	/// </summary>
+ 	public bool CanScroll => _maxViewSize != _viewSize;
+ 
+ 	public void GoToBottom()
 @@ -77,7 +_,7 @@
  		return new Rectangle((int)innerDimensions.X, (int)(innerDimensions.Y + innerDimensions.Height * (_viewPosition / _maxViewSize)) - 3, 20, (int)(innerDimensions.Height * (_viewSize / _maxViewSize)) + 7);
  	}


### PR DESCRIPTION
### Summary
Documents `UIScrollbar.AutoHide` and `UIScrollbar.CanScroll`, two 1.4.5 additions.

### Why
PortingNotes_1.4.5.md item: "UIScrollbar.AutoHide and CanScroll".

### Behavior
Docs-only change.

### Related
PortingNotes_1.4.5.md (item removed by this PR).