### PR TITLE
[1.4.5] ModSky

### DIFF
--- a/ExampleMod/Content/Skies/ExampleSky.cs
+++ b/ExampleMod/Content/Skies/ExampleSky.cs
@@ -17,7 +17,7 @@ namespace ExampleMod.Content.Skies;
 // It is important to note that you don't miss out on any freedom by using ModSky over CustomSky, the range of capabilities is identical.
 public class ExampleSky : ModSky
 {
-    // FadeOpacity is a property that automatically interpolates between 0 and 1 when a sky is activated / deactivated.
+    // FadeOpacity is a property that automatically shifts between 0 and 1 when a sky is activated / deactivated.
     // This property dictates how much FadeOpacity is modified per frame. By default, it's 0.01f;
     public override float FadeRate => 0.05f;
 

--- a/ExampleMod/Content/Skies/ExampleSky.cs
+++ b/ExampleMod/Content/Skies/ExampleSky.cs
@@ -1,0 +1,44 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Terraria;
+using Terraria.Audio;
+using Terraria.GameContent;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace ExampleMod.Content.Skies;
+
+// This example shows a simple modded sky.
+// ExampleSkyScene.cs shows how this can be used.
+
+// ModSky is a class that wraps over CustomSky and handles the boilerplate automatically.
+// For the simplest implementation you only have to override Draw.
+
+// It is important to note that you don't miss out on any freedom by using ModSky over CustomSky, the range of capabilities is identical.
+public class ExampleSky : ModSky
+{
+    // FadeOpacity is a property that automatically interpolates between 0 and 1 when a sky is activated / deactivated.
+    // This property dictates how much FadeOpacity is modified per frame. By default, it's 0.01f;
+    public override float FadeRate => 0.05f;
+
+    // minDepth and maxDepth are somewhat arbitrary values, but they can be used to specify where an element is to be drawn.
+    public override void Draw(SpriteBatch spriteBatch, float minDepth, float maxDepth)
+    {
+        float opacity = FadeOpacity * 0.5f;
+        
+        // A minDepth value of 0 or below implies the front-most layer, whatever drawn here will be drawn in-front of all background elements.
+        if (minDepth <= 0f)
+            spriteBatch.Draw(TextureAssets.MagicPixel.Value, new Rectangle(0, 0, Main.screenWidth / 2, Main.screenHeight), Color.CornflowerBlue * opacity);
+        
+        // A maxDepth value this high implies the back-most layer, whatever drawn here will be drawn behind all background elements.
+        if (maxDepth >= float.MaxValue)
+            spriteBatch.Draw(TextureAssets.MagicPixel.Value, new Rectangle(0, 0, Main.screenWidth, Main.screenHeight), Color.Red * opacity);
+    }
+
+    // You may override OnActivate / OnDeactivate to implement any relevant logic.
+    public override void OnActivate(Vector2 position, params object[] args)
+    {
+        SoundEngine.PlaySound(SoundID.AbigailAttack);
+        Main.NewLightning();
+    }
+}

--- a/ExampleMod/Content/Skies/ExampleSky.cs
+++ b/ExampleMod/Content/Skies/ExampleSky.cs
@@ -35,10 +35,21 @@ public class ExampleSky : ModSky
             spriteBatch.Draw(TextureAssets.MagicPixel.Value, new Rectangle(0, 0, Main.screenWidth, Main.screenHeight), Color.Red * opacity);
     }
 
-    // You may override OnActivate / OnDeactivate to implement any relevant logic.
+    // The following hooks can be quite useful for logic unrelated to rendering the sky.
     public override void OnActivate(Vector2 position, params object[] args)
     {
-        SoundEngine.PlaySound(SoundID.AbigailAttack);
+        SoundEngine.PlaySound(SoundID.AbigailUpgrade);
         Main.NewLightning();
+    }
+    
+    public override void OnUpdate(GameTime gameTime)
+    {
+        if (Main.rand.NextBool(2000))
+            Main.NewLightning();
+    }
+
+    public override void OnDeactivate(params object[] args)
+    {
+        SoundEngine.PlaySound(SoundID.AbigailCry);
     }
 }

