### PR TITLE
Feature: Steam Versioning To Reduce File Size

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -763,22 +763,39 @@ internal static class ModOrganizer
 			RemoveSkippablePreview(repo);
 
 		string[] tmods = Directory.GetFiles(repo, "*.tmod", SearchOption.AllDirectories);
-		if (tmods.Length <= 3)
+		if (tmods.Length <= 2)
 			return;
 
 		var information = AnalyzeWorkshopTmods(repo);
-		if (information == null || information.Count() <= 3)
+		if (information == null || information.Count() <= 2)
 			return;
 
-		foreach (var requirement in SocialBrowserModule.keepRequirements) {
-			var mods = GetOrderedTmodWorkshopInfoForVersion(information, requirement.browserVersion).Skip(requirement.keepCount);
+		// Purge .tmod files that are unrelated to this BrowserVersion
+		foreach (var requirement in SocialBrowserModule.browserVersionRetainRequirements) {
+			if (SocialBrowserModule.CurrentBrowserVersion == requirement.Key)
+				continue;
 
-			foreach (var item in mods) {
+			var unrelatedMods = GetOrderedTmodWorkshopInfoForVersion(information, requirement.Key);
+			foreach (var item in unrelatedMods) {
 				if (item.isInFolder)
 					Directory.Delete(Path.GetDirectoryName(item.file), recursive: true);
 				else
 					File.Delete(item.file);
 			}
+		}
+
+		var mods = GetOrderedTmodWorkshopInfoForVersion(information, SocialBrowserModule.CurrentBrowserVersion);
+		var candidates = mods.Where(a => a.tModVersion < BuildInfo.stableVersion);
+		if (candidates.Count() <= 1)
+			return;
+
+		// Remove outdated stable copies
+		var toDelete = candidates.Skip(1);
+		foreach (var item in toDelete) {
+			if (item.isInFolder)
+				Directory.Delete(Path.GetDirectoryName(item.file), recursive: true);
+			else
+				File.Delete(item.file);
 		}
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModNet.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNet.cs
@@ -359,7 +359,7 @@ public static class ModNet
 		};
 
 		if (riskState == DownloadModRiskState.LowSubscriberCount || riskState == DownloadModRiskState.AvailableOnWorkshop){
-			if (!workshopMod.DevMetadata.modVersionHashes.Any(x => x.GetHash().SequenceEqual(header.hash))) {
+			if (!workshopMod.GetKnownWorkshopVersionHashes().Any(x => x.GetHash().SequenceEqual(header.hash))) {
 				// Mod doesn't match any hash on workshop. Either a dev build or custom build by host.
 				riskState = DownloadModRiskState.HashDiffersFromWorkshop;
 			}

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/ModDownloadItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/ModDownloadItem.cs
@@ -18,9 +18,10 @@ public class ModDownloadItem
 
 	public readonly string Author;
 	public readonly string ModIconUrl;
-	public readonly DateTime TimeStamp;
+	public readonly DateTime LastUpdatedTimeStamp;
 	public readonly bool Banned;
-	public readonly DeveloperMetadata DevMetadata;
+	internal readonly DeveloperMetadata LongFormDevMetadata;
+	internal readonly DeveloperMetadata BrowserVersionDevMetadata;
 
 	public readonly string ModReferencesBySlug;
 	public readonly ModPubId_t[] ModReferenceByModId;
@@ -33,13 +34,27 @@ public class ModDownloadItem
 	public readonly float VoteScore;
 	public readonly string Homepage;
 	public readonly Version ModloaderVersion;
+	public readonly List<string> SupportedVersions;
 
 	internal LocalMod Installed { get; set; }
 	public bool NeedUpdate { get; private set; }
 	public bool AppNeedRestartToReinstall { get; private set; }
 	public bool IsInstalled => Installed != null;
 
-	public ModDownloadItem(string displayName, string name, Version version, string author, string modReferences, ModSide modSide, string modIconUrl, string publishId, int downloads, int hot, DateTime timeStamp, Version modloaderversion, string homepage, string ownerId, string[] referencesById, bool banned, DeveloperMetadata devMetadata, uint upvotes, uint downvotes, float voteScore)
+	public ModDownloadItem(
+		// Properties that are invariant with tml Browser Version
+		string displayName, string name,  string author, string homepage,
+		int downloads, int hot, string modIconUrl, string publishId, string ownerId,
+		uint upvotes, uint downvotes, float voteScore, List<string> supportedVersions,
+		bool banned, DeveloperMetadata longFormDevMetadata,	DeveloperMetadata browserVersionDevMetadata,
+		DateTime lastUpdatedTimeStamp,
+
+		// Properties that could be variant with tML Browser Version
+		string modReferences, string[] referencesById, ModSide modSide,
+
+		// Properties that are variant with tML Browser Version
+		Version version, Version modloaderversion
+		)
 	{
 		ModName = name;
 		DisplayName = displayName;
@@ -55,11 +70,12 @@ public class ModDownloadItem
 		Downloads = downloads;
 		Hot = hot;
 		Homepage = homepage;
-		TimeStamp = timeStamp;
+		LastUpdatedTimeStamp = lastUpdatedTimeStamp;
 		Version = version;
 		ModloaderVersion = modloaderversion;
 		Banned = banned;
-		DevMetadata = devMetadata;
+		LongFormDevMetadata = longFormDevMetadata;
+		BrowserVersionDevMetadata = browserVersionDevMetadata;
 		Upvotes = upvotes;
 		Downvotes = downvotes;
 		VoteScore = voteScore;
@@ -113,6 +129,11 @@ public class ModDownloadItem
 	public override int GetHashCode()
 	{
 		return GetComparable().GetHashCode();
+	}
+
+	public List<ModVersionHash> GetKnownWorkshopVersionHashes()
+	{
+		return LongFormDevMetadata.modVersionHashes.Concat(BrowserVersionDevMetadata.modVersionHashes).ToList();
 	}
 
 	public static IEnumerable<ModDownloadItem> NeedsInstallOrUpdate(IEnumerable<ModDownloadItem> downloads)

--- a/patches/tModLoader/Terraria/Social/Base/DeveloperMetadata.cs
+++ b/patches/tModLoader/Terraria/Social/Base/DeveloperMetadata.cs
@@ -44,6 +44,10 @@ public class DeveloperMetadata
 {
 	public List<ModVersionHash> modVersionHashes { get; set; } = new List<ModVersionHash>();
 
+	// Format version string: "2022.05.10.20:0.2.0;2022.06.10.20:0.2.1;2022.07.10.20:0.2.2"
+	// This replaces VersionSummary keyvaluepair when used with BrowserVersionDeveloperMetadata. Expected character usage: ~80 chars
+	public string versionData;
+
 	internal string Serialize()
 	{
 		return JsonConvert.SerializeObject(this, Formatting.None, new ModVersionHash.VersionHashConverter());
@@ -67,13 +71,28 @@ public class DeveloperMetadata
 
 	// This methods trims contents of developer metadata based on the preferred order of discarding information.
 	// It is primarily written with the intent of 'in case' we need to store other information in this Workshop text field
-	internal void TrimDevMetadataForPublish()
+	// Used for the KeyValue Pair short list
+	internal void TrimDevMetadataForBrowserVersionFieldBeforePublish()
+	{
+		const int MaxMetadataLength = Steamworks.Constants.k_cubUFSTagValueMax;
+
+		const int minNumberOfHashes = 4;
+
+		while (Serialize().Length > MaxMetadataLength && modVersionHashes.Count() > minNumberOfHashes + 2) {
+			modVersionHashes = modVersionHashes.Take(modVersionHashes.Count() - 2).ToList();
+		}
+	}
+
+	// This methods trims contents of developer metadata based on the preferred order of discarding information.
+	// It is primarily written with the intent of 'in case' we need to store other information in this Workshop text field
+	// Used for the WebAPI 'long list' of hashes
+	internal void TrimDevMetadataForMainDeveloperMetadataFieldBeforePublish()
 	{
 		const int MaxMetadataLength = Steamworks.Constants.k_cchDeveloperMetadataMax;
 
 		// In case we want to store anything else down the road and it takes up space, this is the minimum amount of hashes we need to keep
 		// This minimum avoids issues with delays in the deployment time on Steam from when it is published to when it actually arrives for all users globally
-		var minNumberOfHashes = 2 * SocialBrowserModule.keepRequirements.Select(a => a.keepCount).Sum();
+		var minNumberOfHashes = 2 * SocialBrowserModule.browserVersionRetainRequirements.Select(a => a.Value).Sum();
 
 		while (Serialize().Length > MaxMetadataLength && modVersionHashes.Count() > minNumberOfHashes + 2) {
 			modVersionHashes = modVersionHashes.Take(modVersionHashes.Count() - 2).ToList();

--- a/patches/tModLoader/Terraria/Social/Base/SocialBrowserModule.cs
+++ b/patches/tModLoader/Terraria/Social/Base/SocialBrowserModule.cs
@@ -49,7 +49,8 @@ public interface SocialBrowserModule
 
 	public List<ModDownloadItem> DirectQueryItems(QueryParameters queryParams, out List<string> missingMods);
 
-	public DeveloperMetadata GetDeveloperMetadataFromModBrowser(ModPubId_t modId);
+	public (DeveloperMetadata longForm, DeveloperMetadata browserVersion) GetDeveloperMetadataFromModBrowser(ModPubId_t modId);
+	public List<string> GetSupportedBrowserVersions(ModPubId_t modId);
 
 	/////// Display of Browser Items ///////////////////////////////////////////
 
@@ -144,6 +145,7 @@ public interface SocialBrowserModule
 		}
 	}
 
+	// BROWSER_VERSION_RELEASE_FLAG
 	public static string GetBrowserVersionNumber(Version tmlVersion)
 	{
 		if (tmlVersion < new Version(0, 12)) // Versions 0 to 0.11.8.9
@@ -164,17 +166,24 @@ public interface SocialBrowserModule
 		if (tmlVersion < new Version(2026, DateTime.Now.Month)) // Versions 2022.3.85.0 to 2026.?.XXX
 			return "1.4.4"; // Long Term Service version 1.4.4
 
-		return "1.4.5"; // Long Term Service Version 1.4.45(Current)
+		return "1.4.5"; // Long Term Service Version 1.4.5 (Current)
 	}
 
-	// 1.4.5_RELEASE_FLAG
+	public static string CurrentBrowserVersion => GetBrowserVersionNumber(ModLoader.BuildInfo.tMLVersion);
+
+	// BROWSER_VERSION_RELEASE_FLAG
 	/// <summary>
-	/// Solxan: We want to keep 4 copies of the mod. A Preview version, a Stable Version, and a Legacy version in case
+	/// Solxan: We want to keep max of 3 copies of the mod. A Preview version, a Stable Version, and a Legacy version in case
 	/// we need to rollback to the last stable due to a significant bug.
-	/// We also keep a 1.4.3 version from version 2022.9 prior and a 1.4.4 version from 2026.??? prior
 	/// </summary>
-	public static (string browserVersion, int keepCount)[] keepRequirements =
-			{ ("1.4.3", 1), ("1.4.4", 3), ("1.3", 1), ("1.4.4-Transitive", 0) };
+	public static Dictionary<string, int> browserVersionRetainRequirements => new Dictionary<string, int>() {
+		{ "1.3", 1}, // LEGACY
+		{"1.4.3", 1}, // LEGACY
+		{ "1.4.4-Transitive", 0 }, // UNSUPPORTED
+		{ "1.4.4", 1 }, // LEGACY
+		{"1.4.5", 3 } 
+	};
+			
 
 	public static string[] branchNameBlacklist = { "unknown", "stable", "preview", "1.4.3-Legacy", "1.4.4-Legacy" };
 

--- a/patches/tModLoader/Terraria/Social/Steam/SteamWebApi/BatchMetadataSetRunner.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/SteamWebApi/BatchMetadataSetRunner.cs
@@ -6,6 +6,7 @@ using Terraria.Social.Base;
 
 namespace Terraria.Social.Steam;
 
+/* SOLXAN: Broke this during the Workshop versions PR on Sept 2026. Don't see value in fixing
 internal class BatchMetadataSetRunner
 {
 	private string workingDirectory;
@@ -110,3 +111,4 @@ internal class BatchMetadataSetRunner
 		return devMetadataKvp;
 	}
 }
+*/

--- a/patches/tModLoader/Terraria/Social/Steam/SteamedWraps.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/SteamedWraps.cs
@@ -16,6 +16,7 @@ using Terraria.ModLoader.UI;
 using Terraria.ModLoader.UI.DownloadManager;
 using Terraria.ModLoader.UI.ModBrowser;
 using Terraria.Social.Base;
+using static Terraria.DataStructures.GameDifficultyData.LinearCurve;
 
 namespace Terraria.Social.Steam;
 
@@ -26,6 +27,9 @@ public static class SteamedWraps
 	public static bool SteamClient { get; set; }
 	public static bool FamilyShared { get; set; } = false;
 	internal static bool SteamAvailable { get; set; }
+
+	internal static string BrowserDeveloperMetadataKey => $"{SocialBrowserModule.CurrentBrowserVersion}-devmetadata";
+	internal const string LongFormDeveloperMetadataKey = "longformdevelopermetadata";
 
 	// Used to get the right token for fetching/setting localized descriptions from/to Steam Workshop
 	internal static string GetCurrentSteamLangKey() => GetSteamLangKey(LanguageManager.Instance.ActiveCulture);
@@ -441,6 +445,34 @@ public static class SteamedWraps
 		throw new Exception("Invalid Call to FetchDeveloperMetadata. Steam is not initialized");
 	}
 
+	public static List<string> FetchGameVersionSupport(UGCQueryHandle_t handle, uint index)
+	{
+		if (!SteamAvailable) throw new Exception("Invalid Call to FetchDeveloperMetadata. Steam is not initialized");
+
+		uint numberSupportedGameVersions = 0;
+		if (SteamClient)
+			numberSupportedGameVersions = SteamUGC.GetNumSupportedGameVersions(handle, index);
+		else
+			numberSupportedGameVersions = SteamGameServerUGC.GetNumSupportedGameVersions(handle, index);
+
+		List<string> minimumBranches = new List<string>();
+
+		for (uint i = 0; i < numberSupportedGameVersions; i++) {
+			string minimumBranch;
+			string maximumBranch;
+
+			if (SteamClient)
+				SteamUGC.GetSupportedGameVersionData(handle, index, i, out minimumBranch, out maximumBranch, 255);
+			else
+				SteamGameServerUGC.GetSupportedGameVersionData(handle, index, i, out minimumBranch, out maximumBranch, 255);
+
+			if (!string.IsNullOrEmpty(minimumBranch))
+				minimumBranches.Add(minimumBranch.Replace("-legacy", ""));
+		}
+
+		return minimumBranches;
+	}
+
 	/// <summary>
 	/// Used when CoreSocialModule.Pulse() is not available, such as when publishing using command line.
 	/// Also used when need to interact with both Steam Game Server for GoG and SteamClient equivocally (only Mod Browser downloads at this time).
@@ -803,9 +835,6 @@ public static class SteamedWraps
 			SteamUGC.AddItemKeyValueTag(uGCUpdateHandle_t, key, _entryData.BuildData[key]);
 		}
 
-		// Add developer metadata to the Workshop item
-		AddDeveloperMetadata(ref uGCUpdateHandle_t, _entryData.BuildData["developermetadata"]);
-
 		// Add Content Descriptors
 		AddContentDescriptors(ref uGCUpdateHandle_t, _entryData);
 
@@ -826,6 +855,21 @@ public static class SteamedWraps
 				}
 			}
 		}
+
+		Logging.tML.Info("Adding tModLoader Developer Metadata to Workshop Upload");
+
+		string minBrowserVersion = SocialBrowserModule.GetBrowserVersionNumber(BuildInfo.tMLVersion);
+		SteamUGC.SetRequiredGameVersions(uGCUpdateHandle_t, $"{minBrowserVersion}-Legacy",
+			// If the version publishing on is Legacy, in order to avoid this being considered 'the latest' on an active browser version,
+			// We have to set the Max Version field to the same value as the min (ie 1.4.4-legacy is then only changing 1.4.4-legacy).
+			(SocialBrowserModule.browserVersionRetainRequirements[minBrowserVersion] == 1) ? $"{minBrowserVersion}-Legacy" : null);
+
+		
+		SteamUGC.RemoveItemKeyValueTags(uGCUpdateHandle_t, BrowserDeveloperMetadataKey);
+		SteamUGC.AddItemKeyValueTag(uGCUpdateHandle_t, BrowserDeveloperMetadataKey, _entryData.BuildData[BrowserDeveloperMetadataKey]);
+
+		// Add developer metadata to the Workshop item
+		AddDeveloperMetadata(ref uGCUpdateHandle_t, _entryData.BuildData[LongFormDeveloperMetadataKey]);
 	}
 
 	// https://partner.steamgames.com/doc/api/ISteamUGC#EUGCContentDescriptorID

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopBrowserModule.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopBrowserModule.cs
@@ -166,7 +166,7 @@ internal class WorkshopBrowserModule : SocialBrowserModule
 	/// This uses the provided modId and retrieves the list of approved mod hashes from ModBrowser.
 	/// Uses Steam Web API as a fall back when Steam API isn't available (such as headless environments)
 	/// </summary>
