### PR TITLE
Use TileEntity.EntityCreationLock properly in missing places

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/TileEntity.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/TileEntity.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/DataStructures/TileEntity.cs
 +++ src/tModLoader/Terraria/DataStructures/TileEntity.cs
-@@ -4,24 +_,32 @@
+@@ -4,24 +_,35 @@
  using Microsoft.Xna.Framework.Graphics;
  using Terraria.Audio;
  using Terraria.GameInput;
@@ -13,6 +13,9 @@
  {
  	public static TileEntitiesManager manager;
  	public const int MaxEntitiesPerChunk = 1000;
++	/// <summary>
++	/// Used as a lock on modifications to <see cref="ByID"/> and <see cref="ByPosition"/>. Due to multithreading, this needs to be used in a lock statement before adding or removing entries to ByID and ByPosition.
++	/// </summary>
  	public static object EntityCreationLock = new object();
 +	/// <summary> Maps <see cref="ID"/> to TileEntity instances. </summary>
  	public static Dictionary<int, TileEntity> ByID = new Dictionary<int, TileEntity>();

--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_TEs.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_TEs.cs
@@ -15,25 +15,27 @@ internal static partial class TileIO
 
 		var saveData = new TagCompound();
 
-		foreach (KeyValuePair<int, TileEntity> pair in TileEntity.ByID) {
-			var tileEntity = pair.Value;
-			var modTileEntity = tileEntity as ModTileEntity;
+		lock (TileEntity.EntityCreationLock) {
+			foreach (KeyValuePair<int, TileEntity> pair in TileEntity.ByID) {
+				var tileEntity = pair.Value;
+				var modTileEntity = tileEntity as ModTileEntity;
 
-			tileEntity.SaveData(saveData);
+				tileEntity.SaveData(saveData);
 
-			var tag = new TagCompound {
-				["mod"] = modTileEntity?.Mod.Name ?? "Terraria",
-				["name"] = modTileEntity?.Name ?? tileEntity.GetType().Name,
-				["X"] = tileEntity.Position.X,
-				["Y"] = tileEntity.Position.Y
-			};
+				var tag = new TagCompound {
+					["mod"] = modTileEntity?.Mod.Name ?? "Terraria",
+					["name"] = modTileEntity?.Name ?? tileEntity.GetType().Name,
+					["X"] = tileEntity.Position.X,
+					["Y"] = tileEntity.Position.Y
+				};
 
-			if (saveData.Count != 0) {
-				tag["data"] = saveData;
-				saveData = new TagCompound();
+				if (saveData.Count != 0) {
+					tag["data"] = saveData;
+					saveData = new TagCompound();
+				}
+
+				list.Add(tag);
 			}
-
-			list.Add(tag);
 		}
 
 		return list;

--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -132,9 +132,11 @@ public abstract class ModTileEntity : TileEntity, IModType, ILoadable
 		Point16 pos = new Point16(i, j);
 		if (ByPosition.TryGetValue(pos, out var tileEntity)) {
 			if (tileEntity.type == Type) {
-				((ModTileEntity)tileEntity).OnKill();
-				ByID.Remove(tileEntity.ID);
-				ByPosition.Remove(pos);
+				lock (EntityCreationLock) {
+					((ModTileEntity)tileEntity).OnKill();
+					ByID.Remove(tileEntity.ID);
+					ByPosition.Remove(pos);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #5371 

Saving the world happens on another thread, iterating over modded TileEntities while saving could potentially happen as a modded tile entity is being placed or removed, which can cause "Collection was modified; enumeration operation may not execute.".

This PR adds lock statements for thread safety, matching vanilla usages as well. 1.4.5 will also need this fix, but not the ModTileEntity.Kill changes since the new Remove method has that already.

If this issue comes up again, it is likely that a mod is directly modifying ByID or ByPosition, and will need to use `lock (TileEntity.EntityCreationLock)`.