### PR TITLE
[1.4.5] Create current language localization template for new mods

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/SourceManagement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/SourceManagement.cs
@@ -82,6 +82,28 @@ internal static class SourceManagement
 				TryWriteModTemplateFile(modSrcDirectory, resourceKey.Substring(TemplateResourcePrefix.Length), templateParameters);
 			}
 		}
+
+		// In addition to the default en-US localization template, create a matching localization
+		// file for the currently selected language so new mods are immediately ready to edit in-game.
+		TryWriteActiveCultureLocalizationTemplateFile(modSrcDirectory, templateParameters);
+	}
+
+	private static void TryWriteActiveCultureLocalizationTemplateFile(string modSrcDirectory, TemplateParameters templateParameters)
+	{
+		string activeCultureName = Language.ActiveCulture?.Name;
+		string defaultCultureName = GameCulture.DefaultCulture?.Name;
+
+		// The default culture file is already written by the template itself.
+		if (string.IsNullOrEmpty(activeCultureName) || string.IsNullOrEmpty(defaultCultureName) || string.Equals(activeCultureName, defaultCultureName, StringComparison.OrdinalIgnoreCase)) {
+			return;
+		}
+
+		string defaultLocalizationPath = Path.Combine(modSrcDirectory, "Localization", $"{defaultCultureName}_Mods.{templateParameters.ModName}.hjson");
+		string activeCultureLocalizationPath = Path.Combine(modSrcDirectory, "Localization", $"{activeCultureName}_Mods.{templateParameters.ModName}.hjson");
+
+		if (File.Exists(defaultLocalizationPath) && !File.Exists(activeCultureLocalizationPath)) {
+			File.Copy(defaultLocalizationPath, activeCultureLocalizationPath);
+		}
 	}
 
 	/// <summary> Writes a single mod template file to the provided source-code directory. </summary>


### PR DESCRIPTION
### What is the new feature?

When creating a new mod through the in-game Create Mod UI, tModLoader now generates both the default English localization file and a matching localization file for the currently selected game language.

For example, when the active language is Simplified Chinese, creating a mod will generate the default English localization template and an additional current-culture localization template in the new mod's `Localization` folder.

### Why should this be part of tModLoader?

Previously, new mods only started with the default English localization template. Non-English users had to manually create the current language `hjson` file before editing localized content in their own language.

This improves the new mod creation experience for non-English users by making localization files immediately available for the active game language, while preserving the default English template as the required base localization file.

### Are there alternative designs?

An alternative would be adding another template resource file for every culture, but that would duplicate template content and require more maintenance.

This implementation instead reuses the generated default culture localization file and copies it to the active culture when the active culture differs from the default culture. This keeps the template source simple and avoids changing behavior for users already using English.

### Sample usage for the new feature

1. Set the game language to a non-English language.
2. Open the Create Mod UI.
3. Create a new mod.
4. The generated mod source will include the default English localization file and a current-language localization file.

### ExampleMod updates

Not applicable.

### Porting Notes

No action is required from modders. This only affects newly created mod source templates.