-	public DeveloperMetadata GetDeveloperMetadataFromModBrowser(ModPubId_t modId)
+	public (DeveloperMetadata longForm, DeveloperMetadata browserVersion) GetDeveloperMetadataFromModBrowser(ModPubId_t modId)
 	{
 		// Mod Doesn't Exist, return empty hashes
 		if (string.IsNullOrEmpty(modId.m_ModPubId) || string.Equals(modId.m_ModPubId, "0"))
@@ -176,13 +176,25 @@ internal class WorkshopBrowserModule : SocialBrowserModule
 			// If Steam Server and Steam Client are both not available, retrieve it via WebAPI
 			var itemDetails = SteamWebWrapper.GetItemMetadata(modId.m_ModPubId);
 
-			return DeveloperMetadata.Deserialize(itemDetails.Metadata);
+			return (DeveloperMetadata.Deserialize(itemDetails.Metadata), DeveloperMetadata.Deserialize(itemDetails.KeyValuePairs.FirstOrDefault(a => a.key == $"{SocialBrowserModule.CurrentBrowserVersion}-legacy").value));
 		}
 
 		// Mod should Exist, check Mod Browser
 		var items = DirectQueryItems(new QueryParameters() { searchModIds = [modId], queryType = QueryType.SearchDirect, returnDevMetadata = true }, out _);
