### PR TITLE
[1.4.5] Call UseItemHitbox hook reliably for all melee hitbox paths

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -100,7 +100,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - Item.IsTheSameAs removed
 - RefreshInfoAccsFromItemType is now being called on vanity equipment too. Does this affect any of our changes? Is any slot now being checked twice? Do we need to adjust ModAccessorySlotPlayer for the same behavior?
 - `//TML: Eventide and nightglow handled by Item.useLimitPerAnimation.` comment now commenting out item 5669. Might need to make changes to that item similar to 4956
-- ItemLoader.UseItemHitbox callsite useStyle == 3 needs adjustment to call hook reliably.
 - clientClone changed. I think the `_clientClone` field is no longer needed, or extraneous.
 - Player.nonTorch removed
 - What is ApplyRapidAttackBonus?

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7177,6 +7177,20 @@
  		if (!mount.Active || (mount.Type != 62 && mount.Type != 63) || !sItem.melee || sItem.noMelee || sItem.noUseGraphic)
  			return;
  
+@@ -36494,6 +_,13 @@
+ 
+ 	private void ItemCheck_GetMeleeHitbox(Item sItem, Rectangle heldItemFrame, out bool dontAttack, out Rectangle itemRectangle)
+ 	{
++		// TML: The vanilla method has several early returns (e.g. during the early portion of a useStyle 3 swing) which would skip the UseItemHitbox hook if it were called at the end of the method. Call the hook from a wrapper instead so it always runs.
++		ItemCheck_GetMeleeHitbox_Inner(sItem, heldItemFrame, out dontAttack, out itemRectangle);
++		ItemLoader.UseItemHitbox(sItem, this, ref itemRectangle, ref dontAttack);
++	}
++
++	private void ItemCheck_GetMeleeHitbox_Inner(Item sItem, Rectangle heldItemFrame, out bool dontAttack, out Rectangle itemRectangle)
++	{
+ 		dontAttack = false;
+ 		itemRectangle = new Rectangle((int)itemLocation.X, (int)itemLocation.Y, 32, 32);
+ 		if (!Main.dedServ) {
 @@ -36570,6 +_,8 @@
  					itemRectangle.X += 10;
  			}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7181,7 +7181,7 @@
  
  	private void ItemCheck_GetMeleeHitbox(Item sItem, Rectangle heldItemFrame, out bool dontAttack, out Rectangle itemRectangle)
  	{
-+		// TML: The vanilla method has several early returns (e.g. during the early portion of a useStyle 3 swing) which would skip the UseItemHitbox hook if it were called at the end of the method. Call the hook from a wrapper instead so it always runs.
++		// TML: Wrapper approach to handle the early returns to call UseItemHitbox reliably.
 +		ItemCheck_GetMeleeHitbox_Inner(sItem, heldItemFrame, out dontAttack, out itemRectangle);
 +		ItemLoader.UseItemHitbox(sItem, this, ref itemRectangle, ref dontAttack);
 +	}
@@ -7191,15 +7191,6 @@
  		dontAttack = false;
  		itemRectangle = new Rectangle((int)itemLocation.X, (int)itemLocation.Y, 32, 32);
  		if (!Main.dedServ) {
-@@ -36570,6 +_,8 @@
- 					itemRectangle.X += 10;
- 			}
- 		}
-+
-+		ItemLoader.UseItemHitbox(sItem, this, ref itemRectangle, ref dontAttack);
- 	}
- 
- 	private void ItemCheck_UseDemonHeart(Item sItem)
 @@ -36645,29 +_,75 @@
  		releaseUseItem = false;
  	}


### PR DESCRIPTION
### Summary
Ensures `ItemLoader.UseItemHitbox` (the `ModItem/GlobalItem.UseItemHitbox` hook) is called for every melee hitbox calculation, including the early-return paths in `ItemCheck_GetMeleeHitbox`.

### Why
Vanilla 1.4.5's `ItemCheck_GetMeleeHitbox` has several early returns - notably `useStyle == 3` (shortswords) returning during the first third of the swing with `dontAttack = true`, and the `useStyle == 1` wide-swing branches. The ported hook call was appended to the end of the method, so those paths skipped it entirely and modded hitbox modifications were unreliable for affected items (PortingNotes_1.4.5.md: "ItemLoader.UseItemHitbox callsite useStyle == 3 needs adjustment to call hook reliably").

### Behavior
The method is split into a vanilla body (`ItemCheck_GetMeleeHitbox_Inner`) plus a wrapper that always invokes the hook afterwards:
* `useStyle == 3` items now get hitbox adjustments on every frame of their swing instead of only after 2/3 of the animation.
* `dontAttack`/`itemRectangle` values from the hook are honored identically; no change for items that never early-return.

### Testing
Diff verified by hand against the vanilla decompiled flow; full build validated by CI (local full-source setup not possible here). No automated test feasible without game content initialization.

### Related
PortingNotes_1.4.5.md item removed by this PR.