### PR TITLE
[1.4.5] Fixed input method display

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/UI/UIFocusInputTextField.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIFocusInputTextField.cs
@@ -68,6 +68,7 @@ internal class UIFocusInputTextField : UIElement
 		if (Focused) {
 			GameInput.PlayerInput.WritingText = true;
 			Main.instance.HandleIME();
+			SetIMEPanelAnchor();
 			string newString = Main.GetInputText(CurrentString);
 			if (Main.inputTextEscape) {
 				Main.inputTextEscape = false;
@@ -104,5 +105,11 @@ internal class UIFocusInputTextField : UIElement
 		else {
 			Utils.DrawBorderString(spriteBatch, displayString, new Vector2(space.X, space.Y), Color.White);
 		}
+	}
+
+	private void SetIMEPanelAnchor()
+	{
+		Rectangle rect = GetDimensions().ToRectangle();
+		Main.instance.SetIMEPanelAnchor(new Vector2(rect.Left, rect.Bottom + 32), 0f);
 	}
 }


### PR DESCRIPTION
### What is the bug?
tModLoader does not correctly display the system IME candidate window when using CJK and other non-Latin input methods. This causes inconvenience for modders in multi-language regions when typing in-game text.
### How did you fix the bug?
Fixed window message handling to properly forward IME-related messages, allowing the system input method UI to display normally on the game window.
### Are there alternatives to your fix?
The only alternative is manually copying text from external editors, which is unfriendly and inefficient for non-English modders. This fix provides native global IME support for all mods.

<img width="687" height="268" alt="image" src="https://github.com/user-attachments/assets/3b70619d-dc99-4028-82d5-b68d166d8ce3" />