+		var item = items.FirstOrDefault();
 
-		return items.FirstOrDefault()?.DevMetadata ?? new();
+		return (item.LongFormDevMetadata, item.BrowserVersionDevMetadata);
+	}
+
+	public List<string> GetSupportedBrowserVersions(ModPubId_t modId)
+	{
+		if (string.IsNullOrEmpty(modId.m_ModPubId) || string.Equals(modId.m_ModPubId, "0"))
+			return new();
+
+		var items = DirectQueryItems(new QueryParameters() { searchModIds = [modId], queryType = QueryType.SearchDirect, returnDevMetadata = true }, out _);
+		var item = items.FirstOrDefault();
+
+		return item.SupportedVersions;
 	}
 }
 

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -22,7 +22,16 @@ namespace Terraria.Social.Steam;
 
 public partial class WorkshopHelper
 {
-	internal static string[] MetadataKeys = new string[8] { "name", "author", "modside", "homepage", "modloaderversion", "version", "modreferences", "versionsummary" };
+	internal static string[] MetadataKeys = new string[8] {
+		"name", // ACTIVE: Internal modname // tmod file name
+		"author", // ACTIVE: a custom field denoting an author so can be different than steam account name
+		"modside", // ACTIVE: the ModSide field
+		"homepage", // ACTIVE
+		"modloaderversion", // DISCONTINUED ???. Replaced by VersionSummary -- Example: "9999.0"  
+		"version", // DISCONTINUED ???. Replaced by VersionSummary  -- Example: "0.0.0"
+		"modreferences", // ACTIVE: the 'slugs' or internal mod names for dependencies this mod needs
+		"versionsummary" // DISCONTINUED SEPT 2026 -- Output version string: "2022.05.10.20:0.2.0;2022.06.10.20:0.2.1;2022.07.10.20:0.2.2"
+	};
 
 	// TODO: Per latest testing by Solxan Sept 2025, this doesn't work anymore. replace with SetMetadata via WebAPI
 	private static readonly Regex MetadataInDescriptionFallbackRegex = new Regex(@"\[quote=GithubActions\(Don't Modify\)\]Version Summary: (.*) \[/quote\]", RegexOptions.Compiled);
@@ -91,14 +100,19 @@ public partial class WorkshopHelper
 	}
 
 	/////// Workshop Version Calculation Helpers ////////////////////
