### PR TITLE
Trust Prompt for Downloaded Mods

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
@@ -1,4 +1,3 @@
-using Ionic.Zlib;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -7,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using Ionic.Zlib;
 using Terraria.Localization;
 using Terraria.ModLoader.IO;
 using Terraria.ModLoader.UI;
@@ -69,6 +69,8 @@ public class TmodFile : IEnumerable<TmodFile.FileEntry>
 	// Starting position of the hashable part of the stream.
 	private long hashStartPos;
 	private bool? hashVerified;
+	private bool? originVerified;
+	internal string downloadOrigin;
 
 	internal TmodFile(string path, string name = null, Version version = null)
 	{
@@ -459,5 +461,21 @@ public class TmodFile : IEnumerable<TmodFile.FileEntry>
 		using var fs = File.OpenRead(path);
 		fs.Position = hashStartPos;
 		return Hash.SequenceEqual(SHA1.Create().ComputeHash(fs));
+	}
+
+	internal bool VerifyOrigin() => originVerified ??= _VerifyOrigin();
+
+	private bool _VerifyOrigin()
+	{
+		if (FileOriginChecker.IsDownloadedFile(path, out string url)) {
+			if (!string.IsNullOrEmpty(url)) {
+				downloadOrigin = url;
+			}
+			else {
+				downloadOrigin = "Unknown";
+			}
+			Logging.tML.Warn($"The mod {Path.GetFileName(path)} was downloaded from the internet: {downloadOrigin}");
+		}
+		return true;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Engine/FileOriginChecker.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/FileOriginChecker.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+internal static class FileOriginChecker
+{
+	// --- Linux / macOS Native Interop ---
+	[DllImport("libc", EntryPoint = "getxattr", CharSet = CharSet.Ansi, SetLastError = true)]
+	private static extern long getxattr(string path, string name, byte[] value, ulong size);
+
+	internal static bool IsDownloadedFile(string filePath, out string originUrl)
+	{
+		originUrl = string.Empty;
+
+		if (!File.Exists(filePath))
+			throw new FileNotFoundException("Target file not found.", filePath);
+
+		if (OperatingSystem.IsWindows()) {
+			return CheckWindowsZoneIdentifier(filePath, out originUrl);
+		}
+		/* Untested, need to verify typical browser behavior on Linux and macOS and adjust if needed
+		else if (OperatingSystem.IsLinux()) {
+			// Some browsers on Linux set user.xdg.origin.url
+			return CheckUnixExtendedAttribute(filePath, "user.xdg.origin.url", out originUrl);
+		}
+		else if (OperatingSystem.IsMacOS()) {
+			// macOS uses com.apple.metadata:kMDItemWhereFroms
+			// Or just check com.apple.quarantine maybe?
+			return CheckUnixExtendedAttribute(filePath, "com.apple.metadata:kMDItemWhereFroms", out originUrl);
+		}
+		*/
+
+		return false;
+	}
+
+	internal static void ClearDownloadFlags(string filePath)
+	{
+		if (!File.Exists(filePath))
+			throw new FileNotFoundException("Target file not found.", filePath);
+
+		if (OperatingSystem.IsWindows()) {
+			ClearWindowsZoneIdentifier(filePath);
+		}
+		else {
+			throw new NotImplementedException();
+		}
+	}
+
+
+	private static bool CheckWindowsZoneIdentifier(string filePath, out string originUrl)
+	{
+		originUrl = string.Empty;
+
+		// Windows NTFS Alternate Data Streams (ADS) to store some file metadata.
+		string adsPath = $"{filePath}:Zone.Identifier";
+
+		if (File.Exists(adsPath)) {
+			try {
+				string content = File.ReadAllText(adsPath);
+
+				// Parse standard ZoneId (ZoneId=3 means Internet, ZoneId=4 means Untrusted internet sites)
+				if (content.Contains("ZoneId=3") || content.Contains("ZoneId=4")) {
+					// Attempt to extract HostUrl if modern browsers saved it
+					foreach (var line in content.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)) {
+						// ReferrerUrl= is another option
+						if (line.StartsWith("HostUrl=", StringComparison.OrdinalIgnoreCase)) {
+							originUrl = line.Substring(8).Trim();
+							// Remove fragment (#) and query (?) components from url
+							var uri = new Uri(originUrl);
+							originUrl = $"{uri.Scheme}://{uri.Authority}{uri.AbsolutePath}";
+							break;
+						}
+					}
+					return true;
+				}
+			}
+			catch (Exception) {
+			}
+		}
+		return false;
+	}
+
+	private static void ClearWindowsZoneIdentifier(string filePath)
+	{
+		string adsPath = $"{filePath}:Zone.Identifier";
+		if (File.Exists(adsPath)) {
+			File.Delete(adsPath);
+
+			// Causes the mod to be seen as changed, refreshing the LocalMod
+			File.SetLastWriteTime(filePath, DateTime.Now);
+		}
+	}
+
+	/* Untested code for other OS from search results
+	private static bool CheckUnixExtendedAttribute(string filePath, string attributeName, out string originUrl)
+	{
+		originUrl = string.Empty;
+		try {
+			// First pass: Call with size 0 to get the exact buffer size required
+			long size = getxattr(filePath, attributeName, null, 0);
+			if (size <= 0)
+				return false;
+
+			byte[] buffer = new byte[size];
+			long readBytes = getxattr(filePath, attributeName, buffer, (ulong)size);
+
+			if (readBytes > 0) {
+				// Linux: Raw URL string
+				// macOS: Typically a binary Apple Property List (.plist). 
+				// Reading it as UTF-8 often yields plain-text URLs embedded inside.
+				originUrl = Encoding.UTF8.GetString(buffer, 0, (int)readBytes).Trim('\0');
+				return true;
+			}
+		}
+		catch (Exception) {
+		}
+		return false;
+	}
+	*/
+}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -31,6 +31,7 @@ internal class UIModItem : UIPanel
 	private UIText _modName;
 	private UIModStateText _uiModStateText;
 	internal UIAutoScaleTextTextPanel<string> tMLUpdateRequired;
