### PR TITLE
[1.4.5]Add ModPlayer.CanDoWireStuffHere And ModPlayer.CanShowWireStuffHere hook and add its example

### DIFF
--- a/ExampleMod/Common/Players/ExampleCanDoAndShowWireStuffHerePlayer.cs
+++ b/ExampleMod/Common/Players/ExampleCanDoAndShowWireStuffHerePlayer.cs
@@ -1,0 +1,36 @@
+﻿using ExampleMod.Content.Walls;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace ExampleMod.Common.Players
+{
+	// Showcases preventing the player from seeing or modifying wires under specific wall or condition.
+	public class ExampleCanDoAndShowWireStuffHerePlayer : ModPlayer
+	{
+		public override bool? CanDoWireStuffHere(int x, int y) {
+			Tile tile = Framing.GetTileSafely(x, y);
+
+			// Allows the player to modify wires within the Jungle Temple regardless of conditions.
+			if (tile.WallType == WallID.LihzahrdBrickUnsafe)
+				return true;
+
+			// Prevents the player from modifying wires placed on ExampleWall.
+			if (tile.WallType == ModContent.WallType<ExampleWall>())
+				return false;
+
+			// All other cases follow vanilla rules.
+			return null;
+		}
+		public override bool? CanShowWireStuffHere(int x, int y) {
+			Tile tile = Framing.GetTileSafely(x, y);
+
+			// Prevents the player from seeing wires on ExampleWall.
+			if (tile.WallType == ModContent.WallType<ExampleWall>())
+				return false;
+
+			// Unlike the above function, this returns true to show all wires except those on ExampleWall.
+			return true;
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -576,6 +576,34 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	}
 
 	/// <summary>
+	/// Allows you to control whether the player can see wires.<br></br>
+	/// Return true or false to respectively allow or disallow the player from seeing wires, overriding vanilla rules.<br></br>
+	/// Returns null by default, which allows vanilla wire rules to function normally.<para/>
+	/// <para/> See also <see cref="CanShowWireStuffHere"/>.
+	/// <para/> Called on the local client only, when the player attempts to use <see href="https://terraria.wiki.gg/wiki/Mechanisms">Mechanisms</see>.
+	/// </summary>
+	/// <param name="x">The x position in tile coordinates.</param>
+	/// <param name="y">The y position in tile coordinates.</param>
+	public virtual bool? CanDoWireStuffHere(int x, int y)
+	{
+		return null;
+	}
+
+	/// <summary>
+	/// Allows you to control whether the player can break or place wires.<br></br>
+	/// Return true or false to respectively allow or disallow the player from breaking or placing wires, overriding vanilla rules.<br></br>
+	/// Returns null by default, which allows vanilla wire rules to function normally.<para/>
+	/// <para/> See also <see cref="CanDoWireStuffHere"/>.
+	/// <para/> Called on the local client only, when the player attempts to use <see href="https://terraria.wiki.gg/wiki/Mechanisms">Mechanisms</see>.
+	/// </summary>
+	/// <param name="x">The x position in tile coordinates.</param>
+	/// <param name="y">The y position in tile coordinates.</param>
+	public virtual bool? CanShowWireStuffHere(int x, int y)
+	{
+		return null;
+	}
+
+	/// <summary>
 	/// Allows you to do anything before the update code for the player's held item is run. Return false to stop the held item update code from being run (for example, if the player is frozen). Returns true by default.
 	/// <para/> Called on local, server, and remote clients.
 	/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -589,6 +589,40 @@ public static class PlayerLoader
 		}
 	}
 
+	private static HookList HookCanDoWireStuffHere = AddHook<Func<int, int, bool?>>(p => p.CanDoWireStuffHere);
+
+	public static bool? CanDoWireStuffHere(Player player, int x, int y)
+	{
+		bool? ret = null;
+		foreach (var modPlayer in HookCanDoWireStuffHere.Enumerate(player)) {
+			bool? canDoWire = modPlayer.CanDoWireStuffHere(x, y);
+			if (canDoWire.HasValue) {
+				if (!canDoWire.Value)
+					return false;
+
+				ret = true;
+			}
+		}
+		return ret;
+	}
+
+	private static HookList HookCanShowWireStuffHere = AddHook<Func<int, int, bool?>>(p => p.CanShowWireStuffHere);
+
+	public static bool? CanShowWireStuffHere(Player player, int x, int y)
+	{
+		bool? ret = null;
+		foreach (var modPlayer in HookCanShowWireStuffHere.Enumerate(player)) {
+			bool? canShowWire = modPlayer.CanShowWireStuffHere(x, y);
+			if (canShowWire.HasValue) {
+				if (!canShowWire.Value)
+					return false;
+
+				ret = true;
+			}
+		}
+		return ret;
+	}
+
 	private static HookList HookPreItemCheck = AddHook<Func<bool>>(p => p.PreItemCheck);
 
 	public static bool PreItemCheck(Player player)

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7469,6 +7469,26 @@
  				if (inventory[num6].stack <= 0)
  					inventory[num6].SetDefaults(0);
  
+@@ -38004,6 +_,9 @@
+ 		if (!WorldGen.InWorld(x, y))
+ 			return false;
+ 
++		if (PlayerLoader.CanDoWireStuffHere(this, x, y) is bool result)
++			return result;
++
+ 		Tile tile = Main.tile[x, y];
+ 		if (tile.wall == 350)
+ 			return false;
+@@ -38024,6 +_,9 @@
+ 		if (!WorldGen.InWorld(x, y))
+ 			return false;
+ 
++		if (PlayerLoader.CanShowWireStuffHere(this, x, y) is bool result)
++			return result;
++
+ 		if (!NPC.downedGolemBoss) {
+ 			Tile tile = Main.tile[x, y];
+ 			if (Main.dualDungeonsSeed && (double)y > Main.worldSurface && DungeonGenerationStyles.Temple.WallIsInStyle(tile.wall, includeWindows: true))
 @@ -38090,11 +_,21 @@
  
  	private void ItemCheck_Shoot(int i, Item sItem, int weaponDamage, bool withAudioVisualFeedback = true)


### PR DESCRIPTION
### What is the new feature?
It allows modders to modify whether players can see or place and destroy wires
### Why should this be part of tModLoader?
Currently, achieving this functionality would require an IL edit, which is inconvenient and less maintainable. These hooks provide a cleaner, more accessible way to add custom logic or override vanilla wire interaction rules.
### Are there alternative designs?
None
### Sample usage for the new feature
`ExampleCanDoAndShowWireStuffHerePlayer.cs` to demonstrate usage.
### ExampleMod updates
The ExampleMod has been updated with `ExampleCanDoAndShowWireStuffHerePlayer.cs` to showcase the new functionality.