-	private static (System.Version modV, System.Version tmlV) CalculateRelevantVersion(string mbDescription, NameValueCollection metadata)
+	private static (System.Version modV, System.Version tmlV) CalculateRelevantVersion(string mbDescription, NameValueCollection metadata, DeveloperMetadata browserVersionDevMetadata)
 	{
-		(System.Version modV, System.Version tmlV) selectVersion = new(new System.Version(metadata["version"].Replace("v", "")), new System.Version(metadata["modloaderversion"].Replace("tModLoader v", "")));
+		string versionSummary = string.IsNullOrEmpty(browserVersionDevMetadata.versionData) ? metadata["versionsummary"] : browserVersionDevMetadata.versionData;
+
+		(System.Version modV, System.Version tmlV) selectVersion = new(
+			new System.Version(metadata["version"].Replace("v", "")), new System.Version(metadata["modloaderversion"].Replace("tModLoader v", ""))
+		);
+
 		// Backwards compat after metadata version change
-		if (!metadata["versionsummary"].Contains(':'))
+		if (!versionSummary.Contains(':'))
 			return selectVersion;
 
-		InnerCalculateRelevantVersion(ref selectVersion, metadata["versionsummary"]);
+		InnerCalculateRelevantVersion(ref selectVersion, versionSummary);
 
 		// Handle Github Actions metadata from description
 		// Nominal string: [quote=GithubActions(Don't Modify)]Version Summary: YYYY.MM:#.#.#.#;YYYY.MM:#.#.#.#;... [/quote]
@@ -601,7 +615,7 @@ public partial class WorkshopHelper
 
 				// Developer Metadata
 				SteamedWraps.FetchDeveloperMetadata(_primaryUGCHandle, i, out string devMetadataSerialized);
-				var devMetadata = DeveloperMetadata.Deserialize(devMetadataSerialized);
+				var longFormDevMetadata = DeveloperMetadata.Deserialize(devMetadataSerialized);
 
 				// Backwards compat code for the metadata version change
 				if (metadata["versionsummary"] == null)
@@ -617,12 +631,16 @@ public partial class WorkshopHelper
 					throw new SocialBrowserException($"Mod has no internal name / slug: {id}: {displayname}"); // Somehow this happened before and broke mod downloads
 				}
 
