### PR TITLE
Fix #5399: Change GetTextValue to GetText in migration panel title

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/States/UICharacterSelect.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UICharacterSelect.TML.cs
@@ -28,7 +28,7 @@ public partial class UICharacterSelect : UIState
 		_migrationPanel = new UIExpandablePanel();
 		_migrationPanel.OnExpanded += _migrationPanel_OnExpanded;
 
-		var playerMigrationPanelTitle = new UIText(Language.GetTextValue("tModLoader.MigrateIndividualPlayersHeader"));
+		var playerMigrationPanelTitle = new UIText(Language.GetText("tModLoader.MigrateIndividualPlayersHeader"));
 		playerMigrationPanelTitle.Top.Set(4, 0);
 		_migrationPanel.Append(playerMigrationPanelTitle);
 


### PR DESCRIPTION
Fixes #5399

### What is the bug?
The text of the player migration panel ("Migrate Individual Players") does not update when the user switches the game language, it remains in the language that was active when the panel was created

### How did you fix the bug?
Changed `Language.GetTextValue("tModLoader.MigrateIndividualPlayersHeader")` to `Language.GetText("tModLoader.MigrateIndividualPlayersHeader")` in `UICharacterSelect.TML.cs`

### Are there alternatives to your fix?
No, `GetTextValue` only gets the text once, so it can't update 
`GetText` is just the normal way to make UI text change language