--- a/ExampleMod/Content/Skies/ExampleSky.cs
+++ b/ExampleMod/Content/Skies/ExampleSky.cs
@@ -18,7 +18,7 @@ namespace ExampleMod.Content.Skies;
 public class ExampleSky : ModSky
 {
     // FadeOpacity is a property that automatically shifts between 0 and 1 when a sky is activated / deactivated.
-    // This property dictates how much FadeOpacity is modified per frame. By default, it's 0.01f;
+    // This property dictates how much FadeOpacity is modified per frame. By default, it's 0.01.
     public override float FadeRate => 0.05f;
 
     // minDepth and maxDepth are somewhat arbitrary values, but they can be used to specify where an element is to be drawn.

--- a/ExampleMod/Content/Skies/ExampleSkyScene.cs
+++ b/ExampleMod/Content/Skies/ExampleSkyScene.cs
@@ -1,0 +1,19 @@
+using Terraria;
+using Terraria.Graphics.Effects;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace ExampleMod.Content.Skies;
+
+// An example usage of ExampleSky through a ModSceneEffect
+public class ExampleSkyScene : ModSceneEffect
+{
+    public override bool IsSceneEffectActive(Player player) => NPC.AnyNPCs(NPCID.SkeletronPrime) && NPC.AnyNPCs(NPCID.SkeletronHead);
+
+    public override void SpecialVisuals(Player player, bool isActive)
+    {
+        // Toggle activates the sky if the given condition is true and deactivates it otherwise. 
+        // It also checks if the sky is already active / inactive to not repeatedly call the activation / deactivation methods.
+        SkyManager.Instance.Toggle<ExampleSky>(isActive);
+    }
+}

--- a/patches/tModLoader/Terraria/Graphics/Effects/SkyManager.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Effects/SkyManager.cs.patch
@@ -1,10 +1,14 @@
 --- src/TerrariaNetCore/Terraria/Graphics/Effects/SkyManager.cs
 +++ src/tModLoader/Terraria/Graphics/Effects/SkyManager.cs
-@@ -1,3 +_,4 @@
+@@ -1,6 +_,8 @@
 +using System;
  using System.Collections.Generic;
  using Microsoft.Xna.Framework;
  using Microsoft.Xna.Framework.Graphics;
++using Terraria.ModLoader;
+ 
+ namespace Terraria.Graphics.Effects;
+ 
 @@ -21,11 +_,13 @@
  
  	public void Update(GameTime gameTime)
@@ -20,11 +24,10 @@
  			LinkedListNode<CustomSky> linkedListNode = _activeSkies.First;
  			while (linkedListNode != null) {
  				CustomSky value = linkedListNode.Value;
-@@ -98,5 +_,14 @@
- 		}
+@@ -99,4 +_,45 @@
  
  		return MathHelper.Clamp(num, 0f, 1f);
-+	}
+ 	}
 +
 +	// Added by TML.
 +	internal void DeactivateAll()
@@ -33,5 +36,37 @@
 +			if (this[key].IsActive())
 +				this[key].Deactivate(Array.Empty<object>());
 +		}
- 	}
++	}
++    
++    public void Activate<T>(Vector2 position = default(Vector2), params object[] args) where T : ModSky
++    {
++        Activate(ModContent.GetInstance<T>().FullName, position, args);
++    }
++
++    public void Deactivate<T>(params object[] args) where T : ModSky
++    {
++        Deactivate(ModContent.GetInstance<T>().FullName, args);
++    }
++    
++    /// <summary>
++    /// Toggles a sky based on a condition, this can be used to avoid checking if a sky is active before calling Activate or vice versa
++    /// </summary>
++    public void Toggle(string name, bool condition, Vector2 position = default, params object[] args)
++    {
++        if (!_effects.ContainsKey(name))
++            throw new MissingEffectException(string.Concat("Unable to find effect named: ", name, ". Type: ", typeof(CustomSky), "."));
++        
++        var sky = this[name];
++        if (condition && !sky.IsActive())
++            Activate(name, position, args);
++        else if (!condition && sky.IsActive())
++            Deactivate(name, args);
++    }
++    
++    /// <inheritdoc cref="Toggle"/>
++    public void Toggle<T>(bool condition, Vector2 position = default, params object[] args) where T : ModSky
++    {
++        var sky = ModContent.GetInstance<T>();
++        Toggle(sky.FullName, condition, position, args);
++    }
  }