+				DeveloperMetadata browserVersionDevMetadata = DeveloperMetadata.Deserialize(metadata[SteamedWraps.BrowserDeveloperMetadataKey]);
+
 				string[] refsById = SteamedWraps.FetchItemDependencies(_primaryUGCHandle, i, pDetails.m_unNumChildren).Select(x => x.m_PublishedFileId.ToString()).ToArray();
 
 				// Partial Description - we don't include Long Description so this is only first handful of characters
 				string description = pDetails.m_rgchDescription;
 
-				var cVersion = CalculateRelevantVersion(description, metadata);
+				List<string> supportedVersions = SteamedWraps.FetchGameVersionSupport(_primaryUGCHandle, i);
+
+				var cVersion = CalculateRelevantVersion(description, metadata, browserVersionDevMetadata);
 
 				// Assign ModSide Enum
 				ModSide modside = ModSide.Both;
@@ -642,7 +660,19 @@ public partial class WorkshopHelper
 				// Item Statistics
 				SteamedWraps.FetchPlayTimeStats(_primaryUGCHandle, i, out var hot, out var downloads);
 
-				return new ModDownloadItem(displayname, metadata["name"], cVersion.modV, metadata["author"], metadata["modreferences"], modside, modIconURL, id.m_PublishedFileId.ToString(), (int)downloads, (int)hot, lastUpdate, cVersion.tmlV, metadata["homepage"], ownerId, refsById, banned, devMetadata, upvotes, downvotes, voteScore);
+				return new ModDownloadItem(
+					displayname, metadata["name"], metadata["author"], metadata["homepage"],
+					(int)downloads, (int)hot, modIconURL, id.m_PublishedFileId.ToString(), ownerId,
+					upvotes, downvotes, voteScore, supportedVersions,
+					banned,	longFormDevMetadata, browserVersionDevMetadata,
+					lastUpdate,
+
+					// Properties that could be variant with tML Browser Version
+					metadata["modreferences"], refsById, modside,
+
+					// Properties that are variant with tML Browser Version
+					cVersion.modV, cVersion.tmlV
+				);
 			}
 		}
 	}

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -4,6 +4,7 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Security.Policy;
 using System.Text;
 using Newtonsoft.Json;
 using Terraria.Localization;
