### PR TITLE
[1.4.5] Migrate tModPorter Item.SetDefaults()

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -188,8 +188,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 
 - ItemVariants.EverythingWorld renamed to MechdusaWorld
 - Main.GameModeInfo.IsJourneyMode -> Main.IsJourneyMode
-- Item.SetDefaults() -> Item.SetDefaults(0)
-- Item.SetDefaults(int, bool) -> Item.SetDefaults(int)
 
 # ExampleMod TODOs
 - Verify that ExampleZombieThief still works with changes

--- a/tModPorter/tModPorter.Tests/TestData/ItemSetDefaultsTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ItemSetDefaultsTest.cs
@@ -1,0 +1,18 @@
+﻿using Terraria;
+using Terraria.ID;
+
+public class ItemSetDefaultsTest
+{
+	void Method()
+	{
+		Item item = new Item();
+		item.SetDefaults(1);
+		item.SetDefaults(2, false);
+		item.SetDefaults(3, true, null);
+		item.SetDefaults(4, noMatCheck: false);
+		item.SetDefaults(5, variant: null, noMatCheck: false);
+		item.SetDefaults(6, Main.rand.NextBool() ? false : true);
+		item.SetDefaults(7, variant: null, noMatCheck: Main.rand.NextBool() ? false : true);
+		item.SetDefaults();
+	}
+}

--- a/tModPorter/tModPorter.Tests/TestData/ItemSetDefaultsTest.expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ItemSetDefaultsTest.expected.cs
@@ -1,0 +1,18 @@
+﻿using Terraria;
+using Terraria.ID;
+
+public class ItemSetDefaultsTest
+{
+	void Method()
+	{
+		Item item = new Item();
+		item.SetDefaults(1);
+		item.SetDefaults(2);
+		item.SetDefaults(3, null);
+		item.SetDefaults(4);
+		item.SetDefaults(5, variant: null);
+		item.SetDefaults(6);
+		item.SetDefaults(7, variant: null);
+		item.SetDefaults(0);
+	}
+}

--- a/tModPorter/tModPorter/Config.Terraria.cs
+++ b/tModPorter/tModPorter/Config.Terraria.cs
@@ -268,7 +268,7 @@ public static partial class Config
 		RenameInstanceField("Terraria.DataStructures.EntitySource_OnHit", "EntityStriking", "Attacker");
 		RenameInstanceField("Terraria.DataStructures.EntitySource_OnHit", "EntityStruck", "Victim");
 
-		// 1.4.5                
+		// 1.4.5
 		RenameStaticField("Terraria.ID.BuffID.Sets", from: "LongerExpertDebuff", to: "BuffTimeIsExtendedWithGameDifficulty");
 		RenameStaticField("Terraria.ID.GoreID.Sets", from: "LiquidDroplet", to: "IsDrip");
 		RenameStaticField("Terraria.ID.ImmunityCooldownID", from: "Bosses", to: "BossNoCheese");
@@ -371,7 +371,7 @@ public static partial class Config
 		RefactorStaticMethodCall("Terraria.Chest", "FindChestByGuessing", Removed("Use Chest.FindChest with the top left tile coordinate"));
 		RefactorStaticMethodCall("Terraria.RecipeGroup", "RegisterGroup", Removed("Replace this and \"new RecipeGroup()\" with RecipeGroup.Register"));
 
-		RefactorInstanceMethodCall("Terraria.Item", "SetDefaults", RemoveParameter(1, "noMatCheck", "bool"));
+		RefactorInstanceMethodCall("Terraria.Item", "SetDefaults", ConvertItemSetDefaults);
 		RefactorInstanceMethodCall("Terraria.Player", "GetItem", RemoveParameter(0, "plr", "int"));
 		RefactorInstanceMethodCall("Terraria.Player", "AddBuff", RemoveParameter(2, "quiet", "bool"));
 		RefactorInstanceMethodCall("Terraria.Player", "AddBuff", RemoveParameter(3, "foodHack", "bool")); // Order seems to matter here

--- a/tModPorter/tModPorter/Rewriters/InvokeRewriter.cs
+++ b/tModPorter/tModPorter/Rewriters/InvokeRewriter.cs
@@ -253,6 +253,19 @@ public partial class InvokeRewriter : BaseRewriter
 		return invoke;
 	};
 
+	public static RewriteInvoke ConvertItemSetDefaults => (rw, invoke, methodName) => {
+		// Remove noMatCheck parameter
+		if (invoke.ArgumentList.Arguments.Count != 0) return RemoveParameter(1, "noMatCheck", "bool")(rw, invoke, methodName);
+
+		// Item.SetDefaults() -> Item.SetDefaults(0)
+		var zero = Argument(
+			LiteralExpression(
+				SyntaxKind.NumericLiteralExpression, Literal(0)
+			)
+		);
+		return invoke.WithArgumentList(invoke.ArgumentList.AddArguments(zero));
+	};
+
 	private static SyntaxNode CommentOutNode(SyntaxNode node) {
 
 		var t = node.GetLeadingTrivia();


### PR DESCRIPTION
### What is the bug?

In 1.4.5, `Item.SetDefaults(int Type = 0)` no longer has a default value for the `Type` parameter.

### How did you fix the bug?

I added a `ConvertItemSetDefaults` handler which:

- converts `Item.SetDefaults()` to `Item.TurnToAir()`
- preserves the existing migration which removes the obsolete `noMatCheck` parameter

Added regression tests covering both behaviors.

### Are there alternatives to your fix?

The parameterless migration could be implemented as a separate handler, but `InvokeRewriter` uses the first matching handler for a method, so keeping the `Item.SetDefaults` migrations in a single handler avoids overlapping registrations.