+	internal UIAutoScaleTextTextPanel<string> trustRequired;
 	private UIImage _modReferenceIcon;
 	private UIImage _translationModIcon;
 	private UIImage _deleteModButton;
@@ -49,6 +50,7 @@ internal class UIModItem : UIPanel
 	private string[] _modDependencies; // Note: Recursive
 	private string _modRequiresTooltip;
 	public readonly string DisplayNameClean; // No chat tags: for search and sort functionality.
+	public readonly string DownloadOrigin;
 
 	private string ToggleModStateText {
 		get {
@@ -76,6 +78,9 @@ internal class UIModItem : UIPanel
 		Width.Percent = 1f;
 		SetPadding(6f);
 		DisplayNameClean = _mod.DisplayNameClean;
+
+		_mod.modFile.VerifyOrigin();
+		DownloadOrigin = _mod.modFile.downloadOrigin;
 	}
 
 	public override void OnInitialize()
@@ -138,6 +143,19 @@ internal class UIModItem : UIPanel
 				Utils.OpenToURL(updateURL);
 			};
 			Append(tMLUpdateRequired);
+		}
+		else if (DownloadOrigin != null) {
+			trustRequired = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("Downloaded From Internet")).WithFadedMouseOver(Color.Red, Color.Red * 0.7f);
+			trustRequired.BackgroundColor = Color.Red * 0.7f;
+			trustRequired.Top.Pixels = 40;
+			trustRequired.Width.Pixels = 280;
+			trustRequired.Height.Pixels = 36;
+			trustRequired.Left.Pixels += _uiModStateText.Width.Pixels + _uiModStateText.Left.Pixels + PADDING;
+			trustRequired.OnLeftClick += (a, b) => {
+				SoundEngine.PlaySound(SoundID.MenuOpen);
+				Interface.infoMessage.Show("This mod was downloaded from the internet.\n\nMods may contain malicious code, such as stealing passwords or installing viruses, especially mods not downloaded directly from Steam Workshop.\n\nOnly enable this mod if you trust the person who sent you this mod.", Interface.modsMenuID, altButtonText: "Trust file", altButtonAction: () => { FileOriginChecker.ClearDownloadFlags(_mod.modFile.path); }, okButtonText: "Do not trust file");
+			};
+			Append(trustRequired);
 		}
 		else
 			Append(_uiModStateText);
@@ -298,6 +316,8 @@ internal class UIModItem : UIPanel
 		OnLeftDoubleClick += (e, el) => {
 			if (tMLUpdateRequired != null)
 				return;
+			if (trustRequired != null)
+				return;
 			// Only trigger if we didn't target the ModStateText, otherwise we trigger this behavior twice
 			if (e.Target.GetType() != typeof(UIModStateText))
 				_uiModStateText.LeftClick(e);
@@ -420,6 +440,9 @@ internal class UIModItem : UIPanel
 		}
 		else if (tMLUpdateRequired?.IsMouseHovering == true) {
 			_tooltip = Language.GetTextValue("tModLoader.SwitchVersionInfoButton");
+		}
+		else if (trustRequired?.IsMouseHovering == true) {
+			_tooltip = $"This file was downloaded from the internet, this is extremely risky.\n{DownloadOrigin}";
 		}
 		else if (_modReferenceIcon?.IsMouseHovering == true) {
 			_tooltip = _modRequiresTooltip;

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIMods.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIMods.cs
@@ -381,6 +381,8 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 		foreach (UIModItem modItem in items) {
 			if (modItem.tMLUpdateRequired != null)
 				continue;
+			if (modItem.trustRequired != null)
+				continue;
 			modItem.Enable();
 		}
 	}


### PR DESCRIPTION
In https://github.com/tModLoader/tModLoader/pull/4801 we added warning messages when downloading mods from servers. Recently there have been reports of malicious players sending .tmod files directly to users. Sometimes the claim is that the mod is client side, so it wouldn't sync automatically through normal host and play. Directly placing a mod in the mods folder currently does not show any warning to the user.

This PR adds a warning on the Mods menu when attempting to enable a mod that has been downloaded from the internet. This is similar to what some other programs do:

Excel and Visual Studio Code example warnings:
<img width="860" height="32" alt="image" src="https://github.com/user-attachments/assets/2dc9d1d1-e082-4703-93a7-1d5fa498a851" />
<img width="671" height="24" alt="image" src="https://github.com/user-attachments/assets/2b77a717-0daf-4398-ab5c-f44a7f53ce03" />


Here is the new warning. The mod can't be enabled in the mods menu until the user clicks through to read the warning. They can then click "Trust file" to allow the mod to be enabled.

https://github.com/user-attachments/assets/ea395da6-8a04-4bfc-9577-f1a44fa7b868

Currently the PR only implements the Windows approach. Code for Linux and Mac is included and commented out, so we'll need to test those. 

# TODO

- [ ] Linux support
- [ ] Mac support
- [ ] Fix a downloaded `enabled.json` bypassing the new logic (modpacks too?)
- [ ] Finalize language and localization keys