@@ -196,13 +197,11 @@ public partial class WorkshopSocialModule
 			// Cleanup Old Folders
 			ModOrganizer.CleanupOldPublish(workshopFolderPath);
 
-			// Should be called after folder created & cleaned up
-			tagsList.AddRange(DetermineSupportedVersionsFromWorkshop(workshopFolderPath));
-
 			// Developer Metadata Calculations must occur after cleanup old publish
-			var devMetadata = GetDeveloperMetadataForPublish(workshopFolderPath, currPublishID);
+			GetDeveloperMetadataForPublish(ref buildData, workshopFolderPath, currPublishID);
 
-			buildData["developermetadata"] = devMetadata.Serialize();
+			// Should be called after folder created & cleaned up
+			tagsList.AddRange(DetermineSupportedVersionsFromWorkshop(workshopFolderPath, currPublishID));
 
 			var modPublisherInstance = new WorkshopHelper.ModPublisherInstance();
 
@@ -216,7 +215,7 @@ public partial class WorkshopSocialModule
 		return false;
 	}
 
-	// Output version string: "2022.05.10.20:0.2.0;2022.06.10.20:0.2.1;2022.07.10.20:0.2.2"
+	// Output version string: "2022.05.10.20:0.2.0;2022.06.10.20:0.2.1;2022.07.10.20:0.2.2" -- needed for preview vs stable
 	// Return False if the mod version did not increase for the particular tml version
 	// Return False if the mod version isn't less than releases on future tml version
 	// This will have up to 1 more version than is actually relevant, but that won't break anything