--- a/patches/tModLoader/Terraria/ModLoader/ModSky.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSky.cs
@@ -39,7 +39,7 @@ public abstract class ModSky : CustomSky, IModType, ILoadable
 
     /// <summary>
     /// An automatically handled value between 0-1 for fading the sky's visuals in and out.<para/>
-    /// You may override <see cref="FadeRate"/> to alter the speed at which this value is modified, you may also return false in <see cref="PreUpdate"/> to skip the automatic linear fading behavior and replace it with your own. 
+    /// You may override <see cref="FadeRate"/> to alter the speed at which this value is modified, you may also return false in <see cref="ShouldFade"/> to skip the automatic linear fading behavior and replace it with your own. 
     /// </summary>
     public float FadeOpacity { get; set; }
 
@@ -49,16 +49,14 @@ public abstract class ModSky : CustomSky, IModType, ILoadable
     public virtual float FadeRate => 0.01f;
 
     /// <summary>
-    /// Called before <see cref="FadeOpacity"/> is modified.<para/>
-    /// You may return false to skip <see cref="FadeOpacity"/>'s modification but <see cref="PostUpdate"/> will be called regardless.
+    /// Whether <see cref="FadeOpacity"/> should be updated as normal or not. You may return false to provide your own fading logic. 
     /// </summary>
-    public virtual bool PreUpdate(GameTime gameTime) => true;
+    public virtual bool ShouldFade => true;
 
     /// <summary>
-    /// Called after <see cref="FadeOpacity"/> is modified.<para/>
-    /// This will be called regardless of what <see cref="PreUpdate"/> returns.
+    /// Called when this sky's logic is updated.
     /// </summary>
-    public virtual void PostUpdate(GameTime gameTime)
+    public virtual void OnUpdate(GameTime gameTime)
     {
         
     }
@@ -88,11 +86,10 @@ public abstract class ModSky : CustomSky, IModType, ILoadable
     
     public sealed override void Update(GameTime gameTime)
     {
-        if (PreUpdate(gameTime))
-        {
+        if (ShouldFade)
             FadeOpacity = MathHelper.Clamp(FadeOpacity + Enabled.ToDirectionInt() * FadeRate, 0, 1);
-        }
-        PostUpdate(gameTime);
+        
+        OnUpdate(gameTime);
     }
 
     public sealed override void Activate(Vector2 position, params object[] args)

--- a/patches/tModLoader/Terraria/ModLoader/ModSky.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSky.cs
@@ -38,7 +38,7 @@ public abstract class ModSky : CustomSky, IModType, ILoadable
     public bool Enabled { get; private set; }
 
     /// <summary>
-    /// An automatically handled value between 0-1 for fading the sky's visuals in and out.<para/>
+    /// A value that shifts between 0-1 for fading the sky's visuals in and out.<para/>
     /// You may override <see cref="FadeRate"/> to alter the speed at which this value is modified, you may also return false in <see cref="ShouldFade"/> to skip the automatic linear fading behavior and replace it with your own. 
     /// </summary>
     public float FadeOpacity { get; set; }

