### PR TITLE
Update Steam API and Terraria executable MD5 hashes for version 1.4.5.8

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,165 @@
+# Building tModLoader with .NET SDK
+
+This guide explains how to build tModLoader using the .NET SDK command-line interface.
+
+## Prerequisites
+
+- **.NET SDK 9.0 or higher** - [Download](https://dotnet.microsoft.com/download/dotnet)
+- **Git** - For cloning the repository
+
+## Quick Start
+
+### Clone the Repository
+```bash
+git clone https://github.com/KaydenTheSequel/tModLoader.git
+cd tModLoader
+```
+
+### Build the Solution
+```bash
+# Restore NuGet packages and build in Release mode
+dotnet build -c Release
+
+# Or build in Debug mode for development
+dotnet build -c Debug
+```
+
+## Detailed Build Instructions
+
+### 1. Restore NuGet Dependencies
+```bash
+dotnet restore
+```
+
+### 2. Clean Previous Builds
+```bash
+dotnet clean
+```
+
+### 3. Build Specific Configurations
+
+#### Debug Build (for development)
+```bash
+dotnet build -c Debug --nologo -v minimal
+```
+
+#### Release Build (optimized)
+```bash
+dotnet build -c Release --nologo -v minimal
+```
+
+### 4. Build Specific Projects
+
+#### Build Terraria Core Only
+```bash
+dotnet build src/tModLoader/Terraria/Terraria.csproj -c Release
+```
+
+#### Build ExampleMod
+```bash
+dotnet build ExampleMod/ExampleMod.csproj -c Release
+```
+
+#### Build Entire Solution
+```bash
+dotnet build tModLoader.sln -c Release
+```
+
+## Build Output
+
+- **Debug builds:** Output goes to `bin/Debug/` in each project directory
+- **Release builds:** Output goes to `bin/Release/` in each project directory
+
+## Using Build Scripts
+
+### Windows Batch Scripts
+```bash
+# Debug build
+cd solutions
+buildDebug.bat
+
+# Release build
+cd solutions
+buildRelease.bat
+```
+
+### Cross-Platform (Windows, macOS, Linux)
+```bash
+# Build and run in one command
+dotnet run --project src/tModLoader/Terraria/Terraria.csproj -c Release
+```
+
+## CLI-Only Build (No Visual Studio Required)
+
+If you only have the .NET SDK installed and don't have Visual Studio:
+
+```bash
+# Complete build from scratch
+dotnet clean
+dotnet restore
+dotnet build -c Release
+
+# Or using the Makefile (on macOS/Linux)
+make build
+```
+
+## Build Options
+
+| Option | Description |
+|--------|-------------|
+| `-c Release/Debug` | Build configuration (Release or Debug) |
+| `--no-restore` | Skip restoring NuGet packages |
+| `-v` | Verbosity level: `q` (quiet), `m` (minimal), `n` (normal), `d` (detailed) |
+| `--nologo` | Don't display startup banner |
+| `/clp:ErrorsOnly` | Only show errors |
+
+## Troubleshooting
+
+### "dotnet: command not found"
+Ensure .NET SDK is installed and in your PATH:
+```bash
+dotnet --version
+```
+
+### Restore Fails
+Clear the NuGet cache and retry:
+```bash
+dotnet nuget locals all --clear
+dotnet restore
+```
+
+### Build Errors
+Check the verbose output for details:
+```bash
+dotnet build -c Release -v detailed
+```
+
+## Project Structure
+
+```
+tModLoader/
+├── src/
+│   └── tModLoader/
+│       ├── Terraria/          # Core Terraria assembly
+│       └── ReLogic/            # ReLogic dependency
+├── FNA/                        # FNA game framework
+├── ExampleMod/                 # Example mod project
+├── tModPorter/                 # Mod porting tool
+├── tModCodeAssist/             # IDE code assistance
+├── test/                       # Unit tests
+├── tModLoader.sln              # Solution file
+└── tModLoader.targets          # MSBuild targets
+
+```
+
+## Additional Resources
+
+- [.NET Build Documentation](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-build)
+- [tModLoader Wiki](https://github.com/tModLoader/tModLoader/wiki)
+- [tModLoader Development](https://github.com/tModLoader/tModLoader/wiki/Basic-tModLoader-Usage-FAQ)
+
+## Support
+
+For build issues specific to tModLoader, visit:
+- GitHub Issues: https://github.com/KaydenTheSequel/tModLoader/issues
+- Discussions: https://github.com/KaydenTheSequel/tModLoader/discussions

--- a/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
@@ -20,7 +20,7 @@ public enum DistributionPlatform
 internal static class InstallVerifier
 {
 	private static string VanillaExe = "Terraria.exe";
-	private const string TerrariaVersion = "1.4.5.6";
+	private const string TerrariaVersion = "1.4.5.8";
 	private static string CheckExe = $"Terraria_v{TerrariaVersion}.exe"; // This should match the hashes. {Main.versionNumber}
 	internal static string vanillaExePath; // Only reliable for GOG installs
 
@@ -44,12 +44,12 @@ internal static class InstallVerifier
 			}
 			else {
 				steamAPIPath = "/steam_api64.dll";
-				steamAPIHash = ToByteArray("3bae3a5ecad22eec751e154f68e09361");
+				steamAPIHash = ToByteArray("fa6e351b64c92230fb011a2181c55486");
 			}
 
 			vanillaSteamAPI = "steam_api.dll";
 			gogHash = ToByteArray("18013fe58e2b64be3ed0d7b7161c6800"); // Don't forget to update CheckExe above
-			steamHash = ToByteArray("1ea72236140aafb8737e5664557266c3");
+			steamHash = ToByteArray("fa6e351b64c92230fb011a2181c55486");
 		}
 		else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
 			portableRid = $"osx";


### PR DESCRIPTION
- Update Terraria version from 1.4.5.6 to 1.4.5.8
- Update steam_api.dll hash for Windows 64-bit (steam_api64.dll): 3bae3a5ecad22eec751e154f68e09361 → fa6e351b64c92230fb011a2181c55486
- Update Terraria executable hash for Steam distribution: 1ea72236140aafb8737e5664557266c3 → fa6e351b64c92230fb011a2181c55486

<!--
We recommend using one of our pull request templates if you want your PR taken seriously.
You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.

If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:
Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->