@@ -257,10 +256,16 @@ public partial class WorkshopSocialModule
 		return true;
 	}
 
-	internal static HashSet<string> DetermineSupportedVersionsFromWorkshop(string repo)
+	private static HashSet<string> DetermineSupportedVersionsFromWorkshop(string repo, ulong publishId)
 	{
 		var summary = ModOrganizer.AnalyzeWorkshopTmods(repo);
-		return summary.Select(info => SocialBrowserModule.GetBrowserVersionNumber(info.tModVersion)).ToHashSet();
+
+		var localList = summary.Select(info => SocialBrowserModule.GetBrowserVersionNumber(info.tModVersion)).ToHashSet();
+
+		var pubId = new ModPubId_t() { m_ModPubId = publishId.ToString() };
+		var remoteList = WorkshopBrowserModule.Instance.GetSupportedBrowserVersions(pubId);
+
+		return localList.Union(remoteList).ToHashSet();
 	}
 
 	// PR 4345 - We combine the hash data that is currently on workshop with the hash data from the updated publishing folder to ensure that when mods are updated it is backwards compatible
@@ -269,16 +274,26 @@ public partial class WorkshopSocialModule
 	/// Gets the revised Developer Metadata fo usage with publishing a new mod or update to an existing mod.
 	/// Takes the folder path containing all .tmod files and the PublishFileID. A PublishFileID of zero is a new mod by convention.
 	/// </summary>