--- a/patches/tModLoader/Terraria/ModLoader/ModSky.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSky.cs
@@ -1,0 +1,130 @@
+using Microsoft.Xna.Framework;
+using Terraria.Graphics.Effects;
+
+namespace Terraria.ModLoader;
+
+/// <summary>
+/// This class allows you to create a modded sky effect without any boilerplate.<para/>
+/// Skies inheriting this are automatically loaded into <see cref="SkyManager"/> and handle common things like an <see cref="Enabled"/> check and a <see cref="FadeOpacity"/> value for fading sky visuals in and out.<para/>
+/// The simplest implementation only requires overriding <see cref="CustomSky.Draw"/>
+/// </summary>
+/// <seealso cref="CustomSky" />
+public abstract class ModSky : CustomSky, IModType, ILoadable
+{
+    ///<summary>
+    /// The mod this sky belongs to.
+    /// </summary>
+    public Mod Mod { get; internal set;  }
+
+    /// <summary>
+    /// The internal name of this sky.
+    /// </summary>
+    public virtual string Name => GetType().Name;
+
+    /// <summary>
+    /// The internal name of this sky, including the mod it is from. This is used as the key for the <see cref="SkyManager"/> instance for this sky.
+    /// </summary>
+    public string FullName => $"{Mod.Name}/{Name}";
+
+    /// <summary>
+    /// The <see cref="SkyManager"/> instance of this sky, you may still retrieve the modded instance through <see cref="ModContent.GetInstance"/>.
+    /// </summary>
+    public CustomSky Instance => SkyManager.Instance[FullName];
+
+    /// <summary>
+    /// Whether this sky is enabled or not.<para/>
+    /// This is automatically set in <see cref="Activate"/> and <see cref="Deactivate"/> and checked in <see cref="IsActive"/>
+    /// </summary>
+    public bool Enabled { get; private set; }
+
+    /// <summary>
+    /// An automatically handled value between 0-1 for fading the sky's visuals in and out.<para/>
+    /// You may override <see cref="FadeRate"/> to alter the speed at which this value is modified, you may also return false in <see cref="PreUpdate"/> to skip the automatic linear fading behavior and replace it with your own. 
+    /// </summary>
+    public float FadeOpacity { get; set; }
+
+    /// <summary>
+    /// The rate at which <see cref="FadeOpacity"/> is modified.
+    /// </summary>
+    public virtual float FadeRate => 0.01f;
+
+    /// <summary>
+    /// Called before <see cref="FadeOpacity"/> is modified.<para/>
+    /// You may return false to skip <see cref="FadeOpacity"/>'s modification but <see cref="PostUpdate"/> will be called regardless.
+    /// </summary>
+    public virtual bool PreUpdate(GameTime gameTime) => true;
+
+    /// <summary>
+    /// Called after <see cref="FadeOpacity"/> is modified.<para/>
+    /// This will be called regardless of what <see cref="PreUpdate"/> returns.
+    /// </summary>
+    public virtual void PostUpdate(GameTime gameTime)
+    {
+        
+    }
+
+    /// <summary>
+    /// Called the moment the sky is activated.
+    /// </summary>
+    public virtual void OnActivate(Vector2 position, params object[] args)
+    {
+        
+    }
+    
+    /// <summary>
+    /// Called the moment the sky is deactivated.
+    /// </summary>
+    public virtual void OnDeactivate(params object[] args)
+    {
+        
+    }
+    
+    /// <summary>
+    /// The conditions dictating whether this sky is properly active or not.<para/>
+    /// This is not to be used for checking the conditions for activating the sky, instead, use <see cref="SkyManager.Toggle"/> somewhere suitable (such as a <see cref="ModSceneEffect"/>).<para/>
+    /// In most cases you don't need to override this.
+    /// </summary>
+    public override bool IsActive() => Enabled || FadeOpacity > 0f;
+    
+    public sealed override void Update(GameTime gameTime)
+    {
+        if (PreUpdate(gameTime))
+        {
+            FadeOpacity = MathHelper.Clamp(FadeOpacity + Enabled.ToDirectionInt() * FadeRate, 0, 1);
+        }
+        PostUpdate(gameTime);
+    }
+
+    public sealed override void Activate(Vector2 position, params object[] args)
+    {
+        Enabled = true;
+        OnActivate(position, args);
+    }
+
+    public sealed override void Deactivate(params object[] args)
+    {
+        Enabled = false;
+        OnDeactivate(args);
+    }
+
+    // SkyManager.Reset seems to be unused?
+    public sealed override void Reset()
+    {
+        Enabled = false;
+        FadeOpacity = 0;
+    }
+
+    public virtual bool IsLoadingEnabled(Mod mod) => true;
+    void ILoadable.Load(Mod mod)
+    {
+        Mod = mod;
+        SkyManager.Instance[FullName] = this;
+        ModTypeLookup<ModSky>.Register(this);
+        
+        Load();
+    }
+    
+    public new virtual void Load() { }
+    
+    public virtual void Unload() { }
+}


