### PR TITLE
setup: make downloads cancellable

### DIFF
--- a/setup/Core/TerrariaDecompileExecutableProvider.cs
+++ b/setup/Core/TerrariaDecompileExecutableProvider.cs
@@ -58,7 +58,7 @@ public sealed class TerrariaDecompileExecutableProvider
 
 			string serverVersionWithoutDots = ServerVersion.ToString().Replace(".", "");
 			string url = $"https://terraria.org/api/download/pc-dedicated-server/terraria-server-{serverVersionWithoutDots}.zip";
-			using var zip = new ZipArchive(await httpClient.GetStreamAsync(url, cancellationToken));
+			using var zip = new ZipArchive(new MemoryStream(await httpClient.GetByteArrayAsync(url, cancellationToken)));
 			zip.Entries.Single(e => e.FullName == $"{serverVersionWithoutDots}/Windows/TerrariaServer.exe").ExtractToFile(destinationPath);
 		}
 	}
@@ -124,7 +124,7 @@ public sealed class TerrariaDecompileExecutableProvider
 
 		taskProgress.ReportStatus("Downloading .NET Framework Reference Assemblies...");
 		var url = "https://www.nuget.org/api/v2/package/Microsoft.NETFramework.ReferenceAssemblies.net481/1.0.3";
-		using var zip = new ZipArchive(await httpClient.GetStreamAsync(url, cancellationToken));
+		using var zip = new ZipArchive(new MemoryStream(await httpClient.GetByteArrayAsync(url, cancellationToken)));
 
 		var subfolder = "build/.NETFramework/v4.8.1";
 		foreach (var e in zip.Entries) {


### PR DESCRIPTION
### What is the bug?

Setup cannot be interrupted while it is downloading.

`ConsoleAppCancellationTokenSource` sets `e.Cancel = true` on Ctrl+C, which
suppresses the default process termination and cancels a token instead. Neither
of the two downloads in `TerrariaDecompileExecutableProvider` observes that
token: `GetStreamAsync(url, cancellationToken)` only covers obtaining the
response, and the body is then read by `ZipArchive` through plain synchronous
reads that take no token. As a result Ctrl+C does nothing at all, and the only
way out is to kill the process from another terminal.

This is easy to hit on a slow connection. From where I live, traffic to
terraria.org is throttled to about 1.9 KB/s by network filtering on my end —
nothing to do with terraria.org itself. The server zip is 45 MB, so at that rate
the download would run for roughly 6.6 hours.

Nothing is printed while that happens, so there is no way to tell a slow
download from a stuck one. I ended up opening the setup sources to find the URL
and fetching it by hand before I could see that the transfer was merely very
slow rather than hung. At that point the natural reaction is to press Ctrl+C,
and nothing happens.

Measured with a standalone repro that cancels the token 3 seconds into the
download:

    GetStreamAsync + ZipArchive : did not react to cancellation within 20s
    GetByteArrayAsync           : cancelled after 3.0s

### How did you fix the bug?

Read the response body with `GetByteArrayAsync(url, cancellationToken)`, which
honors the token for the whole read, and hand the bytes to `ZipArchive` through
a `MemoryStream`.

This does not introduce buffering. `ZipArchive` in Read mode has to reach the
central directory at the end of the archive, and the HTTP response stream is
forward-only (`HttpConnection+ContentLengthReadStream`, `CanSeek == false`), so
`ZipArchive` was already copying the whole archive into memory on its own.
Buffering explicitly in fact allocates less, because `GetByteArrayAsync` sizes
the buffer from Content-Length instead of growing a `MemoryStream` by doubling:

    Total allocations for the ~20 MB reference assemblies package
      GetStreamAsync + ZipArchive : 65.6 MB
      GetByteArrayAsync           : 23.9 MB

Verified end to end as well: with the change, Ctrl+C during the TerrariaServer
download exits immediately, where before the process had to be killed from
another terminal.

### Are there alternatives to your fix?

- Stream to a temporary file instead of memory. That would reduce memory use
  further, but it needs temp file creation and cleanup for no real gain here,
  since the current code already buffers the whole archive in memory anyway.
- Leave the downloads alone and stop `ConsoleAppCancellationTokenSource` from
  suppressing Ctrl+C. That would restore the ability to abort, but by killing
  the process outright, discarding the graceful cancellation the setup tool is
  clearly trying to implement.
- Do nothing. These downloads finish quickly on a fast connection, so this
  mainly affects contributors on slow or filtered networks. It is not a hard
  block even for them — a proxy, or dropping the file into place by hand, works
  around it. But until you know that, setup looks like it has hung, and it
  cannot be stopped without opening a second terminal.

### Disclosure

This change was written with the help of Claude Code. I reviewed every line, and
the measurements above were produced and verified on my own machine.