-	internal static DeveloperMetadata GetDeveloperMetadataForPublish(string folderPath, ulong publishId)
+	internal static void GetDeveloperMetadataForPublish(ref NameValueCollection buildData, string folderPath, ulong publishId)
 	{
 		var pubId = new ModPubId_t() { m_ModPubId = publishId.ToString() };
-		var developerMetadata = WorkshopBrowserModule.Instance.GetDeveloperMetadataFromModBrowser(pubId);
-
 		var currentHashes = GetModHashesFromFolder(folderPath);
 
-		developerMetadata.modVersionHashes = currentHashes.Concat(developerMetadata.modVersionHashes.Except(currentHashes).ToList()).ToList();
-		developerMetadata.TrimDevMetadataForPublish();
-		return developerMetadata;
+		(var longListDeveloperMetadata, var browserVersionDeveloperMetadata) = WorkshopBrowserModule.Instance.GetDeveloperMetadataFromModBrowser(pubId);
+
+		// Calculate and set the long list developer metadata for use with Steam Developer MEtadata field
+		longListDeveloperMetadata.modVersionHashes = currentHashes.Concat(longListDeveloperMetadata.modVersionHashes.Except(currentHashes).ToList()).ToList();
+		longListDeveloperMetadata.TrimDevMetadataForMainDeveloperMetadataFieldBeforePublish();
+
+		buildData[SteamedWraps.LongFormDeveloperMetadataKey] = longListDeveloperMetadata.Serialize();
+
+		// Calulate and set the short list browser version metadata for use with Steam Key Value Pair field
+		browserVersionDeveloperMetadata.modVersionHashes = currentHashes.Concat(browserVersionDeveloperMetadata.modVersionHashes.Except(currentHashes).ToList()).ToList();
+		browserVersionDeveloperMetadata.TrimDevMetadataForBrowserVersionFieldBeforePublish();
+
+		browserVersionDeveloperMetadata.versionData = buildData["versionsummary"];
+
+		buildData[SteamedWraps.BrowserDeveloperMetadataKey] = browserVersionDeveloperMetadata.Serialize();
 	}
 
 	internal static List<ModVersionHash> GetModHashesFromFolder(string folderPath)

--- a/solutions/Manifests/stable.vdf
+++ b/solutions/Manifests/stable.vdf
@@ -4,7 +4,7 @@
   "desc" "Github Actions Stable Auto-Release"
   "buildoutput" "../../BuildOutput"
   "contentroot" "../../artifacts"
-  "setlive" "internal-stable"
+  "setlive" "1.4.5-legacy"
   "preview" ""
   "local" ""
 


### PR DESCRIPTION
Expected technical outcome: 
stable / 1.4.5-legacy have 2 to 3 tmods dl'd
1.4.4-legacy has only one tmod downloaded. 
1.4.3-legacy has only one tmod downloaded 

User experience impacts:
1) Smaller file sizes on computer
2) workshop items show compatible betas on steam workshop
3) decreased space for hashes stored, so less history for multiplayer

Modder experience impacts:
1) Workflow for publishing remains unchanged
2) Further breaks github CI stuff, but isn't supported anyways
3) Smaller file size on computer

This must also be backported to every version prior that can publish to Steam Workshop (1.4.3-Legacy, 1.4.4-Legacy). 