### PR DESCRIPTION
### What is the new feature?
a `ModSky` abstract class that inherits from `CustomSky` and handles common boilerplate.
the class namely does the following:
- adds the sky to `SkyManager` & `ModTypeLookup` on load.
- provides an `Enabled` flag that's automatically set on activation and deactivation and checked in `IsActive`.
- provides fading-related properties: a `FadeOpacity` value that shifts between 0-1 on activation and deactivation, a `FadeRate` value that dictates the rate at which `FadeOpacity` is modified, and a `ShouldFade` flag that allows custom fading behavior.

to account for the new class, it is also possible to activate and deactivate modded skies like this:
```cs
SkyManager.Instance.Activate<ExampleSky>();
SkyManager.Instance.Deactivate<ExampleSky>();
```

a `Toggle` method is also added to `SkyManager` to simplify toggling skies with basic conditions.

the following:
```cs
public override void PostUpdateEverything()
{
    var sky = ModContent.GetInstance<ExampleSky>();
    if (WhateverCondition && !sky.IsActive())
        SkyManager.Instance.Activate<ExampleSky>();
    else if (!WhateverCondition && sky.IsActive())
        SkyManager.Instance.Deactivate<ExampleSky>();
}
```
is equivalent to:
```cs
public override void PostUpdateEverything()
    => SkyManager.Instance.Toggle<ExampleSky>(WhateverCondition);
```

### Why should this be part of tModLoader?
this feature deeply simplifies the process of creating modded skies, `CustomSky` has a lot of repetitive boilerplate as mentioned above.

with this feature, the simplest possible sky would look like this:
```cs
public class ExampleSky : ModSky
{
    public override void Draw(SpriteBatch spriteBatch, float minDepth, float maxDepth)
    {
        // Whatever
    }
}

public class ExampleSkyHandler : ModSystem
{
    public override void PostUpdateEverything() => SkyManager.Instance.Toggle<ExampleSky>(WhateverCondition);
}
```

instead of:
```cs
public class ExampleSky : CustomSky
{
    public bool Enabled;
    public float FadeOpacity;
    
    public override void Activate(Vector2 position, params object[] args) => Enabled = true;

    public override void Deactivate(params object[] args) => Enabled = false;

    public override bool IsActive() => Enabled && FadeOpacity > 0f;

    public override void Reset()
    {
        Enabled = false;
        FadeOpacity = 0f;
    }

    public override void Update(GameTime gameTime)
    {
        FadeOpacity = MathHelper.Clamp(FadeOpacity + Enabled.ToDirectionInt() * 0.01f, 0, 1);
    }

    public override void Draw(SpriteBatch spriteBatch, float minDepth, float maxDepth)
    {
        // Whatever
    }
}

public class ExampleSkyHandler : ModSystem
{
    public override void Load() => SkyManager.Instance["ExampleMod:ExampleSky"] = new ExampleSky();

    public override void PostUpdateEverything()
    {
        var sky = SkyManager.Instance["ExampleMod:ExampleSky"];
        if (WhateverCondition && !sky.IsActive())
            SkyManager.Instance.Activate("ExampleMod:ExampleSky");
        else if (!WhateverCondition && sky.IsActive())
            SkyManager.Instance.Deactivate("ExampleMod:ExampleSky");
    }
}
```

while still keeping all the freedom that a `CustomSky` can offer.

### Are there alternative designs?
given that this is just a simplification of `CustomSky`, there probably is not much to be changed 

I opted to seal the common hooks and provide new ones since most inexperienced modders are used to removing the base call when overriding methods and would thus be confused if they overrode `Update` without calling base and lost the default fading behavior.

however, `IsActive` can still be overridden to completely invalidate what the sealed hooks do if someone wanted to do that for whatever reason.

### Sample usage for the new feature
already provided above

### ExampleMod updates
an `ExampleSky` showcasing a very basic `ModSky` with important information and an `ExampleSkyScene` showing how it can be toggled are included in this PR.