### PR TITLE
[1.4.5] Fixed modded torches not being placeable on platforms

### DIFF
--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -7,7 +7,7 @@ partial class TileID
 {
 	partial class Sets
 	{
-		/// <summary> Will cause the tile to be killed when right clicked, like <see cref="Torches"/> or <see cref="Bottles"/>. No need to set this if using <see cref="Torch"/>. </summary>
+		/// <summary> Will cause the tile to be killed when right clicked, like <see cref="TileID.Torches"/> or Water Bolt. No need to set this if using <see cref="Torches"/>. </summary>
 		public static bool[] CanDropFromRightClick = Factory.CreateBoolSet(4);
 		public static bool[] Stone = Factory.CreateBoolSet(1, 117, 25, 203);
 		public static bool[] Grass = Factory.CreateBoolSet(2, 23, 109, 199, 477, 492, 633); // Might be incorrect?

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -6226,7 +6226,7 @@
  			PlaceThing_Tiles_TryPlacing(tileToCreate, overrideCanPlace, forcedRandom, data, previewPlaceStyle);
  		}
  	}
-@@ -32113,7 +_,11 @@
+@@ -32113,7 +_,14 @@
  		if (overrideCanPlace.HasValue) {
  			canPlace = overrideCanPlace.Value;
  		}
@@ -6234,7 +6234,9 @@
 +			canPlace = false;
 +			// TODO: CanPlace hook that allows forcing canPlace to true, rather than just preventing placement.
 +		}
--		else if (TileObjectData.CustomPlace(tileToCreate, placeStyle) && tileToCreate != 82 && tileToCreate != 227 && tileToCreate != 4) {
++		/*
+ 		else if (TileObjectData.CustomPlace(tileToCreate, placeStyle) && tileToCreate != 82 && tileToCreate != 227 && tileToCreate != 4) {
++		*/
 +		else if (TileObjectData.CustomPlace(tileToCreate, placeStyle) && tileToCreate != 82 && tileToCreate != 227 && !TileID.Sets.Torches[tileToCreate]) {
  			newObjectType = true;
  			canPlace = TileObject.CanPlace(tileTargetX, tileTargetY, (ushort)tileToCreate, placeStyle, direction, out data, onlyCheck: false, forcedRandom);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -6226,7 +6226,7 @@
  			PlaceThing_Tiles_TryPlacing(tileToCreate, overrideCanPlace, forcedRandom, data, previewPlaceStyle);
  		}
  	}
-@@ -32113,6 +_,10 @@
+@@ -32113,7 +_,11 @@
  		if (overrideCanPlace.HasValue) {
  			canPlace = overrideCanPlace.Value;
  		}
@@ -6234,9 +6234,11 @@
 +			canPlace = false;
 +			// TODO: CanPlace hook that allows forcing canPlace to true, rather than just preventing placement.
 +		}
- 		else if (TileObjectData.CustomPlace(tileToCreate, placeStyle) && tileToCreate != 82 && tileToCreate != 227 && tileToCreate != 4) {
+-		else if (TileObjectData.CustomPlace(tileToCreate, placeStyle) && tileToCreate != 82 && tileToCreate != 227 && tileToCreate != 4) {
++		else if (TileObjectData.CustomPlace(tileToCreate, placeStyle) && tileToCreate != 82 && tileToCreate != 227 && !TileID.Sets.Torches[tileToCreate]) {
  			newObjectType = true;
  			canPlace = TileObject.CanPlace(tileTargetX, tileTargetY, (ushort)tileToCreate, placeStyle, direction, out data, onlyCheck: false, forcedRandom);
+ 			PlaceThing_Tiles_BlockPlacementIfOverPlayers(ref canPlace, ref data);
 @@ -32200,9 +_,15 @@
  			if (!WorldGen.IsTileReplaceable(tileTargetX, tileTargetY))
  				return false;


### PR DESCRIPTION
### What is the bug?

Modded torches cannot be placed on platforms. Vanilla torches can. Placing them on blocks, walls and in water works.

### How did you fix the bug?

`PlaceThing_Tiles_TryPlacing` picks the placement path with a hardcoded id:

```cs
else if (TileObjectData.CustomPlace(tileToCreate, placeStyle) && tileToCreate != 82 && tileToCreate != 227 && tileToCreate != 4) {
    canPlace = TileObject.CanPlace(...);
}
else {
    canPlace = PlaceThing_Tiles_BlockPlacementForAssortedThings(canPlace);
}
```

`tileToCreate != 4` sends vanilla torches to the `else` path, and that path is the one that accepts platforms:

```cs
if (num3 >= 0 && Main.tileSolid[num3] && (!Main.tileNoAttach[num3] || TileID.Sets.Platforms[num3]))
    canPlace = true;
```

Modded torches do not match the id, so they go through `TileObject.CanPlace`, where a platform fails every anchor: `SolidTile` is ruled out by `tileNoAttach`, and torches have no `SolidWithTop` anchor.

Matching on `TileID.Sets.Torches` puts modded torches on the same path as vanilla.

### Are there alternatives to your fix?

No.
