### PR TITLE
[1.4.5] Document UserInterface.MouseCaptured

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -146,7 +146,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 
 - UIElement.PassThroughMouseInteraction --> What does it do? How does it differ from IgnoresMouseInteraction?
 - TileEntity.Read now has a gameversion parameter. For modded tiles, I don't think this affects anything. Vanilla TEs have updated save and load code, need to verify poses and other changes work with modded items.
-- UserInterface.MouseCaptured -> could be useful
 - FlexibleTileWand is now used to place many other tiles that used to rely solely on RandomStyleRange. We should add an example of a custom FlexibleTileWand item/tile and document when to use it.
 - UIScrollbar.AutoHide and CanScroll
 - NPC.DelBuff has new quiet parameter

--- a/patches/tModLoader/Terraria/UI/UserInterface.cs.patch
+++ b/patches/tModLoader/Terraria/UI/UserInterface.cs.patch
@@ -9,7 +9,7 @@
  {
  	private delegate void MouseElementEvent(UIElement element, UIMouseEvent evt);
  
-@@ -77,8 +_,14 @@
+@@ -77,8 +_,15 @@
  	{
  		LeftMouse.Clear();
  		RightMouse.Clear();
@@ -19,7 +19,8 @@
  	}
  
 +	/// <summary>
-+	/// Whether any UI element is currently holding the mouse capture, that is, a mouse button was pressed down over an element and hasn't been released yet. Useful to prevent gameplay interactions while the cursor is over UI.
++	/// Whether any UI element in this UserInterface is currently holding the mouse capture, that is, a mouse button was pressed down over an element and hasn't been released yet.
++	/// <para/> For most situations, <see cref="Player.mouseInterface"/> (<c>Main.LocalPlayer.mouseInterface</c>) should be used instead.
 +	/// </summary>
  	public bool MouseCaptured()
  	{

--- a/patches/tModLoader/Terraria/UI/UserInterface.cs.patch
+++ b/patches/tModLoader/Terraria/UI/UserInterface.cs.patch
@@ -9,7 +9,7 @@
  {
  	private delegate void MouseElementEvent(UIElement element, UIMouseEvent evt);
  
-@@ -77,6 +_,9 @@
+@@ -77,8 +_,14 @@
  	{
  		LeftMouse.Clear();
  		RightMouse.Clear();
@@ -18,7 +18,12 @@
 +		XButton2Mouse.Clear();
  	}
  
++	/// <summary>
++	/// Whether any UI element is currently holding the mouse capture, that is, a mouse button was pressed down over an element and hasn't been released yet. Useful to prevent gameplay interactions while the cursor is over UI.
++	/// </summary>
  	public bool MouseCaptured()
+ 	{
+ 		if (!LeftMouse.WasDown || LeftMouse.LastDown == null) {
 @@ -125,6 +_,9 @@
  	{
  		LeftMouse.WasDown = Main.mouseLeft;


### PR DESCRIPTION
### Summary
Documents `UserInterface.MouseCaptured`.

### Why
PortingNotes_1.4.5.md item: "UserInterface.MouseCaptured -> could be useful". The method reports whether any UI element currently holds the mouse capture, which is exactly what modders need to avoid gameplay interactions while the cursor is over UI.

### Behavior
Docs-only change.

### Related
PortingNotes_1.4.5.md (item removed by this PR).